### PR TITLE
Expose la fixture async_client pour les tests API

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -126,6 +126,10 @@ async def client() -> AsyncClient:
             yield ac
 
 
+@pytest_asyncio.fixture
+async def async_client(client: AsyncClient) -> AsyncClient:
+    return client
+
 @pytest_asyncio.fixture(scope="session")
 async def client_noauth() -> AsyncClient:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.append(ROOT_DIR)
+
+pytest_plugins = ["tests_api.conftest"]

--- a/tests_api/conftest.py
+++ b/tests_api/conftest.py
@@ -125,6 +125,10 @@ async def client(_dispose_engine) -> AsyncClient:
 
 
 @pytest_asyncio.fixture
+async def async_client(client: AsyncClient) -> AsyncClient:
+    return client
+
+@pytest_asyncio.fixture
 async def client_noauth(_dispose_engine) -> AsyncClient:
     """
     Client httpx avec auth ACTIVE (pas d’override) pour tester les 401.


### PR DESCRIPTION
## Résumé
- ajoute une fixture `async_client` qui renvoie le `client` existant dans les suites de tests API
- charge les fixtures d'API pour les tests situés à la racine via `pytest_plugins`

## Tests
- `pytest tests/test_tasks_happy_e2e.py -q`
- `pytest api/tests/test_tasks_e2e.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a766ee4f9c832784b4d664bf37bd42