### PR TITLE
ci: ajout du job validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run pytest
+        run: make test
+
+  alembic-heads:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Check Alembic heads
+        run: |
+          alembic heads
+          test $(alembic heads | wc -l) -eq 1
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: [tests, alembic-heads]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: validate strict (non blocking)
+        run: make validate-strict
+        continue-on-error: true
+      - name: validate
+        run: make validate


### PR DESCRIPTION
## Résumé
- ajoute un workflow CI avec un job `validate` exécutant `make validate`
- vérifie les migrations avec `alembic heads` et lance les tests avant la validation
- inclut un appel informatif non bloquant à `make validate-strict`

## Tests
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9a2fb21c08327a56b9cfb7df9fdb9