### PR TITLE
feat: ajouter la cible validate-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,12 @@ api-e2e-meta: ensure-venv
 	@$(ACTIVATE) && pytest -q api/tests/test_tasks_meta_e2e.py
 
 # ---- Validation ----------------------------------
-.PHONY: validate validate-strict
+.PHONY: validate validate-all validate-strict
 validate: ensure-venv
 	@$(ACTIVATE) && python tools/validate_sidecars.py
+
+validate-all: ensure-venv
+	@$(ACTIVATE) && python tools/validate_sidecars.py --all
 
 validate-strict: ensure-venv
 	@$(ACTIVATE) && python tools/validate_sidecars.py --strict


### PR DESCRIPTION
## Résumé
- ajoute la cible Makefile `validate-all` pour valider tous les sidecars

## Tests
- `make validate-all` *(échoue: ModuleNotFoundError: No module named 'jsonschema')*
- `pytest -q` *(3 tests échouent)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ad6ff57883279c30ff3bb285008a