### PR TITLE
Ensure acceptance criteria use consistent list type

### DIFF
--- a/apps/orchestrator/main.py
+++ b/apps/orchestrator/main.py
@@ -82,7 +82,7 @@ def _default_run_id(hint: str | None = None) -> str:
     return ts
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Orchestrateur CrewIA — exécution d'un plan avec reprise après crash")
     p.add_argument("--task-file", required=False, help="Chemin vers un JSON contenant la clé 'plan'")
     p.add_argument("--run-id", default=None, help="Identifiant stable du run (requis pour --resume)")
@@ -96,12 +96,20 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--use-supervisor", action="store_true", help="Génère le plan via le superviseur LLM")
     p.add_argument("--title", default="Rapport 80p", help="Titre racine pour le superviseur")
     p.add_argument("--description", default="Décomposer la production d'un rapport de 80 pages.", help="Description")
-    p.add_argument("--acceptance", default="Un plan séquencé avec sous-tâches claires.", help="Critères d'acceptance")
+    p.add_argument(
+        "--acceptance",
+        action="append",
+        help="Critères d'acceptance (répéter l’option pour plusieurs valeurs)",
+    )
 
     # overrides LLM globaux (injection au niveau des nœuds)
     p.add_argument("--executor-provider", default=None)
     p.add_argument("--executor-model", default=None)
-    return p.parse_args()
+
+    args = p.parse_args(argv)
+    if args.acceptance is None:
+        args.acceptance = ["Un plan séquencé avec sous-tâches claires."]
+    return args
 
 
 def main() -> None:

--- a/core/agents/schemas.py
+++ b/core/agents/schemas.py
@@ -8,11 +8,11 @@ class PlanNodeModel(BaseModel):
     title: str
     type: NodeType
     suggested_agent_role: str
-    acceptance: List[str] = []
-    deps: List[str] = []
-    risks: List[str] = []
-    assumptions: List[str] = []
-    notes: List[str] = []
+    acceptance: List[str] = Field(default_factory=list)
+    deps: List[str] = Field(default_factory=list)
+    risks: List[str] = Field(default_factory=list)
+    assumptions: List[str] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)
 
 class SupervisorPlan(BaseModel):
     decompose: bool
@@ -44,7 +44,7 @@ class SupervisorPlan(BaseModel):
 class ManagerAssignment(BaseModel):
     node_id: str
     agent: str
-    tooling: List[str] = []
+    tooling: List[str] = Field(default_factory=list)
 
 class ManagerOutput(BaseModel):
     assignments: List[ManagerAssignment]

--- a/core/planning/task_graph.py
+++ b/core/planning/task_graph.py
@@ -9,6 +9,14 @@ import networkx as nx
 from dataclasses import dataclass, field
 from typing import List, Dict, Any
 
+
+def _as_str_list(val) -> List[str]:
+    if not val:
+        return []
+    if isinstance(val, list):
+        return [str(x) for x in val]
+    return [str(val)]
+
 @dataclass
 class PlanNode:
     """
@@ -74,12 +82,12 @@ class TaskGraph:
                 title=p.get("title", ""),
                 description=p.get("description", ""),
                 type=p.get("type", "task"),
-                deps=p.get("deps", []),
-                acceptance=p.get("acceptance", []),
+                deps=_as_str_list(p.get("deps", [])),
+                acceptance=_as_str_list(p.get("acceptance", [])),
                 suggested_agent_role=p.get("suggested_agent_role", ""),
-                risks=p.get("risks", []),
-                assumptions=p.get("assumptions", []),
-                notes=p.get("notes", []),
+                risks=_as_str_list(p.get("risks", [])),
+                assumptions=_as_str_list(p.get("assumptions", [])),
+                notes=_as_str_list(p.get("notes", [])),
                 llm=p.get("llm", {}) or {},                     # <-- NEW
             )
             for p in plan.get("plan", [])

--- a/tests/e2e/test_acceptance_str_e2e.py
+++ b/tests/e2e/test_acceptance_str_e2e.py
@@ -1,0 +1,42 @@
+import os, sys
+from pathlib import Path
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from core.planning.task_graph import TaskGraph
+from apps.orchestrator.executor import run_graph
+from core.llm.providers.base import LLMResponse
+import core.agents.executor_llm as exec_mod
+
+
+class DummyStorage:
+    async def save_artifact(self, node_id, content, ext=".md"):
+        Path(f"artifact_{node_id}{ext}").write_text(content, encoding="utf-8")
+        return True
+
+
+@pytest.mark.asyncio
+async def test_acceptance_str_e2e(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    plan = {
+        "plan": [
+            {
+                "id": "n1",
+                "title": "T1",
+                "type": "execute",
+                "suggested_agent_role": "Researcher",
+                "acceptance": "crit",
+            }
+        ]
+    }
+    dag = TaskGraph.from_plan(plan)
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        return LLMResponse(text="ok", provider="p", model_used="m")
+
+    monkeypatch.setattr(exec_mod, "run_llm", fake_run_llm)
+
+    res = await run_graph(dag, DummyStorage(), "run1")
+    assert res["status"] == "success"
+    assert Path("artifact_n1.md").exists()

--- a/tests/test_acceptance_normalization.py
+++ b/tests/test_acceptance_normalization.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from apps.orchestrator.main import parse_args
+from core.planning.task_graph import TaskGraph
+
+
+def test_parse_args_acceptance_list():
+    args = parse_args([])
+    assert args.acceptance == ["Un plan séquencé avec sous-tâches claires."]
+
+    args = parse_args(["--acceptance", "c1", "--acceptance", "c2"])
+    assert args.acceptance == ["c1", "c2"]
+
+
+def test_task_graph_string_fields_to_lists():
+    plan = {
+        "plan": [
+            {"id": "n0", "title": "root"},
+            {
+                "id": "n1",
+                "title": "T1",
+                "deps": "n0",
+                "acceptance": "crit",
+                "risks": "r1",
+                "assumptions": "a1",
+                "notes": "n1",
+            },
+        ]
+    }
+    dag = TaskGraph.from_plan(plan)
+    node = dag.nodes["n1"]
+    assert node.deps == ["n0"]
+    assert node.acceptance == ["crit"]
+    assert node.risks == ["r1"]
+    assert node.assumptions == ["a1"]
+    assert node.notes == ["n1"]


### PR DESCRIPTION
## Summary
- Make `parse_args` testable and always return an acceptance list
- Factor `_as_str_list` helper for plan field normalization
- Ensure Pydantic models use `Field(default_factory=list)` without duplicates

## Testing
- `pytest -q`
- `pytest tests_api -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4528b1f948327a332a9749d41eb64