### PR TITLE
protège toutes les routes par clé API

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -115,11 +115,11 @@ app.add_middleware(
 
 # -------- Routes --------
 app.include_router(health.router)
-app.include_router(runs.router)
-app.include_router(nodes.router)
-app.include_router(artifacts.router_nodes)
-app.include_router(artifacts.router_artifacts)
-app.include_router(events.router)
+app.include_router(runs.router, dependencies=[Depends(api_key_auth)])
+app.include_router(nodes.router, dependencies=[Depends(api_key_auth)])
+app.include_router(artifacts.router_nodes, dependencies=[Depends(api_key_auth)])
+app.include_router(artifacts.router_artifacts, dependencies=[Depends(api_key_auth)])
+app.include_router(events.router, dependencies=[Depends(api_key_auth)])
 app.include_router(tasks.router, dependencies=[Depends(api_key_auth)])
 
 # Exposition des métriques Prometheus (optionnelle)


### PR DESCRIPTION
## Résumé
- applique l'authentification par clé API à tous les routers de l'API, sauf /health

## Tests
- `pre-commit run --files api/fastapi_app/app.py`
- `pytest` *(échoue : certaines routes renvoient encore 200/202 au lieu de 401)*

------
https://chatgpt.com/codex/tasks/task_e_68a991c53ce083278ff1d9ab431b1c03