### PR TITLE
Expose schema classes for FastAPI

### DIFF
--- a/api/fastapi_app/schemas.py
+++ b/api/fastapi_app/schemas.py
@@ -115,3 +115,9 @@ class EventOut(BaseModel):
     level: str
     message: str
     timestamp: datetime
+
+__all__ = [
+    name
+    for name, obj in globals().items()
+    if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel
+]


### PR DESCRIPTION
## Summary
- expose all pydantic schema classes automatically using __all__

## Testing
- `make fmt`
- `make lint`
- `make test` *(échoue: AssertionError: assert 'running' == 'completed')*


------
https://chatgpt.com/codex/tasks/task_e_68a4b63d77f48327a7c4767976c30014