### PR TITLE
Préserver task_spec lors du plan de démonstration

### DIFF
--- a/apps/orchestrator/api_runner.py
+++ b/apps/orchestrator/api_runner.py
@@ -94,7 +94,7 @@ async def run_task(
     # 1) Construire DAG
     if not task_spec.get("plan") and task_spec.get("type") == "demo":
         # Plan minimal de démonstration
-        task_spec = {"plan": [{"id": "n1", "title": title}]}
+        task_spec = {**task_spec, "plan": [{"id": "n1", "title": title}]}
     dag = TaskGraph.from_plan(task_spec)
 
     # 2) Callbacks télémétrie


### PR DESCRIPTION
## Résumé
- Conserve les autres clés de `task_spec` lors de l'ajout d'un plan minimal pour les tâches de démonstration.

## Tests
- `make test` *(échec : import file mismatch entre `tests/test_tasks_e2e.py` et `api/tests/test_tasks_e2e.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c9c9bcf08327be04068981e04bad