### PR TITLE
feat: normalisation centralisée des sidecars LLM

### DIFF
--- a/api/tests/test_tasks_meta_e2e.py
+++ b/api/tests/test_tasks_meta_e2e.py
@@ -54,5 +54,5 @@ async def test_events_include_llm_metadata(async_client, monkeypatch, tmp_path):
     assert meta.get("provider") == "openai"
     assert meta.get("model") == "gpt4"
     assert meta.get("latency_ms") == 123
-    assert meta.get("usage") == {"prompt_tokens": 1}
+    assert meta.get("usage") == {"prompt_tokens": 1, "completion_tokens": 0}
     assert meta.get("request_id") == "req-456"

--- a/apps/orchestrator/api_runner.py
+++ b/apps/orchestrator/api_runner.py
@@ -17,6 +17,7 @@ from core.telemetry.metrics import (
     get_runs_total,
     get_run_duration_seconds,
 )
+from apps.orchestrator.sidecars import normalize_llm_sidecar as _normalize_llm_sidecar
 
 import json
 from pathlib import Path
@@ -65,30 +66,6 @@ def _extract_llm_meta_from_artifacts(artifacts: list[dict]) -> dict:
                 out["prompts"] = obj.get("prompts")
             return out
     return {}
-
-
-def _normalize_llm_sidecar(data: dict) -> dict:
-    """Normalise un sidecar LLM sans modifier l'original.
-
-    - si ``model`` est absent mais ``model_used`` présent, copie la valeur
-      vers ``model`` ;
-    - si ``model_used`` est absent mais ``model`` présent, copie la valeur
-      vers ``model_used`` ;
-    - n'altère pas les autres champs ;
-    - idempotent : appeler plusieurs fois ne change pas le résultat.
-    """
-
-    out = dict(data or {})
-    model = out.get("model")
-    model_used = out.get("model_used")
-
-    if not model and model_used:
-        out["model"] = model_used
-    if not model_used and model:
-        out["model_used"] = model
-
-    return out
-
 
 def _read_llm_sidecar_fs(run_id: str, node_key: str, runs_root: str = None) -> dict:
     base = runs_root or os.getenv("ARTIFACTS_DIR") or os.getenv("RUNS_ROOT") or ".runs"

--- a/apps/orchestrator/sidecars.py
+++ b/apps/orchestrator/sidecars.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+"""Utilitaires de normalisation des sidecars LLM."""
+
+from typing import Any, Dict, List
+import uuid
+import datetime as dt
+
+PROMPT_TRUNC = 800
+
+
+def _truncate_prompt(val: Any) -> Any:
+    """Tronque récursivement les contenus de prompt à 800 caractères."""
+    if isinstance(val, str):
+        return val[:PROMPT_TRUNC]
+    if isinstance(val, list):
+        out: List[Any] = []
+        for item in val:
+            if isinstance(item, dict):
+                content = item.get("content")
+                if isinstance(content, str):
+                    item = {**item, "content": content[:PROMPT_TRUNC]}
+            elif isinstance(item, str):
+                item = item[:PROMPT_TRUNC]
+            out.append(item)
+        return out
+    if isinstance(val, dict):
+        return {k: _truncate_prompt(v) for k, v in val.items()}
+    return val
+
+
+def _to_uuid(v: Any) -> str | None:
+    try:
+        u = uuid.UUID(str(v))
+        if u.version == 4:
+            return str(u)
+    except Exception:
+        return None
+    return None
+
+
+def _rfc3339(ts: Any) -> str:
+    if isinstance(ts, dt.datetime):
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.timezone.utc)
+        return ts.isoformat()
+    if isinstance(ts, str):
+        try:
+            parsed = dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.timezone.utc)
+            return parsed.isoformat()
+        except Exception:
+            pass
+    now = dt.datetime.now(dt.timezone.utc)
+    return now.isoformat()
+
+
+def normalize_llm_sidecar(data: Dict[str, Any] | None, *, run_id: str | None = None, node_id: str | None = None) -> Dict[str, Any]:
+    """Normalise un sidecar LLM en respectant la spec v1.0."""
+    out: Dict[str, Any] = dict(data or {})
+
+    # version
+    out["version"] = "1.0"
+
+    # provider (défaut 'other')
+    provider = out.get("provider") or "other"
+    out["provider"] = provider
+
+    # run_id / node_id
+    rid = _to_uuid(run_id or out.get("run_id"))
+    if rid:
+        out["run_id"] = rid
+    nid = _to_uuid(node_id or out.get("node_id"))
+    if nid:
+        out["node_id"] = nid
+
+    # model / model_used harmonisation
+    warnings: List[str] = list(out.get("warnings") or [])
+    model = out.get("model")
+    model_used = out.get("model_used")
+    if model and model_used and model != model_used:
+        warnings.append("model/model_used mismatch (normalized)")
+    final_model = model_used or model
+    if final_model:
+        out["model"] = final_model
+    out.pop("model_used", None)
+
+    if warnings:
+        out["warnings"] = warnings
+
+    # latency
+    try:
+        lat = int(out.get("latency_ms") or 0)
+    except Exception:
+        lat = 0
+    if lat < 0:
+        lat = 0
+    out["latency_ms"] = lat
+
+    # usage tokens
+    usage = dict(out.get("usage") or {})
+    for k in ("prompt_tokens", "completion_tokens"):
+        try:
+            v = int(usage.get(k) or 0)
+        except Exception:
+            v = 0
+        if v < 0:
+            v = 0
+        usage[k] = v
+    out["usage"] = usage
+
+    # cost
+    cost = dict(out.get("cost") or {})
+    try:
+        est = float(cost.get("estimated") or 0)
+    except Exception:
+        est = 0.0
+    if est < 0:
+        est = 0.0
+    cost["estimated"] = est
+    out["cost"] = cost
+
+    # prompts
+    prompts = dict(out.get("prompts") or {})
+    prompts["system"] = _truncate_prompt(prompts.get("system", ""))
+    prompts["user"] = _truncate_prompt(prompts.get("user", ""))
+    if "final" in prompts:
+        prompts["final"] = _truncate_prompt(prompts["final"])
+    out["prompts"] = prompts
+
+    # timestamps
+    ts = dict(out.get("timestamps") or {})
+    ts_start = ts.get("started_at")
+    ts_end = ts.get("ended_at")
+    if not ts_start:
+        ts_start = dt.datetime.now(dt.timezone.utc)
+    if not ts_end:
+        ts_end = ts_start
+    ts["started_at"] = _rfc3339(ts_start)
+    ts["ended_at"] = _rfc3339(ts_end)
+    out["timestamps"] = ts
+
+    return out

