### PR TITLE
feat: add strict agent schemas

### DIFF
--- a/core/agents/schemas.py
+++ b/core/agents/schemas.py
@@ -1,59 +1,112 @@
-from pydantic import BaseModel, Field, ValidationError, model_validator
-from typing import List, Optional, Literal, Dict, Any, Set
+from typing import List, Literal
+from collections import Counter
 
-NodeType = Literal["manage","execute"]
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-class PlanNodeModel(BaseModel):
+
+NodeType = Literal["task", "manage", "synthesis"]
+
+
+class PlanNode(BaseModel):
+    """Noeud du plan supervisé."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
     id: str
     title: str
     type: NodeType
     suggested_agent_role: str
-    acceptance: List[str] = Field(default_factory=list)
     deps: List[str] = Field(default_factory=list)
+    acceptance: List[str] = Field(default_factory=list)
     risks: List[str] = Field(default_factory=list)
     assumptions: List[str] = Field(default_factory=list)
     notes: List[str] = Field(default_factory=list)
 
+    @model_validator(mode="before")
+    @classmethod
+    def map_execute(cls, data: dict):
+        """Convertir l'ancien type 'execute' en 'task' pour compatibilité."""
+        if isinstance(data, dict) and data.get("type") == "execute":
+            data = dict(data)
+            data["type"] = "task"
+        return data
+
+
+# Compatibilité ascendante
+PlanNodeModel = PlanNode
+
+
 class SupervisorPlan(BaseModel):
-    decompose: bool
-    plan: List[PlanNodeModel]
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    decompose: bool = False
+    plan: List[PlanNode]
 
     @model_validator(mode="after")
-    def no_cycles_and_roles(self) -> "SupervisorPlan":
-        ids = {n.id for n in self.plan}
-        # deps must exist
+    def validate_graph(self) -> "SupervisorPlan":
+        all_ids = [n.id for n in self.plan]
+        ids = set(all_ids)
+        if len(ids) != len(all_ids):
+            counts = Counter(all_ids)
+            dup = [node_id for node_id, count in counts.items() if count > 1]
+            raise ValueError(f"Duplicate node id(s) detected: {dup}")
         for n in self.plan:
-            assert all(d in ids for d in n.deps), "Unknown dep in node "+n.id
-            assert n.suggested_agent_role.strip(), "Missing role in node "+n.id
-        # cycle check
-        indeg = {n.id:0 for n in self.plan}
+            missing = set(n.deps) - ids
+            if missing:
+                raise ValueError(f"Unknown dep in node {n.id}: {missing}")
+            if not n.suggested_agent_role.strip():
+                raise ValueError(f"Missing role in node {n.id}")
+        indeg = {n.id: 0 for n in self.plan}
+        outgoing = {n.id: [] for n in self.plan}
         for n in self.plan:
-            for d in n.deps: indeg[n.id]+=1
-        zero = [k for k,v in indeg.items() if v==0]
+            for d in n.deps:
+                indeg[n.id] += 1
+                outgoing[d].append(n.id)
+        zero = [k for k, v in indeg.items() if v == 0]
         visited = 0
-        nodes_by_id = {n.id:n for n in self.plan}
         while zero:
             u = zero.pop()
             visited += 1
-            for v in (x.id for x in self.plan if u in x.deps):
-                indeg[v]-=1
-                if indeg[v]==0: zero.append(v)
-        assert visited==len(self.plan), "Cycle detected"
+            for v in outgoing[u]:
+                indeg[v] -= 1
+                if indeg[v] == 0:
+                    zero.append(v)
+        if visited != len(self.plan):
+            raise ValueError("Cycle detected")
         return self
 
+
 class ManagerAssignment(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, populate_by_name=True)
+
     node_id: str
-    agent: str
+    agent_role: str = Field(alias="agent")
     tooling: List[str] = Field(default_factory=list)
 
