### PR TITLE
feat(api): instrumenter les requêtes HTTP

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI, Depends
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from contextlib import asynccontextmanager
@@ -17,6 +17,8 @@ load_dotenv()
 from .deps import settings, api_key_auth
 from .routes import health, runs, nodes, artifacts, events, tasks
 from .middleware import RequestIDMiddleware
+from .middleware.metrics import MetricsMiddleware
+from core.telemetry.metrics import metrics_enabled, generate_latest
 from core.storage.postgres_adapter import PostgresAdapter
 from core.storage.file_adapter import FileAdapter
 from core.storage.composite_adapter import CompositeAdapter
@@ -70,7 +72,17 @@ app = FastAPI(
 
 # -------- Middlewares --------
 app.add_middleware(RequestIDMiddleware)                # X-Request-ID propagation
+app.add_middleware(MetricsMiddleware)                  # Prometheus metrics
 app.add_middleware(GZipMiddleware, minimum_size=1024) # gzip
+
+if metrics_enabled():
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics():
+        payload = generate_latest()
+        return Response(
+            content=payload,
+            media_type="text/plain; version=0.0.4; charset=utf-8",
+        )
 
 # CORS (une seule source de vérité : settings.cors_origins)
 app.add_middleware(

--- a/api/fastapi_app/middleware/metrics.py
+++ b/api/fastapi_app/middleware/metrics.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.telemetry.metrics import (
+    metrics_enabled,
+    get_http_requests_total,
+    get_http_request_duration_seconds,
+)
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: Any):  # type: ignore[override]
+        if not metrics_enabled():
+            return await call_next(request)
+
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+
+        route_path = "/unknown"
+        route = request.scope.get("route")
+        if route is not None:
+            route_path = getattr(route, "path", None) or getattr(route, "path_format", "/unknown")
+        method = request.method
+        status = str(response.status_code)
+
+        counter_labels = (route_path, method, status)
+        hist_labels = (route_path, method)
+
+        get_http_requests_total().labels(*counter_labels).inc()
+        get_http_request_duration_seconds().labels(*hist_labels).observe(duration)
+
+        return response


### PR DESCRIPTION
## Résumé
- utilise la registry centrale via `core.telemetry.metrics` pour `MetricsMiddleware`
- expose `/metrics` via une route FastAPI quand les métriques sont activées

## Tests
- `pre-commit run --files api/fastapi_app/middleware/metrics.py api/fastapi_app/app.py`
- `pytest -q` *(échoue : ModuleNotFoundError: core.telemetry.metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68a986cee9b08327ad3ccf14135b05d6