### PR TITLE
feat: add run and node logs with tail events cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,11 @@ tail:
 	echo "Tailing $$latest_run/orchestrator.log"; \
 	tail -f "$$latest_run/orchestrator.log"
 
+.PHONY: tail-events
+tail-events: ensure-venv
+	@if [ -z "$(RUN_ID)" ]; then echo "RUN_ID requis"; exit 1; fi
+	@$(ACTIVATE) && $(PYTHON) tools/tail_events.py --run-id $(RUN_ID) --url http://$(API_HOST):$(API_PORT)/events
+
 .PHONY: env-check
 env-check: ensure-venv
 	@$(ACTIVATE) && $(PYTHON) - << 'PY'

--- a/apps/orchestrator/api_runner.py
+++ b/apps/orchestrator/api_runner.py
@@ -197,6 +197,15 @@ async def run_task(
             if node_status == NodeStatus.completed
             else EventType.NODE_FAILED
         )
+        if node_status == NodeStatus.completed:
+            log.info(
+                "NODE_COMPLETED run_id=%s node=%s provider=%s model=%s latency_ms=%s",
+                run_id,
+                node_key,
+                payload.get("provider"),
+                payload.get("model"),
+                payload.get("latency_ms"),
+            )
         await event_publisher.emit(event_type, payload, request_id=request_id)
 
     try:

--- a/core/services/orchestrator_service.py
+++ b/core/services/orchestrator_service.py
@@ -5,6 +5,7 @@ import json
 import os
 import anyio
 from datetime import datetime, timezone
+import logging
 
 from core.storage.db_models import Run, RunStatus
 from core.storage.composite_adapter import CompositeAdapter
@@ -12,6 +13,8 @@ from core.storage.file_adapter import FileAdapter
 from core.storage.postgres_adapter import PostgresAdapter
 from core.events.publisher import EventPublisher
 from apps.orchestrator.api_runner import run_task
+
+log = logging.getLogger("orchestrator.service")
 
 def _load_task_from_file(path: str) -> Dict[str, Any]:
     if not os.path.isfile(path):
@@ -63,6 +66,7 @@ async def schedule_run(
     await storage.save_run(
         run=Run(id=run_id, title=title, status=RunStatus.running, started_at=now, meta={"request_id": request_id})
     )
+    log.info("run created request_id=%s run_id=%s", request_id, run_id)
 
     # Démarrer l'exécution asynchrone fire-and-forget
     tg.start_soon(

--- a/tools/tail_events.py
+++ b/tools/tail_events.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Petit utilitaire pour suivre les events d'un run en temps réel."""
+
+import argparse
+import json
+import time
+from typing import Any
+
+import httpx
+
+
+def format_event(evt: dict[str, Any]) -> str:
+    ts = evt.get("timestamp")
+    level = evt.get("level")
+    msg = evt.get("message", "")
+    try:
+        payload = json.loads(msg)
+    except Exception:
+        payload = {}
+    if level == "NODE_COMPLETED":
+        return (
+            f"{ts} NODE_COMPLETED node={payload.get('node_key')} "
+            f"provider={payload.get('provider')} "
+            f"model={payload.get('model')} latency_ms={payload.get('latency_ms')}"
+        )
+    return f"{ts} {level} {payload or msg}"
+
+
+def tail_events(run_id: str, url: str, interval: float = 1.0) -> None:
+    offset = 0
+    while True:
+        try:
+            resp = httpx.get(url, params={"run_id": run_id, "offset": offset, "limit": 100})
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            print(f"Erreur requête: {exc}")
+            time.sleep(interval)
+            continue
+        items = data.get("items", [])
+        for evt in items:
+            print(format_event(evt), flush=True)
+        offset += len(items)
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True, dest="run_id")
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:8000/events",
+        help="URL de base vers /events",
+    )
+    parser.add_argument("--interval", type=float, default=1.0, help="Pause entre deux requêtes")
+    args = parser.parse_args()
+    tail_events(args.run_id, args.url, args.interval)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- log run creation with request id and run id
- log node completion with provider, model and latency
- add tail-events CLI utility and Makefile target
- fix Makefile tail targets to use tabs and mark CLI script executable

## Testing
- `make api-test`
- `. .venv/bin/activate && pytest -q`
- `RUN_ID=1234 make tail-events RUN_ID=1234`


------
https://chatgpt.com/codex/tasks/task_e_68a888ab50608327ba0407624b876eee