### PR TITLE
feat: validation et rate limit sur /tasks

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -57,6 +57,7 @@ async def lifespan(app: FastAPI):
         app.state.task_group = tg
         app.state.storage = storage
         app.state.event_publisher = EventPublisher(storage)
+        app.state.rate_limits = {}
         yield
         # task group exits cancelling background tasks
 

--- a/api/fastapi_app/routes/tasks.py
+++ b/api/fastapi_app/routes/tasks.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi import Header
-from pydantic import BaseModel, Field, ConfigDict
-from typing import Optional, Any, Dict, List
+from pydantic import ValidationError
+from typing import Optional, Any, Dict
 from uuid import UUID
 import os
+import time
 
 from ..deps import api_key_auth
+from ..schemas import TaskRequest, TaskAcceptedResponse
 from core.services.orchestrator_service import schedule_run
 
 router = APIRouter(
@@ -17,43 +19,42 @@ router = APIRouter(
     dependencies=[Depends(api_key_auth)],  # 🔒 vérifie la valeur de la clé
 )
 
-# ---------- Schemas ----------
+# ---------- Rate limit config ----------
+RATE_LIMIT = 3
+WINDOW_SEC = 60
 
-class Options(BaseModel):
-    resume: bool = False
-    dry_run: bool = False
-    override: List[str] = Field(default_factory=list)
 
-class TaskSpec(BaseModel):
-    model_config = ConfigDict(extra="allow")  # tolère "plan", etc.
-
-class TaskRequest(BaseModel):
-    model_config = ConfigDict(extra="allow")
-    title: str = Field(..., examples=["Rapport 80p"])
-    task: Optional[TaskSpec] = None
-    task_spec: Optional[TaskSpec] = None
-    task_file: Optional[str] = None
-    options: Options = Field(default_factory=Options)
-    llm: Optional[Dict[str, Any]] = None
-    request_id: Optional[str] = None
-
-class TaskAcceptedResponse(BaseModel):
-    status: str = "accepted"
-    run_id: str
-    location: str
+def _check_rate_limit(request: Request) -> None:
+    store: Dict[str, tuple[int, float]] = request.app.state.rate_limits
+    ip = request.client.host if request.client else "?"
+    api_key = request.headers.get("X-API-Key", "")
+    key = f"{ip}:{api_key}"
+    now = time.time()
+    count, start = store.get(key, (0, now))
+    if now - start > WINDOW_SEC:
+        store[key] = (1, now)
+        return
+    if count >= RATE_LIMIT:
+        raise HTTPException(status_code=429, detail="Too Many Requests")
+    store[key] = (count + 1, start)
 
 # ---------- Route ----------
 
 @router.post("", response_model=TaskAcceptedResponse, status_code=status.HTTP_202_ACCEPTED)
 async def create_task(
-    body: TaskRequest,
+    payload: Dict[str, Any],
     request: Request,
     x_request_id: str | None = Header(default=None, alias="X-Request-ID"),
 ):
-    """
-    Lance l'orchestrateur en arrière-plan, répond 202 + run_id.
-    Convertit proprement les erreurs d'entrée (ex: task_file manquant) en 400.
-    """
+    """Lance l'orchestrateur en arrière-plan, répond 202 + run_id."""
+
+    _check_rate_limit(request)
+
+    try:
+        body = TaskRequest.model_validate(payload)
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=e.errors())
+
     # Source du plan prioritaire: task_spec > task ; sinon task_file
     task_spec: Optional[Dict[str, Any]] = None
     if body.task_spec is not None:
@@ -63,30 +64,25 @@ async def create_task(
 
     # Validation rapide côté API si on passe par un fichier
     if task_spec is None and body.task_file:
-        # 1) existence
         if not os.path.isfile(body.task_file):
             raise HTTPException(status_code=400, detail=f"task_file not found: {body.task_file}")
-        # 2) format
         if not body.task_file.lower().endswith(".json"):
             raise HTTPException(status_code=400, detail="task_file must be a .json file")
 
-    # Propagation du request_id
     request_id = x_request_id or body.request_id
 
     try:
         run_id: UUID = await schedule_run(
             task_spec=task_spec,
-            options=body.options,      # ✅ resume/dry_run/override transmis
+            options=body.options,
             app_state=request.app.state,
             title=body.title,
-            task_file=body.task_file,  # le service relira le JSON
+            task_file=body.task_file,
             request_id=request_id,
         )
     except (FileNotFoundError, ValueError) as e:
-        # Sécurité ceinture+bretelles si le service relance ce type d'erreurs
         raise HTTPException(status_code=400, detail=str(e))
     except Exception:
-        # Erreur interne inattendue
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
     return TaskAcceptedResponse(run_id=str(run_id), location=f"/runs/{run_id}")

--- a/tests_api/test_tasks_validation.py
+++ b/tests_api/test_tasks_validation.py
@@ -1,0 +1,27 @@
+import pytest
+import uuid
+
+
+@pytest.mark.asyncio
+async def test_invalid_task_spec_returns_400(async_client):
+    payload = {"title": "X", "task_spec": {"plan": "not a list"}}
+    r = await async_client.post("/tasks", headers={"X-API-Key": "test-key"}, json=payload)
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_returns_429(async_client, monkeypatch):
+    async def fake_schedule_run(**kwargs):
+        return uuid.uuid4()
+
+    monkeypatch.setattr(
+        "api.fastapi_app.routes.tasks.schedule_run", fake_schedule_run
+    )
+
+    payload = {"title": "R", "task_spec": {"type": "demo"}}
+    headers = {"X-API-Key": "test-key"}
+    for _ in range(3):
+        res = await async_client.post("/tasks", headers=headers, json=payload)
+        assert res.status_code == 202
+    r = await async_client.post("/tasks", headers=headers, json=payload)
+    assert r.status_code == 429


### PR DESCRIPTION
## Résumé
- validation stricte de `task_spec` et des options via Pydantic
- limite de débit en mémoire par IP et clé API pour `/tasks`
- tests couvrant 400 sur `task_spec` invalide et 429 après dépassement

## Tests
- `pytest tests_api -q`
- `pytest api/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8922ac9548327a550e876045664b2