### PR TITLE
Renforce l’authentification par clé API

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -31,7 +31,7 @@ if SENTRY_DSN:
                 sentry_sdk.set_tag("request_id", rid)
             return await call_next(request)
 
-from .deps import settings, api_key_auth
+from .deps import settings, strict_api_key_auth
 from .routes import health, runs, nodes, artifacts, events, tasks
 from .middleware import RequestIDMiddleware
 from .middleware.metrics import MetricsMiddleware
@@ -115,12 +115,12 @@ app.add_middleware(
 
 # -------- Routes --------
 app.include_router(health.router)
-app.include_router(runs.router, dependencies=[Depends(api_key_auth)])
-app.include_router(nodes.router, dependencies=[Depends(api_key_auth)])
-app.include_router(artifacts.router_nodes, dependencies=[Depends(api_key_auth)])
-app.include_router(artifacts.router_artifacts, dependencies=[Depends(api_key_auth)])
-app.include_router(events.router, dependencies=[Depends(api_key_auth)])
-app.include_router(tasks.router, dependencies=[Depends(api_key_auth)])
+app.include_router(runs.router, dependencies=[Depends(strict_api_key_auth)])
+app.include_router(nodes.router, dependencies=[Depends(strict_api_key_auth)])
+app.include_router(artifacts.router_nodes, dependencies=[Depends(strict_api_key_auth)])
+app.include_router(artifacts.router_artifacts, dependencies=[Depends(strict_api_key_auth)])
+app.include_router(events.router, dependencies=[Depends(strict_api_key_auth)])
+app.include_router(tasks.router, dependencies=[Depends(strict_api_key_auth)])
 
 # Exposition des métriques Prometheus (optionnelle)
 if metrics_enabled():

--- a/api/fastapi_app/routes/tasks.py
+++ b/api/fastapi_app/routes/tasks.py
@@ -9,14 +9,14 @@ from uuid import UUID
 import os
 import time
 
-from ..deps import api_key_auth
+from ..deps import strict_api_key_auth
 from ..schemas import TaskRequest, TaskAcceptedResponse
 from core.services.orchestrator_service import schedule_run
 
 router = APIRouter(
     prefix="/tasks",
     tags=["tasks"],
-    dependencies=[Depends(api_key_auth)],  # 🔒 vérifie la valeur de la clé
+    dependencies=[Depends(strict_api_key_auth)],  # 🔒 vérifie la valeur de la clé
 )
 
 # ---------- Rate limit config ----------
@@ -45,6 +45,7 @@ async def create_task(
     payload: Dict[str, Any],
     request: Request,
     x_request_id: str | None = Header(default=None, alias="X-Request-ID"),
+    _auth: bool = Depends(strict_api_key_auth),
 ):
     """Lance l'orchestrateur en arrière-plan, répond 202 + run_id."""
 


### PR DESCRIPTION
## Résumé
- ajoute `strict_api_key_auth` qui respecte la désactivation explicite de l’auth
- protège toutes les routes (`runs`, `tasks`, etc.) avec cette vérification stricte

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a99395036c832796f37665a83372b9