### PR TITLE
feat: add observability toggles and deps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,18 @@ RECRUITER_MAX_TOKENS=1000
 LOG_LEVEL=INFO        # DEBUG pour plus de détails
 LOG_TO_STDOUT=1       # 1 = logs aussi en console, 0 = fichier uniquement
 
+# Active les métriques Prometheus (0 désactivé, 1 activé)
+METRICS_ENABLED=0
+
+# DSN Sentry
+SENTRY_DSN=
+
+# Environnement Sentry
+SENTRY_ENV=dev
+
+# Version de release pour Sentry
+RELEASE=crew_ia@0.1.0
+
 # === PostgreSQL & Alembic ===
 POSTGRES_USER=crew
 POSTGRES_PASSWORD=crew

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ httpx
 asgi-lifespan
 pytest
 pytest-asyncio
+
+# Observabilité
+prometheus-client==0.22.1
+sentry-sdk==2.35.0


### PR DESCRIPTION
## Summary
- add toggles for Prometheus metrics and Sentry in env sample
- add Prometheus and Sentry packages with pinned versions

## Testing
- `pre-commit run --files requirements.txt .env.example`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a9853ef94c832786f95e1228dcb204