### PR TITLE
Fix make run setup and restore file adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ init-env:
 install: init-env
 	@python3 -m venv .venv
 	@. .venv/bin/activate && pip install -U pip
-	@. .venv/bin/activate && pip install -e .
+	@. .venv/bin/activate && pip install -r requirements.txt
 	@echo "✅ Installation terminée"
 
 # (optionnel) forcer juste la (ré)création du venv et l'install
 venv:
 	@python3 -m venv .venv
 	@. .venv/bin/activate && pip install -U pip
-	@. .venv/bin/activate && pip install -e .
+	@. .venv/bin/activate && pip install -r requirements.txt
 
 fmt:
 	@echo "Skip (formatter non configuré)"
@@ -34,13 +34,22 @@ lint:
 	@echo "Skip (linter non configuré)"
 
 test:
+	@if [ ! -d .venv ]; then \
+	$(MAKE) install; \
+	fi
 	@. .venv/bin/activate && pytest -q
 
 test-recovery:
+	@if [ ! -d .venv ]; then \
+	$(MAKE) install; \
+	fi
 	@. .venv/bin/activate && pytest -q -k "recovery or status_store"
 
 run:
-	@. .venv/bin/activate && python -m apps.orchestrator.main --task-file examples/task_rapport_80p.json
+	@if [ ! -d .venv ]; then \
+	$(MAKE) install; \
+	fi
+	@. .venv/bin/activate && python -m apps.orchestrator.main --task-file examples/task_rapport_80p.json $(RUN_ARGS)
 
 # 3) Vérifier rapidement que les variables d'env sont chargées
 env-check:

--- a/core/agents/executor_llm.py
+++ b/core/agents/executor_llm.py
@@ -217,21 +217,22 @@ async def run_executor_llm(node, storage) -> bool:
         # Log debug tokens & coût
         log.debug("node=%s tokens=%s cost=%s", node_id_txt, usage, cost)
 
+        acceptance_sanitized = (acceptance or "").replace('"', '\\"')
         content = dedent(
             f"""\
         ---
         node_id: {node_id_txt}
         title: {title}
         type: {node_type}
-        acceptance: "{(acceptance or "").replace('"','\\\"')}"
+        acceptance: "{acceptance_sanitized}"
         model: {model}
         provider_primary: {provider}
-        provider_fallbacks: {", ".join(params["fallback_order"])}
+        provider_fallbacks: {', '.join(params['fallback_order'])}
         ---
 
         # {title}
 
-        > Type: {node_type} | Acceptation: {acceptance or "—"}
+        > Type: {node_type} | Acceptation: {acceptance or '—'}
 
         ## Livrable
         {body}

--- a/core/storage/file_adapter.py
+++ b/core/storage/file_adapter.py
@@ -143,3 +143,11 @@ class FileStatusStore:
         st.error = error_msg
         self.write(st)
         return st
+
+
+# ------------------------------------------------------------------
+# Backward compatibility
+# ------------------------------------------------------------------
+class FileAdapter(FileStorage):
+    """Legacy name kept for backward compatibility."""
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,11 @@ openai
 fastapi
 pydantic
 pydantic-settings
+networkx
 sqlmodel
 SQLAlchemy
 aiosqlite
+asyncpg
 httpx
 asgi-lifespan
 pytest


### PR DESCRIPTION
## Summary
- ensure `make run` and tests bootstrap a virtualenv and install dependencies
- add missing dependencies for orchestrator and database usage
- restore `FileAdapter` alias and sanitize LLM artifact content

## Testing
- `RUN_ARGS="--dry-run" make run`
- `make test` *(fails: connection refused to Postgres; unauthorized API response)*

------
https://chatgpt.com/codex/tasks/task_e_68a43ca144308327b5842bfef9058892