### PR TITLE
Refactorisation superviseur et améliorations LLM/logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ make db-upgrade
 - `make api-test` – run API tests.
 - `make db-revision msg="..."` – create a new Alembic revision.
 - `make db-upgrade` – apply migrations to the database.
+
+## Orchestrateur CLI
+
+Quelques commandes utiles pour piloter l'orchestrateur en ligne de commande :
+
+- `make run` – exécute un plan JSON existant (`examples/task_rapport_80p.json` par défaut).
+- `make run-supervisor` – génère un plan via le superviseur LLM puis l'exécute.
+- `make run-ollama` / `make run-openai` – variantes avec provider forcé.
+- `make tail` – affiche les logs du dernier run.

--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -15,7 +15,9 @@ load_dotenv()
 from .deps import settings
 from .routes import health, runs, nodes, artifacts, events, tasks
 from .middleware import RequestIDMiddleware
+import os
 from core.storage.postgres_adapter import PostgresAdapter
+from core.storage.file_adapter import FileAdapter
 from core.storage.composite_adapter import CompositeAdapter
 from core.events.publisher import EventPublisher
 
@@ -32,7 +34,10 @@ TAGS_METADATA = [
 async def lifespan(app: FastAPI):
     async with create_task_group() as tg:
         pg = PostgresAdapter(settings.database_url)
-        storage = CompositeAdapter([pg])
+        file = FileAdapter(settings.artifacts_dir)
+        order_env = os.getenv("STORAGE_ORDER")
+        order = [x.strip() for x in order_env.split(",") if x.strip()] if order_env else None
+        storage = CompositeAdapter([file, pg], order=order)
         app.state.task_group = tg
         app.state.storage = storage
         app.state.event_publisher = EventPublisher(storage)

--- a/apps/orchestrator/main.py
+++ b/apps/orchestrator/main.py
@@ -24,6 +24,7 @@ from core.storage.file_adapter import FileAdapter
 from core.telemetry.logging_setup import setup_logging
 from apps.orchestrator.executor import run_graph
 from core.agents import supervisor
+from core.agents.schemas import SupervisorPlan
 
 
 # --------------------------------------------------------------------------------------
@@ -55,7 +56,13 @@ class SafeTracker:
         return None
 
 
-def _normalize_supervisor_plan(super_plan: dict, title: str) -> dict:
+def _normalize_supervisor_plan(super_plan: SupervisorPlan | dict, title: str) -> dict:
+    """Convertit le plan du superviseur en dict exploitable par TaskGraph."""
+    if isinstance(super_plan, SupervisorPlan):
+        items = [p.model_dump() for p in super_plan.plan]
+        return {"title": title, "plan": items}
+
+    # Fallback legacy (dict brut) pour compatibilité éventuelle
     items = []
     if isinstance(super_plan.get("subtasks"), list) and super_plan["subtasks"]:
         for i, st in enumerate(super_plan["subtasks"], start=1):
@@ -123,7 +130,7 @@ def main() -> None:
         os.makedirs(run_dir, exist_ok=True)
 
         # logger du run
-        logger = setup_logging(run_dir, logger_name="crew")
+        logger = setup_logging(run_dir, logger_name="crew", run_id=run_id)
 
         # Storage file-only pour le mode CLI
         file_adapter = FileAdapter(runs_root)
@@ -162,7 +169,7 @@ def main() -> None:
         run_dir = os.path.join(runs_root, run_id)
         os.makedirs(run_dir, exist_ok=True)
 
-        logger = setup_logging(run_dir, logger_name="crew")
+        logger = setup_logging(run_dir, logger_name="crew", run_id=run_id)
 
         with open(os.path.join(run_dir, "plan.json"), "w", encoding="utf-8") as f:
             json.dump(plan_dict, f, ensure_ascii=False, indent=2)

--- a/core/agents/recruiter.py
+++ b/core/agents/recruiter.py
@@ -1,12 +1,19 @@
-from .registry import AgentSpec
+from .registry import AgentSpec, ROLE_PROMPTS, _resolve_provider_model
 
-def recruit(role:str) -> AgentSpec:
+
+def recruit(role: str) -> AgentSpec:
     r = role.strip()
+    if not r:
+        raise ValueError("role vide")
+
     if r.lower().startswith("writer"):
-        return AgentSpec(role,"core/agents/prompts/executors/writer_fr.txt","ollama","llama3.1:8b",[])
-    if r.lower().startswith("research"):
-        return AgentSpec(role,"core/agents/prompts/executors/researcher.txt","ollama","llama3.1:8b",[])
-    if r.lower().startswith("review"):
-        return AgentSpec(role,"core/agents/prompts/executors/reviewer.txt","ollama","llama3.1:8b",[])
-    # fallback manager
-    return AgentSpec(role,"core/agents/prompts/manager.txt","ollama","llama3.1:8b",[])
+        prompt, prefix = ROLE_PROMPTS["Writer_FR"]
+    elif r.lower().startswith("research"):
+        prompt, prefix = ROLE_PROMPTS["Researcher"]
+    elif r.lower().startswith("review"):
+        prompt, prefix = ROLE_PROMPTS["Reviewer"]
+    else:
+        prompt, prefix = ROLE_PROMPTS["Manager_Generic"]
+
+    provider, model = _resolve_provider_model(prefix)
+    return AgentSpec(r, prompt, provider, model, [])

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -1,6 +1,7 @@
 import os
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Dict
+
 
 @dataclass
 class AgentSpec:
@@ -10,29 +11,38 @@ class AgentSpec:
     model: str
     tools: list[str]
 
-def _env(name:str, default:str=""):
-    return os.getenv(name, default)
 
-def load_default_registry() -> Dict[str,AgentSpec]:
-    return {
-        "Supervisor": AgentSpec("Supervisor","core/agents/prompts/supervisor.txt",
-            _env("SUPERVISOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("SUPERVISOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Manager_Generic": AgentSpec("Manager_Generic","core/agents/prompts/manager.txt",
-            _env("MANAGER_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("MANAGER_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Writer_FR": AgentSpec("Writer_FR","core/agents/prompts/executors/writer_fr.txt",
-            _env("EXECUTOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("EXECUTOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Researcher": AgentSpec("Researcher","core/agents/prompts/executors/researcher.txt",
-            _env("EXECUTOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("EXECUTOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Reviewer": AgentSpec("Reviewer","core/agents/prompts/executors/reviewer.txt",
-            _env("EXECUTOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("EXECUTOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-    }
+def _resolve_provider_model(prefix: str) -> tuple[str, str]:
+    """Résout provider/modèle à partir des variables d'environnement.
+
+    PREFIX_PROVIDER et PREFIX_MODEL sont utilisés en priorité, sinon on
+    retombe sur LLM_DEFAULT_PROVIDER / LLM_DEFAULT_MODEL."""
+
+    provider = os.getenv(f"{prefix}_PROVIDER", os.getenv("LLM_DEFAULT_PROVIDER", "ollama"))
+    model = os.getenv(f"{prefix}_MODEL", os.getenv("LLM_DEFAULT_MODEL", "llama3.1:8b"))
+    return provider, model
+
+
+# Rôles connus -> (fichier prompt, préfixe env)
+ROLE_PROMPTS: Dict[str, tuple[str, str]] = {
+    "Supervisor": ("core/agents/prompts/supervisor.txt", "SUPERVISOR"),
+    "Manager_Generic": ("core/agents/prompts/manager.txt", "MANAGER"),
+    "Writer_FR": ("core/agents/prompts/executors/writer_fr.txt", "EXECUTOR"),
+    "Researcher": ("core/agents/prompts/executors/researcher.txt", "EXECUTOR"),
+    "Reviewer": ("core/agents/prompts/executors/reviewer.txt", "EXECUTOR"),
+}
+
+
+def load_default_registry() -> Dict[str, AgentSpec]:
+    """Charge les specs par défaut pour les rôles connus.
+
+    Pour ajouter un nouveau rôle, compléter ROLE_PROMPTS avec
+    ("NomDuRôle", ("chemin/prompt.txt", "PREFIX_ENV")). Le provider et le
+    modèle seront automatiquement résolus via PREFIX_ENV_PROVIDER/MODEL avec
+    fallback sur LLM_DEFAULT_PROVIDER/MODEL."""
+
+    registry: Dict[str, AgentSpec] = {}
+    for role, (prompt, prefix) in ROLE_PROMPTS.items():
+        provider, model = _resolve_provider_model(prefix)
+        registry[role] = AgentSpec(role, prompt, provider, model, [])
+    return registry

--- a/core/agents/supervisor.py
+++ b/core/agents/supervisor.py
@@ -11,7 +11,23 @@ from core.llm.providers.base import LLMRequest
 from core.llm.runner import run_llm
 
 
-async def run_supervisor(task_input: str) -> SupervisorPlan:
+async def run(task: Dict[str, Any], storage: Any | None = None) -> SupervisorPlan:
+    """Génère un plan via le rôle Supervisor.
+
+    Parameters
+    ----------
+    task: dict
+        Description structurée de la tâche (titre, description, acceptance).
+    storage: Any, optional
+        Paramètre conservé pour compatibilité future (non utilisé).
+
+    Returns
+    -------
+    SupervisorPlan
+        Plan validé (pas de cycles, dépendances existantes, rôle non vide).
+    """
+
+    task_input = json.dumps(task, ensure_ascii=False)
     spec = load_default_registry().get("Supervisor") or recruit("Supervisor")
     root = Path(__file__).resolve().parents[2]
     system_prompt = (root / spec.system_prompt_path).read_text(encoding="utf-8")
@@ -25,24 +41,3 @@ async def run_supervisor(task_input: str) -> SupervisorPlan:
                 req.prompt = task_input + "\nRAPPEL: répondez UNIQUEMENT en JSON strict valide."
             else:
                 raise
-
-
-async def run(task: Dict[str, Any], storage: Any | None = None) -> Dict[str, Any]:
-    """Maintient la compatibilité avec l'ancienne interface.
-
-    Parameters
-    ----------
-    task: dict
-        Description structurée de la tâche (titre, description, acceptance).
-    storage: Any, optional
-        Paramètre conservé pour compatibilité, non utilisé ici.
-
-    Returns
-    -------
-    dict
-        Plan du superviseur sous forme de dictionnaire.
-    """
-
-    task_input = json.dumps(task, ensure_ascii=False)
-    sup = await run_supervisor(task_input)
-    return sup.model_dump()

--- a/core/llm/providers/base.py
+++ b/core/llm/providers/base.py
@@ -20,6 +20,7 @@ class LLMResponse:
     # Ajouts pour la traçabilité
     provider: Optional[str] = None      # "ollama" | "openai" | ...
     model_used: Optional[str] = None    # modèle effectivement utilisé (peut différer en fallback)
+    latency_ms: Optional[int] = None    # durée d'appel en millisecondes
 
 
 class ProviderError(Exception): ...

--- a/core/llm/runner.py
+++ b/core/llm/runner.py
@@ -126,6 +126,7 @@ async def run_llm(req: LLMRequest, primary: Optional[str] = None, fallback_order
             # enrichir la réponse pour la traçabilité
             resp.provider = name
             resp.model_used = model
+            resp.latency_ms = dt_ms
 
             log.info("llm.used provider=%s model=%s duration_ms=%d", name, model, dt_ms)
             return resp

--- a/core/planning/planner.py
+++ b/core/planning/planner.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from typing import List
 import json
 
-from core.agents.supervisor import run_supervisor
+from core.agents.supervisor import run
 from core.agents.schemas import PlanNodeModel
 from core.planning.task_graph import PlanNode
 
 async def plan_from_task(task_input: str, run_dir: str = ".") -> List[PlanNode]:
-    sup = await run_supervisor(task_input)
+    task = json.loads(task_input)
+    sup = await run(task)
     nodes: List[PlanNode] = []
     for n in sup.plan:
         nodes.append(

--- a/core/telemetry/logging_setup.py
+++ b/core/telemetry/logging_setup.py
@@ -3,42 +3,54 @@ import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-def setup_logging(run_dir: str, logger_name: str = "crew", *, to_stdout: bool = True) -> logging.Logger:
-    """
-    Configure un logger 'crew' avec :
-      - niveau depuis LOG_LEVEL (default INFO)
-      - fichier .runs/<run_id>/orchestrator.log (rotation 1 Mo x 3)
-      - console (stdout) optionnelle
-    """
+
+class _RunIdFilter(logging.Filter):
+    def __init__(self, run_id: str):
+        super().__init__()
+        self.run_id = run_id
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.run_id = self.run_id
+        return True
+
+
+def setup_logging(run_dir: str, logger_name: str = "crew", *, to_stdout: bool = True, run_id: str | None = None) -> logging.Logger:
+    """Configure un logger préfixant les messages par le run_id."""
+
     level_name = (os.getenv("LOG_LEVEL") or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
 
+    run_id = run_id or Path(run_dir).name
     log_path = Path(run_dir) / "orchestrator.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
-    logger.propagate = False  # pas d’héritage root
+    logger.propagate = False
 
-    # clear handlers si relance dans le même process (pytest)
+    # reset handlers (utile en tests)
     for h in list(logger.handlers):
         logger.removeHandler(h)
 
     fmt = logging.Formatter(
-        fmt="%(asctime)s %(levelname)s [%(name)s] %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S"
+        fmt="%(asctime)s %(levelname)s [%(name)s] %(run_id)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
+    run_filter = _RunIdFilter(run_id)
 
     file_h = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3, encoding="utf-8")
     file_h.setLevel(level)
     file_h.setFormatter(fmt)
+    file_h.addFilter(run_filter)
     logger.addHandler(file_h)
 
     if to_stdout and os.getenv("LOG_TO_STDOUT", "1") == "1":
         sh = logging.StreamHandler()
         sh.setLevel(level)
         sh.setFormatter(fmt)
+        sh.addFilter(run_filter)
         logger.addHandler(sh)
 
     logger.debug("logging initialized (level=%s, path=%s)", level_name, log_path)
     return logger
+

--- a/tests/test_acceptance_normalization.py
+++ b/tests/test_acceptance_normalization.py
@@ -37,3 +37,27 @@ def test_task_graph_string_fields_to_lists():
     assert node.risks == ["r1"]
     assert node.assumptions == ["a1"]
     assert node.notes == ["n1"]
+
+
+def test_task_graph_none_fields_to_empty_list():
+    plan = {
+        "plan": [
+            {"id": "n0", "title": "root"},
+            {
+                "id": "n1",
+                "title": "T1",
+                "deps": None,
+                "acceptance": None,
+                "risks": None,
+                "assumptions": None,
+                "notes": None,
+            },
+        ]
+    }
+    dag = TaskGraph.from_plan(plan)
+    node = dag.nodes["n1"]
+    assert node.deps == []
+    assert node.acceptance == []
+    assert node.risks == []
+    assert node.assumptions == []
+    assert node.notes == []

--- a/tests/test_run_supervisor_integration.py
+++ b/tests/test_run_supervisor_integration.py
@@ -1,0 +1,48 @@
+import json
+import sys
+
+import pytest
+
+from core.llm.providers.base import LLMResponse
+import apps.orchestrator.main as orch
+
+
+def test_run_supervisor_integration(tmp_path, monkeypatch):
+    runs_root = tmp_path / ".runs"
+    monkeypatch.setenv("RUNS_ROOT", str(runs_root))
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        plan = {
+            "decompose": False,
+            "plan": [
+                {
+                    "id": "n1",
+                    "title": "T1",
+                    "type": "execute",
+                    "suggested_agent_role": "Writer_FR",
+                    "deps": [],
+                }
+            ],
+        }
+        return LLMResponse(text=json.dumps(plan))
+
+    async def fake_agent_runner(node, storage):
+        await storage.save_artifact(node_id=node.id, content="ok", ext=".md")
+        return "artifact"
+
+    monkeypatch.setattr("core.llm.runner.run_llm", fake_run_llm)
+    monkeypatch.setattr("core.agents.supervisor.run_llm", fake_run_llm)
+    import apps.orchestrator.executor as ex
+    monkeypatch.setattr(ex, "agent_runner", fake_agent_runner)
+
+    argv = ["prog", "--use-supervisor", "--title", "Demo"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    orch.main()
+
+    runs = [p for p in runs_root.iterdir() if p.is_dir()]
+    assert runs
+    plan_file = runs[0] / "plan.json"
+    assert plan_file.exists()
+    data = json.loads(plan_file.read_text())
+    assert data["plan"]


### PR DESCRIPTION
## Résumé
- Aligne le planificateur sur la nouvelle API `supervisor.run`
- Simplifie `CompositeAdapter` avec normalisation asynchrone des identifiants
- Stabilise le test d'intégration du superviseur

## Tests
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a47738ad108327a8ecadfc94e53b55