### PR TITLE
Ajout re-prompt du superviseur et retour graphe

### DIFF
--- a/core/agents/prompts/supervisor.txt
+++ b/core/agents/prompts/supervisor.txt
@@ -1,14 +1,14 @@
 Vous êtes le Superviseur. Objectif: produire un plan JSON strict pour exécuter la tâche.
 Contraintes:
-- Répondez UNIQUEMENT en JSON valide conforme au schéma suivant:
+- Répondez UNIQUEMENT en JSON valide conforme au schéma suivant (aucun texte hors JSON):
 {
   "decompose": true|false,
   "plan": [
     {
       "id": "string",
       "title": "string",
-      "type": "manage"|"execute",
-      "suggested_agent_role": "Writer_FR|Researcher|Reviewer|Manager_[domaine]|... ",
+      "type": "task"|"manage"|"synthesis",
+      "suggested_agent_role": "Writer_FR|Researcher|Reviewer|Manager_[domaine]|...",
       "acceptance": ["critère 1", "..."],
       "deps": ["id_node"],
       "risks": ["..."],
@@ -17,5 +17,5 @@ Contraintes:
     }
   ]
 }
-- Pas de texte avant/après le JSON.
+- "execute" est accepté pour compatibilité et sera converti en "task".
 - Le plan doit être acyclique et chaque nœud avoir 'suggested_agent_role'.

--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -54,3 +54,11 @@ def load_default_registry() -> Dict[str, AgentSpec]:
             [],
         ),
     }
+
+
+def resolve_agent(role: str) -> AgentSpec:
+    """Résout un agent par rôle à partir du registre par défaut."""
+    registry = load_default_registry()
+    if role in registry:
+        return registry[role]
+    raise KeyError(role)

--- a/core/agents/supervisor.py
+++ b/core/agents/supervisor.py
@@ -1,32 +1,59 @@
 from __future__ import annotations
-from pathlib import Path
+
 import json
+from pathlib import Path
 from typing import Any, Dict
 
 from pydantic import ValidationError
 
-from .registry import load_default_registry
+from .registry import resolve_agent, AgentSpec
 from .recruiter import recruit
 from .schemas import SupervisorPlan, parse_supervisor_json
 from core.llm.providers.base import LLMRequest
 from core.llm import runner as llm_runner
 
+
 async def run(task: Dict[str, Any], storage: Any = None) -> SupervisorPlan:
-    """
-    Execute the Supervisor role once and return a validated SupervisorPlan.
-    """
-    registry = load_default_registry()
-    spec = registry.get("Supervisor") or recruit("Supervisor")
-
-    root = Path(__file__).resolve().parents[2]
-    system_prompt = (root / spec.system_prompt_path).read_text(encoding="utf-8")
-
-    user_msg = json.dumps(task, ensure_ascii=False)
-    req = LLMRequest(system=system_prompt, prompt=user_msg, model=spec.model, provider=spec.provider)
-    resp = await llm_runner.run_llm(req)
+    """Exécute le rôle Supervisor et renvoie un plan validé."""
 
     try:
-        plan = parse_supervisor_json(resp.text)
-    except ValidationError as ve:
-        raise ve
-    return plan
+        spec: AgentSpec = resolve_agent("Supervisor")
+    except KeyError:
+        spec = recruit("Supervisor")
+
+    if getattr(spec, "system_prompt", None):
+        system_prompt = spec.system_prompt
+    elif getattr(spec, "system_prompt_path", None):
+        sp = Path(spec.system_prompt_path)
+        if not sp.is_absolute():
+            repo_root = Path(__file__).resolve().parents[2]
+            sp = repo_root / sp
+        system_prompt = sp.read_text(encoding="utf-8")
+    else:
+        raise ValueError("Prompt système du Supervisor introuvable")
+
+    task_json = json.dumps(task, ensure_ascii=False)
+    user_msg = task_json
+    last_err: ValidationError | None = None
+
+    for _ in range(3):
+        req = LLMRequest(
+            system=system_prompt,
+            prompt=user_msg,
+            model=spec.model,
+            provider=spec.provider,
+        )
+        resp = await llm_runner.run_llm(req)
+        try:
+            return parse_supervisor_json(resp.text)
+        except ValidationError as ve:
+            last_err = ve
+            user_msg = (
+                task_json
+                + "\nLa réponse précédente n'était pas un JSON valide. "
+                + "Réponds uniquement avec un JSON valide conforme au schéma."
+            )
+
+    if last_err:
+        raise last_err
+    raise RuntimeError("Unexpected supervisor failure")

--- a/core/planning/planner.py
+++ b/core/planning/planner.py
@@ -1,30 +1,17 @@
 from pathlib import Path
-from typing import List
 import json
 
 from core.agents.supervisor import run
-from core.agents.schemas import PlanNodeModel
-from core.planning.task_graph import PlanNode
+from core.planning.task_graph import TaskGraph
 
-async def plan_from_task(task_input: str, run_dir: str = ".") -> List[PlanNode]:
+
+async def plan_from_task(task_input: str, run_dir: str = ".") -> TaskGraph:
     sup = await run(json.loads(task_input))
-    nodes: List[PlanNode] = []
-    for n in sup.plan:
-        nodes.append(
-            PlanNode(
-                id=n.id,
-                title=n.title,
-                type=n.type,
-                suggested_agent_role=n.suggested_agent_role,
-                acceptance=n.acceptance,
-                deps=n.deps,
-                risks=n.risks,
-                assumptions=n.assumptions,
-                notes=n.notes,
-            )
-        )
+
     Path(run_dir).mkdir(parents=True, exist_ok=True)
     Path(run_dir, "plan.json").write_text(
         sup.model_dump_json(indent=2, ensure_ascii=False), encoding="utf-8"
     )
-    return nodes
+
+    graph = TaskGraph.from_plan(sup.model_dump())
+    return graph

--- a/tests/test_supervisor_json.py
+++ b/tests/test_supervisor_json.py
@@ -8,6 +8,9 @@ from core.agents.schemas import (
     parse_manager_json,
     parse_supervisor_json,
 )
+from core.agents.supervisor import run as supervisor_run
+import core.agents.supervisor as supervisor_mod
+from core.llm.providers.base import LLMResponse
 
 
 def test_supervisor_json_valid():
@@ -119,3 +122,31 @@ def test_supervisor_json_backward_compat():
     }
     out = parse_manager_json(json.dumps(manager_data))
     assert out.assignments[0].agent_role == "X"
+
+
+@pytest.mark.asyncio
+async def test_supervisor_reprompt(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return LLMResponse(text="oops")
+        valid = {
+            "plan": [
+                {
+                    "id": "a",
+                    "title": "A",
+                    "type": "task",
+                    "suggested_agent_role": "Writer_FR",
+                }
+            ]
+        }
+        return LLMResponse(text=json.dumps(valid))
+
+    monkeypatch.setattr(supervisor_mod.llm_runner, "run_llm", fake_run_llm)
+
+    sup = await supervisor_run({"title": "demo"})
+    assert calls["n"] == 2
+    assert isinstance(sup, SupervisorPlan)
+    assert sup.plan[0].id == "a"


### PR DESCRIPTION
## Résumé
- Résolution de l'agent Supervisor via `resolve_agent` avec repli sur `recruit`
- Ajout de la fonction utilitaire `resolve_agent` dans le registre des agents

## Tests
- `pytest -k supervisor_json -q`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a53a79c8832788963757e1d42599