### PR TITLE
Normalise le provider des sidecars LLM

### DIFF
--- a/apps/orchestrator/sidecars.py
+++ b/apps/orchestrator/sidecars.py
@@ -65,6 +65,8 @@ def normalize_llm_sidecar(data: Dict[str, Any] | None, *, run_id: str | None = N
 
     # provider (défaut 'other')
     provider = out.get("provider") or "other"
+    if provider not in {"openai", "anthropic", "ollama", "azure_openai", "other"}:
+        provider = "other"
     out["provider"] = provider
 
     # run_id / node_id

--- a/tests/e2e/test_mini_flow.py
+++ b/tests/e2e/test_mini_flow.py
@@ -47,7 +47,7 @@ async def test_mini_flow(tmp_path, monkeypatch):
     for nid in ["R1","R2","W1"]:
         assert Path(f"artifact_{nid}.md").exists()
         side = json.loads(Path(f"artifact_{nid}.llm.json").read_text())
-        assert side["provider"] == "p" and side["model_used"] == "m"
+        assert side["provider"] == "other" and side["model_used"] == "m"
 
     await run_graph(dag, DummyStorage(), "run1")
     summary = json.loads(Path(".runs/run1/summary.json").read_text())

--- a/tests/test_agent_routing.py
+++ b/tests/test_agent_routing.py
@@ -33,7 +33,7 @@ async def test_agent_routing_writer(monkeypatch, tmp_path):
     content = res["markdown"]
     assert content.startswith("# ")
     side = res["llm"]
-    assert side["provider"] == "p"
+    assert side["provider"] == "other"
     assert side["model_used"] == "m"
     assert set(side["prompts"].keys()) == {"system", "user", "final"}
 
@@ -105,7 +105,7 @@ async def test_agent_routing_researcher(monkeypatch, tmp_path):
     assert "## Limites" in content
     assert "## Sources" in content
     side = res["llm"]
-    assert side["provider"] == "p"
+    assert side["provider"] == "other"
     assert side["model_used"] == "m"
     md_path = Path(tmp_path, "runR", "nodes", "r1", "artifact_r1.md")
     side_path = Path(tmp_path, "runR", "nodes", "r1", "artifact_r1.llm.json")
@@ -137,7 +137,7 @@ async def test_agent_routing_reviewer(monkeypatch, tmp_path):
     assert "### Corrections proposées" in content
     assert "### Risques résiduels" in content
     side = res["llm"]
-    assert side["provider"] == "p"
+    assert side["provider"] == "other"
     assert side["model_used"] == "m"
     md_path = Path(tmp_path, "runV", "nodes", "rv1", "artifact_rv1.md")
     side_path = Path(tmp_path, "runV", "nodes", "rv1", "artifact_rv1.llm.json")

--- a/tests/test_llm_sidecar.py
+++ b/tests/test_llm_sidecar.py
@@ -15,7 +15,7 @@ def _write_sidecar(base: Path, run_id: str, node_key: str, data: dict) -> None:
 def test_read_llm_sidecar_fs_with_runs_root(tmp_path: Path) -> None:
     _write_sidecar(tmp_path, "run1", "n1", {"provider": "p"})
     out = _read_llm_sidecar_fs("run1", "n1", runs_root=str(tmp_path))
-    assert out["provider"] == "p"
+    assert out["provider"] == "other"
 
 
 def test_read_llm_sidecar_fs_with_env(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Résumé
- Homogénéisation du champ `provider` des sidecars LLM : toute valeur exotique est désormais convertie en `other`.
- Ajustement des tests pour refléter cette normalisation.

## Tests
- `pre-commit run --files apps/orchestrator/sidecars.py tests/test_agent_routing.py tests/e2e/test_mini_flow.py tests/test_llm_sidecar.py`
- `pytest tests/test_llm_sidecar.py tests/test_agent_routing.py tests/e2e/test_mini_flow.py`
- `make validate`


------
https://chatgpt.com/codex/tasks/task_e_68a9b0baf9d08327850abd45fc43b23a