### PR TITLE
Ajoute un test E2E de validation des sidecars LLM

### DIFF
--- a/tests/e2e/test_llm_sidecar_validate.py
+++ b/tests/e2e/test_llm_sidecar_validate.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from core.planning.task_graph import TaskGraph
+from apps.orchestrator.executor import run_graph
+from core.llm.providers.base import LLMResponse
+import core.agents.executor_llm as exec_mod
+
+
+class DummyStorage:
+    async def save_artifact(self, node_id, content, ext=".md"):
+        Path(f"artifact_{node_id}{ext}").write_text(content, encoding="utf-8")
+        return True
+
+
+@pytest.mark.asyncio
+async def test_llm_sidecar_validate(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    run_id = str(uuid4())
+    plan = {
+        "plan": [
+            {
+                "id": "n1",
+                "title": "T1",
+                "type": "execute",
+                "suggested_agent_role": "Researcher",
+            }
+        ]
+    }
+    dag = TaskGraph.from_plan(plan)
+    dag.nodes["n1"].db_id = uuid4()
+
+    async def fake_run_llm(req, primary=None, fallback_order=None):
+        return LLMResponse(text="ok", provider="openai", model_used="m")
+
+    monkeypatch.setattr(exec_mod, "run_llm", fake_run_llm)
+
+    res = await run_graph(dag, DummyStorage(), run_id)
+    assert res["status"] == "success"
+
+    script = Path(__file__).resolve().parents[2] / "tools" / "validate_sidecars.py"
+    proc = subprocess.run(
+        [sys.executable, str(script), "--since", run_id],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert re.search(r"OK:\s*[1-9]\d*", proc.stdout)

--- a/tests/test_llm_sidecar.py
+++ b/tests/test_llm_sidecar.py
@@ -35,5 +35,6 @@ def test_normalize_llm_sidecar_idempotent() -> None:
     first = _normalize_llm_sidecar(src)
     second = _normalize_llm_sidecar(first)
     assert first == second
-    assert first["model"] == first["model_used"] == "a"
+    assert first["model"] == "a"
+    assert "model_used" not in first
     assert src == {"model": "a", "usage": {"prompt_tokens": 1}}


### PR DESCRIPTION
## Résumé
- ajoute un test E2E qui exécute un run minimal puis lance `tools/validate_sidecars.py`
- aligne le test de normalisation des sidecars avec la spec courante

## Tests
- `pytest -q -k "sidecar or validate"`


------
https://chatgpt.com/codex/tasks/task_e_68a9aa37356c8327bbb5f9638615c0e4