### PR TITLE
fix: ignore markdown warning in sidecar validator

### DIFF
--- a/tools/validate_sidecars.py
+++ b/tools/validate_sidecars.py
@@ -96,6 +96,7 @@ def main() -> None:
             ):
                 file_errors.append("'model' et 'model_used' diffèrent")
         unknown = set(data.keys()) - known_props
+        unknown.discard("markdown")  # champs optionnel ignoré
         if unknown:
             file_warnings.append("Champs inconnus: " + ", ".join(sorted(unknown)))
         if file_errors:


### PR DESCRIPTION
## Summary
- ignore `markdown` property when computing unknown sidecar fields to avoid spurious warnings

## Testing
- `make test`
- `RUNS_ROOT=.runs/test make validate`


------
https://chatgpt.com/codex/tasks/task_e_68a9b0c4c1d483278716bed48af747a4