### PR TITLE
Ajout de pyproject et nettoyage des tests

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,8 +2,6 @@
 import asyncio
 import datetime as dt
 import uuid
-import os
-import sys
 
 import pytest
 import pytest_asyncio
@@ -13,11 +11,6 @@ from asgi_lifespan import LifespanManager
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import delete, insert
-
-# Ensure project root on sys.path
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-if ROOT_DIR not in sys.path:
-    sys.path.append(ROOT_DIR)
 
 # --- importe l'app et les deps ---
 from api.fastapi_app.main import app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "crew_ia"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "crewai>=0.51",
+  "pydantic>=2",
+  "pydantic-settings>=2",
+  "networkx>=3",
+  "httpx>=0.27",
+  "anyio>=4",
+  "uvicorn>=0.30",
+  "fastapi>=0.111",
+  "rich>=13",
+  "python-dotenv>=1",
+  "opentelemetry-sdk>=1.26",
+  "opentelemetry-exporter-otlp>=1.26",
+  "pytest>=8",
+  "aiofiles>=24.1.0",
+  "sqlmodel>=0.0.21",
+  "SQLAlchemy>=2.0",
+  "asyncpg>=0.29",
+  "alembic>=1.13",
+  "psycopg[binary]>=3.1",
+  "pytest-asyncio>=0.23"
+]
+
+[tool.setuptools]
+# le code vit à la racine (pas de src/)
+package-dir = {"" = "."}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["apps*", "core*"]
+exclude = ["tests*", "examples*", "api*", "dashboard*", ".*"]
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/tests/e2e/test_acceptance_str_e2e.py
+++ b/tests/e2e/test_acceptance_str_e2e.py
@@ -1,8 +1,5 @@
-import os, sys
 from pathlib import Path
 import pytest
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 from core.planning.task_graph import TaskGraph
 from apps.orchestrator.executor import run_graph

--- a/tests/e2e/test_mini_flow.py
+++ b/tests/e2e/test_mini_flow.py
@@ -1,8 +1,6 @@
 import json
 from pathlib import Path
 import pytest
-import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..','..')))
 
 from core.planning.task_graph import PlanNode, TaskGraph
 from apps.orchestrator.executor import run_graph

--- a/tests/test_acceptance_normalization.py
+++ b/tests/test_acceptance_normalization.py
@@ -1,8 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from apps.orchestrator.main import parse_args
 from core.planning.task_graph import TaskGraph
 

--- a/tests/test_agent_routing.py
+++ b/tests/test_agent_routing.py
@@ -1,8 +1,7 @@
 import json
 from pathlib import Path
 import pytest
-import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from core.agents.executor_llm import agent_runner
 from core.agents.schemas import PlanNodeModel
 from core.llm.providers.base import LLMResponse

--- a/tests/test_llm_sidecar.py
+++ b/tests/test_llm_sidecar.py
@@ -1,8 +1,6 @@
 import json
 from pathlib import Path
-import os, sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from apps.orchestrator.api_runner import _read_llm_sidecar_fs
 
 
@@ -30,4 +28,3 @@ def test_read_llm_sidecar_fs_with_env(tmp_path: Path, monkeypatch) -> None:
 def test_read_llm_sidecar_fs_missing(tmp_path: Path) -> None:
     out = _read_llm_sidecar_fs("missing", "none", runs_root=str(tmp_path))
     assert out == {}
-

--- a/tests/test_manager_assignments.py
+++ b/tests/test_manager_assignments.py
@@ -1,6 +1,5 @@
 import pytest
-import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from core.agents.manager import run_manager
 from core.agents.schemas import PlanNodeModel
 from core.llm.providers.base import LLMResponse

--- a/tests/test_recovery_e2e.py
+++ b/tests/test_recovery_e2e.py
@@ -1,8 +1,6 @@
 import asyncio
 import os
-import sys
 import pytest
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from apps.orchestrator.executor import run_graph
 from core.storage.file_adapter import FileStatusStore

--- a/tests/test_registry_recruiter.py
+++ b/tests/test_registry_recruiter.py
@@ -1,5 +1,3 @@
-import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.agents.recruiter import recruit
 
 def test_recruiter_unknown():

--- a/tests/test_supervisor_json.py
+++ b/tests/test_supervisor_json.py
@@ -1,6 +1,4 @@
 import pytest
-import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from pydantic import ValidationError
 from core.agents.schemas import parse_supervisor_json, SupervisorPlan
 

--- a/tests/test_supervisor_sim.py
+++ b/tests/test_supervisor_sim.py
@@ -1,5 +1,6 @@
-import os, sys, json, pytest
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import json
+import pytest
+
 from core.agents.supervisor import run as supervisor_run
 from core.llm.providers.base import LLMResponse
 import core.llm.runner as runner_mod


### PR DESCRIPTION
## Résumé
- rendre le projet installable via `pyproject.toml`
- enlever les manipulations `sys.path` des tests

## Tests
- `pip install -e .`
- `pytest tests` *(échoue: fixture `async_client` absente)*
- `pytest api/tests`
- `pytest tests_api`
- `pytest tests_extra`


------
https://chatgpt.com/codex/tasks/task_e_68a7671a129c8327b780269c1749cfdb