### PR TITLE
Ajout d'un identifiant UUID lors du démarrage d'un nœud

### DIFF
--- a/apps/orchestrator/api_runner.py
+++ b/apps/orchestrator/api_runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import uuid
 from uuid import UUID
 from typing import Any, Dict, Optional
 
@@ -104,6 +105,7 @@ async def run_task(
         """Persiste un nœud au démarrage et mémorise son UUID."""
         node_db = await storage.save_node(
             node=Node(
+                id=uuid.uuid4(),
                 run_id=UUID(run_id),
                 key=node_key,
                 title=getattr(node, "title", "") or (node.get("title") if isinstance(node, dict) else ""),


### PR DESCRIPTION
## Résumé
- génère un identifiant unique avec `uuid4` pour chaque nœud lancé
- ajoute l'import du module `uuid`

## Tests
- `pytest tests -q` *(échoue : fixture `client` manquante)*
- `pytest api/tests -q`
- `pytest tests_api -q`
- `pytest tests_extra -q` *(échoue : ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68a6c9c6a86c8327b96b34730cfc65fa