### PR TITLE
chore: mise à jour des dépendances via make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ help:
 	@echo "  install             -> crée venv + installe deps"
 	@echo "  venv                -> (re)crée le venv"
 	@echo "  clean-venv          -> supprime le venv"
+	@echo "  deps-update        -> met à jour les dépendances"
 	@echo "  test                -> pytest (rapide)"
 	@echo "  test-extra          -> pytest tests_extra (si présents)"
 	@echo "  test-all            -> pytest tests + tests_extra (si présents)"
@@ -81,6 +82,10 @@ install: init-env venv
 clean-venv:
 	@rm -rf $(VENV_DIR)
 	@echo "🧹 Venv supprimé"
+.PHONY: deps-update
+deps-update: ensure-venv
+	@$(ACTIVATE) && $(PIP) install -r $(REQ_FILE)
+	@echo "✅ Dépendances mises à jour"
 
 # ---- Qualité -------------------------------------------------
 .PHONY: fmt

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ make api-run
 curl -H "X-API-Key: test-key" http://localhost:8000/runs
 ```
 
+> **Note :** Après un `git pull`, lancez `make deps-update` pour installer les nouvelles dépendances.
+
 Pour lister les événements d'un run spécifique :
 
 ```


### PR DESCRIPTION
## Résumé
- ajoute une cible `deps-update` dans le Makefile pour réinstaller les dépendances
- documente la nécessité d'exécuter `make deps-update` après un `git pull`

## Tests
- `make deps-update`
- `make test` *(échoue: tests d'authentification `401`)*

------
https://chatgpt.com/codex/tasks/task_e_68a98f15e3248327b085824edfdbc82f