### PR TITLE
fix: improve schema validation for model and timestamps

### DIFF
--- a/schemas/llm_sidecar.schema.json
+++ b/schemas/llm_sidecar.schema.json
@@ -64,8 +64,16 @@
     "timestamps": {
       "type": "object",
       "properties": {
-        "started_at": { "type": "string", "format": "date-time" },
-        "ended_at": { "type": "string", "format": "date-time" }
+        "started_at": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "ended_at": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)(Z|[+-]\\d{2}:\\d{2})$"
+        }
       },
       "required": ["started_at", "ended_at"]
     },
@@ -122,7 +130,7 @@
   "required": ["version", "provider", "latency_ms", "usage", "cost", "prompts", "timestamps", "run_id", "node_id"],
   "allOf": [
     {
-      "oneOf": [
+      "anyOf": [
         { "required": ["model"] },
         { "required": ["model_used"] }
       ]


### PR DESCRIPTION
## Summary
- use `anyOf` to require `model` or `model_used`
- enforce RFC3339 regex for timestamps

## Testing
- `pytest tests/unit/test_llm_sidecar_schema.py::test_malformed_timestamp_invalid tests/e2e/test_llm_sidecar_validate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9af9533488327806647130257d6f9