### PR TITLE
Isolate auth overrides between tests

### DIFF
--- a/tests_api/conftest.py
+++ b/tests_api/conftest.py
@@ -101,7 +101,7 @@ def _clear_auth_overrides():
             del app.dependency_overrides[dep]
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def client(_dispose_engine) -> AsyncClient:
     """
     Client httpx avec:
@@ -123,10 +123,12 @@ async def client(_dispose_engine) -> AsyncClient:
             yield ac
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def client_noauth(_dispose_engine) -> AsyncClient:
     """
     Client httpx avec auth ACTIVE (pas d’override) pour tester les 401.
+    Après utilisation, les overrides d'auth sont rétablis pour ne pas
+    polluer les autres tests.
     """
     # utilise la base de test pour les deps et l'adaptateur de stockage
     api_deps.settings.database_url = _TEST_DB_URL
@@ -139,6 +141,9 @@ async def client_noauth(_dispose_engine) -> AsyncClient:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             yield ac
+
+    # réactive l'override d'auth pour les autres tests
+    _disable_auth_overrides()
 
 
 # ---------- Données seed ----------


### PR DESCRIPTION
## Summary
- scope test HTTP clients per test
- restore auth override after client_noauth to avoid side effects

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a45ecd1c84832788a507b55916212e