### PR TITLE
Stabilise e2e task event test

### DIFF
--- a/tests/test_tasks_e2e.py
+++ b/tests/test_tasks_e2e.py
@@ -14,12 +14,14 @@ async def test_events_include_llm_metadata(client):
     rid = r.json()["run_id"]
 
     # poll
-    for _ in range(60):
+    for _ in range(120):
         rr = await client.get(f"/runs/{rid}", headers={"X-API-Key": "test-key"})
-        if rr.json()["status"] in ("completed", "failed"):
+        status = rr.json()["status"]
+        if status in ("completed", "failed"):
             break
         await asyncio.sleep(0.05)
-
+    else:
+        pytest.fail("Run did not finish in time")
 
     ev = await client.get("/events", params={"run_id": rid}, headers={"X-API-Key": "test-key"})
 


### PR DESCRIPTION
## Résumé
- Attend plus longtemps la fin d'un run dans le test e2e des tâches
- Échoue explicitement si le run ne se termine pas à temps

## Tests
- `pre-commit run --files tests/test_tasks_e2e.py`
- `PYTHONPATH=. pytest tests/test_tasks_e2e.py::test_events_include_llm_metadata tests_api/test_node_completed_meta.py::test_node_completed_has_meta -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a859745cf0832796edbe8660f917bc