### PR TITLE
Déduplique la normalisation des sidecars

### DIFF
--- a/apps/orchestrator/executor.py
+++ b/apps/orchestrator/executor.py
@@ -40,7 +40,6 @@ from core.io.artifacts_fs import (
     write_md,
     node_dir as fs_node_dir,
 )
-from apps.orchestrator.sidecars import normalize_llm_sidecar
 
 log = logging.getLogger("crew.executor")
 
@@ -320,8 +319,9 @@ async def _execute_node(
                 node_uuid_str = str(UUID(str(node_dbid)))
             except Exception:
                 node_uuid_str = None
-        sidecar = normalize_llm_sidecar(sidecar, run_id=run_id, node_id=node_uuid_str)
-        write_llm_sidecar(run_id, node_key, sidecar)
+        sidecar = write_llm_sidecar(
+            run_id, node_key, sidecar, node_id=node_uuid_str
+        )
         if node_dbid:
             if node_uuid_str:
                 try:

--- a/apps/orchestrator/sidecars.py
+++ b/apps/orchestrator/sidecars.py
@@ -84,7 +84,7 @@ def normalize_llm_sidecar(data: Dict[str, Any] | None, *, run_id: str | None = N
     final_model = model_used or model
     if final_model:
         out["model"] = final_model
-    out.pop("model_used", None)
+        out["model_used"] = final_model
 
     if warnings:
         out["warnings"] = warnings

--- a/core/io/artifacts_fs.py
+++ b/core/io/artifacts_fs.py
@@ -29,13 +29,15 @@ def write_md(run_id: str, node_key: str, content_md: str) -> Path:
     p.write_text(content_md, encoding="utf-8")
     return p
 
-def write_llm_sidecar(run_id: str, node_key: str, meta: Dict[str, Any], node_id: str | None = None) -> Path:
-    """Écrit un sidecar LLM normalisé."""
+def write_llm_sidecar(
+    run_id: str, node_key: str, meta: Dict[str, Any], node_id: str | None = None
+) -> Dict[str, Any]:
+    """Écrit un sidecar LLM normalisé et le retourne."""
     ensure_dirs(run_id, node_key)
     p = llm_sidecar_path(run_id, node_key)
     meta_norm = normalize_llm_sidecar(meta, run_id=run_id, node_id=node_id)
     p.write_text(json.dumps(meta_norm, ensure_ascii=False, indent=2), encoding="utf-8")
-    return p
+    return meta_norm
 
 def read_first_llm_meta(run_id: str, node_key: str) -> Dict[str, Any]:
     """


### PR DESCRIPTION
## Résumé
- Centralise la normalisation des sidecars LLM dans `write_llm_sidecar`
- Nettoie l'appel dans l'exécuteur et transmet `node_id`
- Maintient `model` et `model_used` cohérents lors de la normalisation

## Tests
- `python -m pytest`
- `make validate`
- `make validate-strict`

------
https://chatgpt.com/codex/tasks/task_e_68a9aa1689f4832793bca0629a00c99f