--- a/core/agents/executor_llm.py
+++ b/core/agents/executor_llm.py
@@ -8,6 +8,7 @@ from .schemas import PlanNodeModel
 from core.llm.providers.base import LLMRequest
 from core.llm.runner import run_llm
 from core.storage.composite_adapter import CompositeAdapter
+from apps.orchestrator.sidecars import normalize_llm_sidecar
 
 
 async def agent_runner(node: PlanNodeModel, storage: CompositeAdapter | None = None) -> dict:
@@ -63,6 +64,8 @@ async def agent_runner_legacy(node: PlanNodeModel, storage: CompositeAdapter) ->
     meta = res.get("llm", {})
 
     node_dbid = getattr(node, "db_id", None)
+    if meta:
+        meta = normalize_llm_sidecar(meta, node_id=str(node_dbid) if node_dbid else None)
     if node_dbid:
         await storage.save_artifact(node_id=str(node_dbid), content=md, ext=".md")
         if meta:

--- a/core/io/artifacts_fs.py
+++ b/core/io/artifacts_fs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os, json
 from pathlib import Path
 from typing import Optional, Dict, Any
+from apps.orchestrator.sidecars import normalize_llm_sidecar
 
 def runs_root() -> Path:
     return Path(os.getenv("ARTIFACTS_DIR") or os.getenv("RUNS_ROOT") or ".runs")
@@ -28,13 +29,12 @@ def write_md(run_id: str, node_key: str, content_md: str) -> Path:
     p.write_text(content_md, encoding="utf-8")
     return p
 
-def write_llm_sidecar(run_id: str, node_key: str, meta: Dict[str, Any]) -> Path:
-    """
-    meta attendu: { provider, model or model_used, latency_ms, usage, prompts? }
-    """
+def write_llm_sidecar(run_id: str, node_key: str, meta: Dict[str, Any], node_id: str | None = None) -> Path:
+    """Écrit un sidecar LLM normalisé."""
     ensure_dirs(run_id, node_key)
     p = llm_sidecar_path(run_id, node_key)
-    p.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+    meta_norm = normalize_llm_sidecar(meta, run_id=run_id, node_id=node_id)
+    p.write_text(json.dumps(meta_norm, ensure_ascii=False, indent=2), encoding="utf-8")
     return p
 
 def read_first_llm_meta(run_id: str, node_key: str) -> Dict[str, Any]:

--- a/tests/test_llm_meta_fallback_fs.py
+++ b/tests/test_llm_meta_fallback_fs.py
@@ -91,6 +91,6 @@ async def test_llm_meta_fallback_fs(tmp_path, monkeypatch):
     assert payload["provider"] == "openai"
     assert payload["model"] == "gpt4"
     assert payload["latency_ms"] == 123
-    assert payload["usage"] == {"prompt_tokens": 1}
-    assert payload["prompts"] == {"user": "hello"}
+    assert payload["usage"] == {"prompt_tokens": 1, "completion_tokens": 0}
+    assert payload["prompts"] == {"system": "", "user": "hello"}
     assert payload["request_id"] == "req-1"


### PR DESCRIPTION
## Résumé
- centralise la normalisation des fichiers `.llm.json`
- applique la spec v1.0 sur les métadonnées LLM avant écriture
- met à jour les tests pour refléter les valeurs normalisées

## Tests
- `pytest -q`
- `make validate`


------
https://chatgpt.com/codex/tasks/task_e_68a9a72121588327a08591524028fd8e