### PR TITLE
Handle dict DAG nodes and report failed runs

### DIFF
--- a/core/storage/file_adapter.py
+++ b/core/storage/file_adapter.py
@@ -105,7 +105,7 @@ class FileStatusStore:
         return os.path.join(self.runs_root, run_id)
 
     def status_path(self, run_id: str, node_id: str) -> str:
-        return os.path.join(self.run_dir(run_id), f"{node_id}.status.json")
+        return os.path.join(self.run_dir(run_id), "nodes", node_id, "status.json")
 
     def read(self, run_id: str, node_id: str) -> Optional[NodeStatus]:
         path = self.status_path(run_id, node_id)
@@ -113,7 +113,8 @@ class FileStatusStore:
             return None
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        return NodeStatus(**data)
+        allowed = {k: v for k, v in data.items() if k in NodeStatus.__annotations__}
+        return NodeStatus(**allowed)
 
     def write(self, st: NodeStatus) -> None:
         _atomic_write_json(self.status_path(st.run_id, st.node_id), asdict(st))


### PR DESCRIPTION
## Summary
- Iterate over DAG nodes as dict values when appropriate
- Track node execution failures and mark overall run as failed
- Persist node status in FileStatusStore-compatible format

## Testing
- `PYTHONPATH=. pytest tests/test_recovery_e2e.py::test_recovery_resume -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4417eec348327b420575a3d2f44a2