### PR TITLE
feat: routing exécutants et sidecar LLM complet

### DIFF
--- a/apps/orchestrator/executor.py
+++ b/apps/orchestrator/executor.py
@@ -138,7 +138,7 @@ def _norm_dep_ids(node) -> list[str]:
 def _extract_llm_meta_from_result(artifact: Any) -> Dict[str, Any]:
     """
     Rend un dict normalisé pour le sidecar:
-      {provider, model, latency_ms, usage, prompts?}
+      {provider, model_used, latency_ms, usage, prompts?}
     On est tolérant: artifact peut être dict imbriqué, etc.
     """
     if not isinstance(artifact, dict):
@@ -163,7 +163,7 @@ def _extract_llm_meta_from_result(artifact: Any) -> Dict[str, Any]:
         if prov or model or lat or usage or prompts:
             out = {
                 "provider": prov,
-                "model": model,
+                "model_used": model,
                 "latency_ms": lat,
                 "usage": usage,
             }
@@ -332,7 +332,7 @@ async def _execute_node(
         node_key,
         role,
         sidecar.get("provider") if sidecar else None,
-        sidecar.get("model") if sidecar else None,
+        (sidecar.get("model") or sidecar.get("model_used")) if sidecar else None,
         sidecar.get("latency_ms") if sidecar else None,
     )
 

--- a/core/agents/executor_llm.py
+++ b/core/agents/executor_llm.py
@@ -44,7 +44,7 @@ async def agent_runner(node: PlanNodeModel, storage: CompositeAdapter | None = N
 
     meta = {
         "provider": getattr(resp, "provider", None),
-        "model": getattr(resp, "model_used", getattr(resp, "model", None)),
+        "model_used": getattr(resp, "model_used", getattr(resp, "model", None)),
         "latency_ms": getattr(resp, "latency_ms", getattr(resp, "duration_ms", None)),
         "usage": getattr(resp, "usage", None),
         "prompts": {

--- a/tests/e2e/test_mini_flow.py
+++ b/tests/e2e/test_mini_flow.py
@@ -43,7 +43,7 @@ async def test_mini_flow(tmp_path, monkeypatch):
     for nid in ["R1","R2","W1"]:
         assert Path(f"artifact_{nid}.md").exists()
         side = json.loads(Path(f"artifact_{nid}.llm.json").read_text())
-        assert side["provider"] == "p" and side["model"] == "m"
+        assert side["provider"] == "p" and side["model_used"] == "m"
 
     await run_graph(dag, DummyStorage(), "run1")
     summary = json.loads(Path(".runs/run1/summary.json").read_text())


### PR DESCRIPTION
## Summary
- normaliser l'extraction des métadonnées LLM et journaliser le modèle utilisé
- exposer `model_used` dans les sidecars produits par le runner
- couvrir le routage des rôles Writer_FR, Researcher et Reviewer par des tests dédiés

## Testing
- `pytest -k agent_routing -q`
- `pytest -q`
- `pre-commit run --files apps/orchestrator/executor.py core/agents/executor_llm.py tests/test_agent_routing.py tests/e2e/test_mini_flow.py` *(échoué: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a96e7f6bc88327a404f229399c0c02