### PR TITLE
Fix API tests by adding missing modules and defaults

### DIFF
--- a/api/database/__init__.py
+++ b/api/database/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities for the API layer."""
+
+from .models import Base, Run, Node, Artifact, Event
+
+__all__ = ["Base", "Run", "Node", "Artifact", "Event"]

--- a/api/database/models.py
+++ b/api/database/models.py
@@ -1,0 +1,17 @@
+"""Re-export database models for the API tests.
+
+The core application stores its SQLModel models in
+``core.storage.db_models``.  The API tests expect them to be available
+under ``api.database.models`` so we re-export them here.
+"""
+
+from sqlmodel import SQLModel
+
+from core.storage.db_models import Artifact, Event, Node, Run
+
+# FastAPI tests expect a ``Base`` object with a ``metadata`` attribute
+# similar to the SQLAlchemy declarative base. ``SQLModel`` already
+# exposes the metadata via ``SQLModel.metadata`` so we simply alias it.
+Base = SQLModel
+
+__all__ = ["Base", "Run", "Node", "Artifact", "Event"]

--- a/api/fastapi_app/main.py
+++ b/api/fastapi_app/main.py
@@ -1,0 +1,9 @@
+"""Entry point for FastAPI application.
+
+This module exposes the FastAPI ``app`` instance so tests and
+runners can import it using ``from api.fastapi_app.main import app``.
+"""
+
+from .app import app
+
+__all__ = ["app"]

--- a/core/storage/db_models.py
+++ b/core/storage/db_models.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from typing import Optional, List, Dict
 
 from sqlmodel import SQLModel, Field
-from sqlalchemy import Column, DateTime, Enum as SAEnum, Text, String, func
-from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
+from sqlalchemy import Column, DateTime, Enum as SAEnum, Text, String, func, JSON
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 
 
 # ---------------- Enums ----------------
@@ -49,7 +49,7 @@ class Run(SQLModel, table=True):
     # ⚠️ ne pas utiliser l'attribut Python "metadata" (réservé).
     meta: Optional[Dict] = Field(
         default=None,
-        sa_column=Column("metadata", JSONB, nullable=True),
+        sa_column=Column("metadata", JSON, nullable=True),
     )
 
 
@@ -65,7 +65,7 @@ class Node(SQLModel, table=True):
     key: Optional[str] = Field(default=None, sa_column=Column(String, index=True))
     title: str = Field(sa_column=Column(String, nullable=False))
     status: NodeStatus = Field(sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False))
-    deps: Optional[List[str]] = Field(default=None, sa_column=Column(JSONB, nullable=True))
+    deps: Optional[List[str]] = Field(default=None, sa_column=Column(JSON, nullable=True))
     checksum: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
     created_at: datetime = Field(
         default_factory=lambda: datetime.utcnow(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,15 @@
 python-dotenv
 aiohttp
 openai
+
+# API and testing dependencies
+fastapi
+pydantic
+pydantic-settings
+sqlmodel
+SQLAlchemy
+aiosqlite
+httpx
+asgi-lifespan
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add FastAPI test dependencies
- expose FastAPI app and database models expected by tests
- supply default settings and auth/db aliases for tests
- use SQLite-compatible JSON columns

## Testing
- `make api-test`


------
https://chatgpt.com/codex/tasks/task_e_68a2e76494bc8327b346507fd0658a03