+
 class ManagerOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
     assignments: List[ManagerAssignment]
-    quality_checks: List[str]
+    quality_checks: List[str] = Field(min_length=1)
     integration_notes: str = ""
 
-# Utilitaires d’analyse/parse strict JSON
+
+class AgentSpec(BaseModel):
+    """Spécification d'un agent disponible pour l'exécution."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    role: str
+    system_prompt: str
+    provider: str
+    model: str
+    tools: List[str] = Field(default_factory=list)
+
+
 def parse_supervisor_json(data: str) -> SupervisorPlan:
     return SupervisorPlan.model_validate_json(data)
+
 
 def parse_manager_json(data: str) -> ManagerOutput:
     return ManagerOutput.model_validate_json(data)

--- a/tests/test_supervisor_json.py
+++ b/tests/test_supervisor_json.py
@@ -1,12 +1,121 @@
+import json
+
 import pytest
 from pydantic import ValidationError
-from core.agents.schemas import parse_supervisor_json, SupervisorPlan
+
+from core.agents.schemas import (
+    SupervisorPlan,
+    parse_manager_json,
+    parse_supervisor_json,
+)
+
 
 def test_supervisor_json_valid():
-    data = '{"decompose": true, "plan": []}'
-    plan = parse_supervisor_json(data)
+    data = {
+        "plan": [
+            {
+                "id": "a",
+                "title": "A",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+            },
+            {
+                "id": "b",
+                "title": "B",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+                "deps": ["a"],
+            },
+        ]
+    }
+    plan = parse_supervisor_json(json.dumps(data))
     assert isinstance(plan, SupervisorPlan)
+    assert len(plan.plan) == 2
 
-def test_supervisor_json_invalid():
+
+def test_supervisor_json_unknown_dep():
+    data = {
+        "plan": [
+            {
+                "id": "a",
+                "title": "A",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+            },
+            {
+                "id": "b",
+                "title": "B",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+                "deps": ["c"],
+            },
+        ]
+    }
     with pytest.raises(ValidationError):
-        parse_supervisor_json('{"bad":1}')
+        parse_supervisor_json(json.dumps(data))
+
+
+def test_supervisor_json_cycle():
+    data = {
+        "plan": [
+            {
+                "id": "a",
+                "title": "A",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+                "deps": ["b"],
+            },
+            {
+                "id": "b",
+                "title": "B",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+                "deps": ["a"],
+            },
+        ]
+    }
+    with pytest.raises(ValidationError):
+        parse_supervisor_json(json.dumps(data))
+
+
+def test_supervisor_json_duplicate_ids():
+    data = {
+        "plan": [
+            {
+                "id": "a",
+                "title": "A",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+            },
+            {
+                "id": "a",
+                "title": "A2",
+                "type": "task",
+                "suggested_agent_role": "Writer",
+            },
+        ]
+    }
+    with pytest.raises(ValidationError):
+        parse_supervisor_json(json.dumps(data))
+
+
+def test_supervisor_json_backward_compat():
+    plan_data = {
+        "plan": [
+            {
+                "id": "a",
+                "title": "A",
+                "type": "execute",
+                "suggested_agent_role": "Writer",
+            }
+        ]
+    }
+    plan = parse_supervisor_json(json.dumps(plan_data))
+    assert plan.plan[0].type == "task"
+
+    manager_data = {
+        "assignments": [{"node_id": "a", "agent": "X"}],
+        "quality_checks": ["qc"],
+    }
+    out = parse_manager_json(json.dumps(manager_data))
+    assert out.assignments[0].agent_role == "X"


### PR DESCRIPTION
## Summary
- implement new strict Pydantic schemas for plan nodes, supervisor plans and manager outputs
- validate dependency graph without cycles and ensure plan node ids are unique
- add backward-compat tests and document agent specification model

## Testing
- `pytest -k supervisor_json -q`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a89dfac4948327a78193b987a726cd