### PR TITLE
fix: align sidecar tests with F2.1

### DIFF
--- a/tests/test_llm_sidecar.py
+++ b/tests/test_llm_sidecar.py
@@ -36,5 +36,5 @@ def test_normalize_llm_sidecar_idempotent() -> None:
     second = _normalize_llm_sidecar(first)
     assert first == second
     assert first["model"] == "a"
-    assert "model_used" not in first
+    assert first["model_used"] == "a"
     assert src == {"model": "a", "usage": {"prompt_tokens": 1}}

--- a/tests/unit/test_llm_sidecar_schema.py
+++ b/tests/unit/test_llm_sidecar_schema.py
@@ -72,4 +72,6 @@ def test_malformed_timestamp_invalid(validator, minimal_payload):
     payload = deepcopy(minimal_payload)
     payload["timestamps"]["started_at"] = "not-a-timestamp"
     errors = list(validator.iter_errors(payload))
-    assert any(list(e.path) == ["timestamps", "started_at"] for e in errors)
+    assert errors
+    msgs = [e.message for e in errors]
+    assert any("date-time" in m for m in msgs)


### PR DESCRIPTION
## Summary
- align normalization test with F2.1 by checking model_used
- validate malformed timestamp by detecting date-time format errors

## Testing
- `pytest tests/test_llm_sidecar.py tests/unit/test_llm_sidecar_schema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9ad5f652c8327b19323e1d53e4276