### PR TITLE
feat(config): add role-based LLM matrix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,31 @@
 # CONFIGURATION LLM - CREW IA
 # ==============================
 
+# === Presets commentés ===
+# --- DEV : Ollama only ---
+# LLM_DEFAULT_PROVIDER=ollama
+# LLM_DEFAULT_MODEL=llama3.1:8b
+# SUPERVISOR_PROVIDER=ollama
+# SUPERVISOR_MODEL=llama3.1:8b
+# MANAGER_PROVIDER=ollama
+# MANAGER_MODEL=llama3.1:8b
+# EXECUTOR_PROVIDER=ollama
+# EXECUTOR_MODEL=llama3.1:8b
+# RECRUITER_PROVIDER=ollama
+# RECRUITER_MODEL=llama3.1:8b
+#
+# --- PROD : OpenAI only ---
+# LLM_DEFAULT_PROVIDER=openai
+# LLM_DEFAULT_MODEL=gpt-4o-mini
+# SUPERVISOR_PROVIDER=openai
+# SUPERVISOR_MODEL=gpt-4o-mini
+# MANAGER_PROVIDER=openai
+# MANAGER_MODEL=gpt-4o-mini
+# EXECUTOR_PROVIDER=openai
+# EXECUTOR_MODEL=gpt-4o-mini
+# RECRUITER_PROVIDER=openai
+# RECRUITER_MODEL=gpt-4o-mini
+
 LOG_LEVEL=DEBUG
 LOG_TO_STDOUT=1
 
@@ -14,8 +39,8 @@ LLM_FALLBACK_ORDER=ollama,openai
 
 # Paramètres communs aux LLM
 LLM_TIMEOUT_S=60
-LLM_TEMPERATURE=0.2
-LLM_MAX_TOKENS=1500
+LLM_DEFAULT_TEMPERATURE=0.2
+LLM_DEFAULT_MAX_TOKENS=1500
 
 # ==============================
 # CONFIGURATION OLLAMA

--- a/core/agents/recruiter.py
+++ b/core/agents/recruiter.py
@@ -1,12 +1,40 @@
 from .registry import AgentSpec
+from core.config import get_role_config
 
-def recruit(role:str) -> AgentSpec:
+
+def recruit(role: str) -> AgentSpec:
     r = role.strip()
+    exe_cfg = get_role_config("EXECUTOR")
     if r.lower().startswith("writer"):
-        return AgentSpec(role,"core/agents/prompts/executors/writer_fr.txt","ollama","llama3.1:8b",[])
+        return AgentSpec(
+            role,
+            "core/agents/prompts/executors/writer_fr.txt",
+            exe_cfg.provider,
+            exe_cfg.model,
+            [],
+        )
     if r.lower().startswith("research"):
-        return AgentSpec(role,"core/agents/prompts/executors/researcher.txt","ollama","llama3.1:8b",[])
+        return AgentSpec(
+            role,
+            "core/agents/prompts/executors/researcher.txt",
+            exe_cfg.provider,
+            exe_cfg.model,
+            [],
+        )
     if r.lower().startswith("review"):
-        return AgentSpec(role,"core/agents/prompts/executors/reviewer.txt","ollama","llama3.1:8b",[])
+        return AgentSpec(
+            role,
+            "core/agents/prompts/executors/reviewer.txt",
+            exe_cfg.provider,
+            exe_cfg.model,
+            [],
+        )
     # fallback manager
-    return AgentSpec(role,"core/agents/prompts/manager.txt","ollama","llama3.1:8b",[])
+    man_cfg = get_role_config("MANAGER")
+    return AgentSpec(
+        role,
+        "core/agents/prompts/manager.txt",
+        man_cfg.provider,
+        man_cfg.model,
+        [],
+    )

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -1,6 +1,8 @@
-import os
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Dict
+
+from core.config import get_role_config
+
 
 @dataclass
 class AgentSpec:
@@ -10,29 +12,45 @@ class AgentSpec:
     model: str
     tools: list[str]
 
-def _env(name:str, default:str=""):
-    return os.getenv(name, default)
 
-def load_default_registry() -> Dict[str,AgentSpec]:
+def load_default_registry() -> Dict[str, AgentSpec]:
+    sup_cfg = get_role_config("SUPERVISOR")
+    man_cfg = get_role_config("MANAGER")
+    exe_cfg = get_role_config("EXECUTOR")
     return {
-        "Supervisor": AgentSpec("Supervisor","core/agents/prompts/supervisor.txt",
-            _env("SUPERVISOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("SUPERVISOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Manager_Generic": AgentSpec("Manager_Generic","core/agents/prompts/manager.txt",
-            _env("MANAGER_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("MANAGER_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Writer_FR": AgentSpec("Writer_FR","core/agents/prompts/executors/writer_fr.txt",
-            _env("EXECUTOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("EXECUTOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Researcher": AgentSpec("Researcher","core/agents/prompts/executors/researcher.txt",
-            _env("EXECUTOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("EXECUTOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
-        "Reviewer": AgentSpec("Reviewer","core/agents/prompts/executors/reviewer.txt",
-            _env("EXECUTOR_PROVIDER",_env("LLM_DEFAULT_PROVIDER","ollama")),
-            _env("EXECUTOR_MODEL",_env("LLM_DEFAULT_MODEL","llama3.1:8b")),
-            []),
+        "Supervisor": AgentSpec(
+            "Supervisor",
+            "core/agents/prompts/supervisor.txt",
+            sup_cfg.provider,
+            sup_cfg.model,
+            [],
+        ),
+        "Manager_Generic": AgentSpec(
+            "Manager_Generic",
+            "core/agents/prompts/manager.txt",
+            man_cfg.provider,
+            man_cfg.model,
+            [],
+        ),
+        "Writer_FR": AgentSpec(
+            "Writer_FR",
+            "core/agents/prompts/executors/writer_fr.txt",
+            exe_cfg.provider,
+            exe_cfg.model,
+            [],
+        ),
+        "Researcher": AgentSpec(
+            "Researcher",
+            "core/agents/prompts/executors/researcher.txt",
+            exe_cfg.provider,
+            exe_cfg.model,
+            [],
+        ),
+        "Reviewer": AgentSpec(
+            "Reviewer",
+            "core/agents/prompts/executors/reviewer.txt",
+            exe_cfg.provider,
+            exe_cfg.model,
+            [],
+        ),
     }


### PR DESCRIPTION
## Summary
- centralize LLM settings with role-based config loader
- expose get_role_config with provider/model/temperature/tokens
- document env presets and defaults for each role

## Testing
- `pytest -k "registry_recruiter or agent_routing" -q`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a89dee194c83279f6e07233870f2f8