### PR TITLE
Autoriser des champs supplémentaires pour la création de tâche

### DIFF
--- a/api/fastapi_app/routes/tasks.py
+++ b/api/fastapi_app/routes/tasks.py
@@ -28,6 +28,7 @@ class TaskSpec(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 class TaskRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
     title: str = Field(..., examples=["Rapport 80p"])
     # l’appelant peut envoyer soit "task", soit "task_spec"
     task: Optional[TaskSpec] = None


### PR DESCRIPTION
## Résumé
- autorise les champs additionnels pour `TaskRequest`

## Tests
- `python -m py_compile api/fastapi_app/routes/tasks.py`
- `pytest` *(échec : Plugin already registered under a different name: tests_api/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a4ac5e88327b2ffe721154fd8d9