### PR TITLE
tests: re-prompt et échec JSON manager/supervisor

### DIFF
--- a/tests/test_manager_assignments.py
+++ b/tests/test_manager_assignments.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from core.agents.manager import run_manager
 from core.agents.schemas import PlanNodeModel
@@ -20,3 +21,37 @@ async def test_manager_assignments(monkeypatch):
     for a in out.assignments:
         assert a.node_id in ids
     assert out.quality_checks
+
+
+@pytest.mark.asyncio
+async def test_manager_assignments_reprompt(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return LLMResponse(text="oops")
+        text = '{"assignments":[{"node_id":"a","agent":"Writer_FR","tooling":[]}],"quality_checks":["qc"]}'
+        return LLMResponse(text=text)
+
+    monkeypatch.setattr(manager_mod, "run_llm", fake_run_llm)
+    nodes = [PlanNodeModel(id="a", title="A", type="execute", suggested_agent_role="Writer_FR")]
+    out = await run_manager(nodes)
+    assert calls["n"] == 2
+    assert out.assignments[0].node_id == "a"
+
+
+@pytest.mark.asyncio
+async def test_manager_assignments_fallback(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        calls["n"] += 1
+        return LLMResponse(text="oops")
+
+    monkeypatch.setattr(manager_mod, "run_llm", fake_run_llm)
+    nodes = [PlanNodeModel(id="a", title="A", type="execute", suggested_agent_role="Writer_FR")]
+
+    with pytest.raises(ValidationError):
+        await run_manager(nodes)
+    assert calls["n"] == 3

--- a/tests/test_supervisor_json.py
+++ b/tests/test_supervisor_json.py
@@ -150,3 +150,18 @@ async def test_supervisor_reprompt(monkeypatch):
     assert calls["n"] == 2
     assert isinstance(sup, SupervisorPlan)
     assert sup.plan[0].id == "a"
+
+
+@pytest.mark.asyncio
+async def test_supervisor_reprompt_fail(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        calls["n"] += 1
+        return LLMResponse(text="oops")
+
+    monkeypatch.setattr(supervisor_mod.llm_runner, "run_llm", fake_run_llm)
+
+    with pytest.raises(ValidationError):
+        await supervisor_run({"title": "demo"})
+    assert calls["n"] == 3


### PR DESCRIPTION
## Résumé
- ajoute un test d'échec après plusieurs réponses invalides pour le supervisor
- couvre les scénarios de re-prompt et d'échec du manager

## Tests
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9778790048327bf78bd14c8e4ed29