### PR TITLE
feat: permettre validation des runs non uuid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ api-e2e-meta: ensure-venv
 	@$(ACTIVATE) && pytest -q api/tests/test_tasks_meta_e2e.py
 
 # ---- Validation ----------------------------------
-.PHONY: validate validate-all validate-strict
+.PHONY: validate validate-all validate-strict validate-non-uuid
 validate: ensure-venv
 	@$(ACTIVATE) && python tools/validate_sidecars.py
 
@@ -224,6 +224,9 @@ validate-all: ensure-venv
 
 validate-strict: ensure-venv
 	@$(ACTIVATE) && python tools/validate_sidecars.py --strict
+
+validate-non-uuid: ensure-venv
+	@$(ACTIVATE) && python tools/validate_sidecars.py --non-uuid
 
 # ---- Docker compose (optionnel) -------------------------------
 HAS_COMPOSE := $(shell test -f docker-compose.yml && echo yes || echo no)


### PR DESCRIPTION
## Résumé
- ignorer les runs dont l'identifiant n'est pas un UUID v4
- option CLI `--non-uuid` pour les valider malgré tout
- cible Makefile `validate-non-uuid`

## Tests
- `python tools/validate_sidecars.py`
- `python tools/validate_sidecars.py --non-uuid`
- `make -n validate-non-uuid`


------
https://chatgpt.com/codex/tasks/task_e_68a9b76cd3c083278f4f15d0b2908cca