### PR TITLE
Ajoute cible metrics et doc observabilité

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,11 +179,16 @@ env-check: ensure-venv
 # ---- API (FastAPI) -------------------------------------------
 .PHONY: api-run
 api-run: ensure-venv
-	@$(ACTIVATE) && uvicorn $(API_MODULE) --reload --host $(API_HOST) --port $(API_PORT) --env-file $(ENV_FILE)
+        @$(ACTIVATE) && uvicorn $(API_MODULE) --reload --host $(API_HOST) --port $(API_PORT) --env-file $(ENV_FILE)
+
+.PHONY: api-run-metrics
+api-run-metrics: ensure-venv
+	@export METRICS_ENABLED=1; \
+	$(ACTIVATE) && uvicorn $(API_MODULE) --reload --port $(API_PORT)
 
 .PHONY: api-run-prod
 api-run-prod: ensure-venv
-	@$(ACTIVATE) && uvicorn $(API_MODULE) --host 0.0.0.0 --port $(API_PORT) --workers 2
+        @$(ACTIVATE) && uvicorn $(API_MODULE) --host 0.0.0.0 --port $(API_PORT) --workers 2
 
 .PHONY: api-test
 api-test: ensure-venv

--- a/README.md
+++ b/README.md
@@ -114,3 +114,24 @@ make db-upgrade
 - `make api-test` – run API tests.
 - `make db-revision msg="..."` – create a new Alembic revision.
 - `make db-upgrade` – apply migrations to the database.
+
+## Observabilité
+
+### Metrics Prometheus
+
+- Activer avec la variable `METRICS_ENABLED=1` (ex : `make api-run-metrics`).
+- Les métriques sont exposées sur `/metrics`.
+- Exemple minimal de configuration pour Prometheus :
+
+```yaml
+scrape_configs:
+  - job_name: 'crew_ia_api'
+    static_configs:
+      - targets: ['localhost:8000']
+    metrics_path: /metrics
+```
+
+### Sentry
+
+- Variables requises : `SENTRY_DSN`, `SENTRY_ENV`, `RELEASE`.
+- Test rapide : appeler une route qui lève une exception, l'événement apparaît dans Sentry (mock possible côté tests).


### PR DESCRIPTION
## Résumé
- Ajout d'une cible `api-run-metrics` pour lancer l'API avec l'exposition Prometheus.
- Documentation d'activation des métriques et de l'intégration Sentry.

## Tests
- `make test` (échecs : tests d'authentification)


------
https://chatgpt.com/codex/tasks/task_e_68a98e7d2d708327837cce6c19b18c1e