### PR TITLE
Nettoyage lecture sidecar LLM

### DIFF
--- a/apps/orchestrator/api_runner.py
+++ b/apps/orchestrator/api_runner.py
@@ -58,6 +58,13 @@ def _extract_llm_meta_from_artifacts(artifacts: list[dict]) -> dict:
     return {}
 
 def _read_llm_sidecar_fs(run_id: str, node_key: str, runs_root: str = None) -> dict:
+    """Lit un sidecar ``artifact_<node_key>.llm.json``.
+
+    La racine de recherche est, par ordre de priorité :
+    ``runs_root`` si fourni, puis ``ARTIFACTS_DIR``, ``RUNS_ROOT``
+    et enfin ``.runs``.  Retourne un ``dict`` si le fichier existe,
+    sinon ``{}``.
+    """
     base = runs_root or os.getenv("ARTIFACTS_DIR") or os.getenv("RUNS_ROOT") or ".runs"
     path = Path(base) / run_id / "nodes" / node_key / f"artifact_{node_key}.llm.json"
     if path.exists():
@@ -66,19 +73,6 @@ def _read_llm_sidecar_fs(run_id: str, node_key: str, runs_root: str = None) -> d
         except Exception:
             return {}
     return {}
-
-def _read_llm_sidecar_by_key(run_id: str, node_key: str) -> Dict[str, Any]:
-    """
-    Sidecar path format (clé logique):
-    .runs/<run_id>/nodes/<node_key>/artifact_<node_key>.llm.json
-    """
-    try:
-        path = Path(".runs") / run_id / "nodes" / node_key / f"artifact_{node_key}.llm.json"
-        if not path.exists():
-            return {}
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
 
 async def run_task(
     run_id: str,

--- a/tests/test_llm_sidecar.py
+++ b/tests/test_llm_sidecar.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+import os, sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from apps.orchestrator.api_runner import _read_llm_sidecar_fs
+
+
+def _write_sidecar(base: Path, run_id: str, node_key: str, data: dict) -> None:
+    folder = base / run_id / "nodes" / node_key
+    folder.mkdir(parents=True)
+    (folder / f"artifact_{node_key}.llm.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+
+
+def test_read_llm_sidecar_fs_with_runs_root(tmp_path: Path) -> None:
+    _write_sidecar(tmp_path, "run1", "n1", {"provider": "p"})
+    out = _read_llm_sidecar_fs("run1", "n1", runs_root=str(tmp_path))
+    assert out == {"provider": "p"}
+
+
+def test_read_llm_sidecar_fs_with_env(tmp_path: Path, monkeypatch) -> None:
+    _write_sidecar(tmp_path, "run2", "n2", {"model": "m"})
+    monkeypatch.setenv("ARTIFACTS_DIR", str(tmp_path))
+    out = _read_llm_sidecar_fs("run2", "n2")
+    assert out == {"model": "m"}
+
+
+def test_read_llm_sidecar_fs_missing(tmp_path: Path) -> None:
+    out = _read_llm_sidecar_fs("missing", "none", runs_root=str(tmp_path))
+    assert out == {}
+


### PR DESCRIPTION
## Résumé
- centralisation de la lecture du sidecar LLM via `_read_llm_sidecar_fs`
- suppression de la fonction redondante `_read_llm_sidecar_by_key`
- ajout de tests couvrant les usages `runs_root` et variables d'environnement

## Tests
- `pytest -q` *(échoue: import file mismatch)*
- `pytest tests/test_llm_sidecar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c9c8df0c8327ad22b07de29916d1