### PR TITLE
feat: add typed service API with hooks

### DIFF
--- a/dashboard/mini/package-lock.json
+++ b/dashboard/mini/package-lock.json
@@ -8,8 +8,11 @@
       "name": "mini",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.62.8",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "uuid": "^9.0.1",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.6",
@@ -17,6 +20,7 @@
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
+        "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^8.39.1",
         "@typescript-eslint/parser": "^8.39.1",
         "@vitejs/plugin-react": "^5.0.0",
@@ -26,10 +30,12 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "jsdom": "^24.0.0",
+        "msw": "^2.4.9",
         "prettier": "^3.3.3",
         "typescript": "~5.8.3",
         "vite": "^7.1.2",
-        "vitest": "^2.1.4"
+        "vitest": "^2.1.4",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -384,6 +390,37 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1195,6 +1232,84 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
+      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1234,6 +1349,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1271,6 +1404,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -1572,6 +1730,32 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.5.tgz",
+      "integrity": "sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.5.tgz",
+      "integrity": "sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1701,6 +1885,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1744,6 +1935,27 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
@@ -2137,13 +2349,41 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2560,6 +2800,49 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2606,6 +2889,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2865,6 +3158,13 @@
       "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -3718,6 +4018,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3838,6 +4148,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3931,6 +4251,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -4209,6 +4536,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -4266,6 +4603,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -4790,6 +5134,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.5.tgz",
+      "integrity": "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4956,6 +5355,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -5056,6 +5462,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5369,6 +5782,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/requires-port": {
@@ -5737,6 +6160,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5753,6 +6189,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -5773,6 +6219,28 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -5871,6 +6339,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-indent": {
@@ -6108,6 +6589,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -6286,6 +6780,19 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -7526,6 +8033,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -7682,6 +8196,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -7721,12 +8250,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -7739,6 +8307,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/dashboard/mini/package.json
+++ b/dashboard/mini/package.json
@@ -14,8 +14,11 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.62.8",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "uuid": "^9.0.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.6",
@@ -32,7 +35,10 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "jsdom": "^24.0.0",
+    "msw": "^2.4.9",
     "prettier": "^3.3.3",
+    "whatwg-fetch": "^3.6.20",
+    "@types/uuid": "^9.0.7",
     "typescript": "~5.8.3",
     "vite": "^7.1.2",
     "vitest": "^2.1.4"

--- a/dashboard/mini/src/App.tsx
+++ b/dashboard/mini/src/App.tsx
@@ -1,5 +1,6 @@
-import ApiKeyBanner from "./components/ApiKeyBanner";
-import { ApiKeyProvider } from "./state/ApiKeyContext";
+import type { JSX } from 'react';
+import ApiKeyBanner from './components/ApiKeyBanner';
+import { ApiKeyProvider } from './state/ApiKeyContext';
 
 export const App = (): JSX.Element => (
   <ApiKeyProvider>

--- a/dashboard/mini/src/__tests__/api/client.test.ts
+++ b/dashboard/mini/src/__tests__/api/client.test.ts
@@ -1,0 +1,70 @@
+import 'whatwg-fetch';
+import { describe, expect, it, vi } from 'vitest';
+import * as client from '../../api/client';
+import { ApiError } from '../../api/http';
+
+const okPage = { items: [], meta: { page: 1, page_size: 1, total: 0 } };
+
+describe('client API', () => {
+  it('mappe correctement les paramètres de requête', async () => {
+    const mock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(okPage), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    global.fetch = mock as unknown as typeof fetch;
+    await client.listRuns({
+      page: 2,
+      pageSize: 10,
+      status: ['running', 'succeeded'],
+      dateFrom: '2024-01-01',
+      dateTo: '2024-01-31',
+      title: 'test',
+    });
+    const url = new URL(mock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('page_size')).toBe('10');
+    expect(url.searchParams.get('status')).toBe('running,succeeded');
+    expect(url.searchParams.get('date_from')).toBe('2024-01-01');
+    expect(url.searchParams.get('date_to')).toBe('2024-01-31');
+    expect(url.searchParams.get('title')).toBe('test');
+  });
+
+  it('propage le signal', async () => {
+    const mock = vi.fn(
+      (_: string, opts: RequestInit) =>
+        new Promise((_, reject) => {
+          opts.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
+    global.fetch = mock as unknown as typeof fetch;
+    const ctrl = new AbortController();
+    const prom = client.getRun('1', { signal: ctrl.signal });
+    ctrl.abort();
+    await expect(prom).rejects.toThrow();
+  });
+
+  it('lève ApiError structuré', async () => {
+    const mock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'nope' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    global.fetch = mock as unknown as typeof fetch;
+    let error: unknown;
+    try {
+      await client.getRun('42');
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ApiError);
+    const err = error as ApiError;
+    expect(err.status).toBe(400);
+    expect(err.body).toEqual({ detail: 'nope' });
+    expect(err.requestId).toBeTruthy();
+  });
+});

--- a/dashboard/mini/src/__tests__/api/http.test.ts
+++ b/dashboard/mini/src/__tests__/api/http.test.ts
@@ -1,0 +1,116 @@
+import 'whatwg-fetch';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchJson, ApiError } from '../../api/http';
+import { setCurrentApiKey } from '../../state/ApiKeyContext';
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setCurrentApiKey(undefined);
+  });
+
+  it('ajoute les bons headers', async () => {
+    setCurrentApiKey('secret');
+    const mock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    global.fetch = mock as unknown as typeof fetch;
+    const { requestId: id1 } = await fetchJson<{ ok: boolean }>('/runs');
+    const headers1 = (mock.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers1['Accept']).toBe('application/json');
+    expect(headers1['X-API-Key']).toBe('secret');
+    expect(headers1['X-Request-ID']).toBe(id1);
+    const { requestId: id2 } = await fetchJson<{ ok: boolean }>('/runs');
+    const headers2 = (mock.mock.calls[1][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers2['X-Request-ID']).not.toBe(headers1['X-Request-ID']);
+    expect(id2).not.toBe(id1);
+  });
+
+  it('aborte après le timeout', async () => {
+    vi.useFakeTimers();
+    const mock = vi.fn(
+      (_: string, opts: RequestInit) =>
+        new Promise((_, reject) => {
+          opts.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
+    global.fetch = mock as unknown as typeof fetch;
+    const prom = fetchJson('/runs');
+    const assertion = expect(prom).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(15000);
+    await assertion;
+    vi.useRealTimers();
+  });
+
+  it('peut être annulé via un signal externe', async () => {
+    const ctrl = new AbortController();
+    const mock = vi.fn(
+      (_: string, opts: RequestInit) =>
+        new Promise((_, reject) => {
+          opts.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
+    global.fetch = mock as unknown as typeof fetch;
+    const prom = fetchJson('/runs', { signal: ctrl.signal });
+    ctrl.abort();
+    await expect(prom).rejects.toThrow();
+  });
+
+  it('retry sur 500 puis succès', async () => {
+    vi.useFakeTimers();
+    const mock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('err', {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    global.fetch = mock as unknown as typeof fetch;
+    const prom = fetchJson<{ ok: boolean }>('/runs');
+    await vi.advanceTimersByTimeAsync(200);
+    const res = await prom;
+    expect(res.data.ok).toBe(true);
+    expect(mock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('pas de retry sur 401', async () => {
+    const mock = vi.fn().mockResolvedValue(
+      new Response('no', {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    global.fetch = mock as unknown as typeof fetch;
+    await expect(fetchJson('/runs')).rejects.toBeInstanceOf(ApiError);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -1,0 +1,108 @@
+import { fetchJson, FetchOpts } from './http';
+import {
+  ArtifactItem,
+  EventItem,
+  NodeItem,
+  Page,
+  Run,
+  RunDetail,
+  Status,
+} from './types';
+
+export const listRuns = async (
+  params: {
+    page: number;
+    pageSize: number;
+    status?: Status[];
+    dateFrom?: string;
+    dateTo?: string;
+    title?: string;
+  },
+  opts: FetchOpts = {},
+): Promise<Page<Run>> => {
+  const query: Record<string, string | number | boolean | undefined> = {
+    page: params.page,
+    page_size: params.pageSize,
+    status: params.status?.join(','),
+    date_from: params.dateFrom,
+    date_to: params.dateTo,
+    title: params.title,
+  };
+  const { data } = await fetchJson<Page<Run>>('/runs', { ...opts, query });
+  return data;
+};
+
+export const getRun = async (
+  id: string,
+  opts: FetchOpts = {},
+): Promise<RunDetail> => {
+  const { data } = await fetchJson<RunDetail>(`/runs/${id}`, opts);
+  return data;
+};
+
+export const getRunSummary = async (
+  id: string,
+  opts: FetchOpts = {},
+): Promise<{ summary: string }> => {
+  const { data } = await fetchJson<{ summary: string }>(
+    `/runs/${id}/summary`,
+    opts,
+  );
+  return data;
+};
+
+export const listRunNodes = async (
+  id: string,
+  params: { page: number; pageSize: number },
+  opts: FetchOpts = {},
+): Promise<Page<NodeItem>> => {
+  const query = { page: params.page, page_size: params.pageSize };
+  const { data } = await fetchJson<Page<NodeItem>>(`/runs/${id}/nodes`, {
+    ...opts,
+    query,
+  });
+  return data;
+};
+
+export const listRunEvents = async (
+  id: string,
+  params: {
+    page: number;
+    pageSize: number;
+    level?: 'info' | 'warn' | 'error' | 'debug';
+    text?: string;
+  },
+  opts: FetchOpts = {},
+): Promise<Page<EventItem>> => {
+  const query: Record<string, string | number | boolean | undefined> = {
+    page: params.page,
+    page_size: params.pageSize,
+    level: params.level,
+    text: params.text,
+  };
+  const { data } = await fetchJson<Page<EventItem>>(`/runs/${id}/events`, {
+    ...opts,
+    query,
+  });
+  return data;
+};
+
+export const listNodeArtifacts = async (
+  nodeId: string,
+  params: { page: number; pageSize: number; kind?: string },
+  opts: FetchOpts = {},
+): Promise<Page<ArtifactItem>> => {
+  const query: Record<string, string | number | boolean | undefined> = {
+    page: params.page,
+    page_size: params.pageSize,
+    kind: params.kind,
+  };
+  const { data } = await fetchJson<Page<ArtifactItem>>(
+    `/nodes/${nodeId}/artifacts`,
+    {
+      ...opts,
+      query,
+    },
+  );
+  return data;
+};

--- a/dashboard/mini/src/api/hooks.ts
+++ b/dashboard/mini/src/api/hooks.ts
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getRun,
+  getRunSummary,
+  listNodeArtifacts,
+  listRunEvents,
+  listRunNodes,
+  listRuns,
+} from './client';
+import {
+  ArtifactItem,
+  EventItem,
+  NodeItem,
+  Page,
+  Run,
+  RunDetail,
+  Status,
+} from './types';
+
+export const useRuns = (params: {
+  page: number;
+  pageSize: number;
+  status?: Status[];
+  dateFrom?: string;
+  dateTo?: string;
+  title?: string;
+}) =>
+  useQuery<Page<Run>>({
+    queryKey: ['runs', params],
+    queryFn: ({ signal }) => listRuns(params, { signal }),
+    staleTime: 5_000,
+  });
+
+export const useRun = (id: string) =>
+  useQuery<RunDetail>({
+    queryKey: ['run', id],
+    queryFn: ({ signal }) => getRun(id, { signal }),
+  });
+
+export const useRunSummary = (id: string) =>
+  useQuery<{ summary: string }>({
+    queryKey: ['run', id, 'summary'],
+    queryFn: ({ signal }) => getRunSummary(id, { signal }),
+  });
+
+export const useRunNodes = (
+  id: string,
+  params: { page: number; pageSize: number },
+) =>
+  useQuery<Page<NodeItem>>({
+    queryKey: ['run', id, 'nodes', params],
+    queryFn: ({ signal }) => listRunNodes(id, params, { signal }),
+  });
+
+export const useRunEvents = (
+  id: string,
+  params: {
+    page: number;
+    pageSize: number;
+    level?: 'info' | 'warn' | 'error' | 'debug';
+    text?: string;
+  },
+) =>
+  useQuery<Page<EventItem>>({
+    queryKey: ['run', id, 'events', params],
+    queryFn: ({ signal }) => listRunEvents(id, params, { signal }),
+  });
+
+export const useNodeArtifacts = (
+  nodeId: string,
+  params: { page: number; pageSize: number; kind?: string },
+) =>
+  useQuery<Page<ArtifactItem>>({
+    queryKey: ['node', nodeId, 'artifacts', params],
+    queryFn: ({ signal }) => listNodeArtifacts(nodeId, params, { signal }),
+  });

--- a/dashboard/mini/src/api/http.ts
+++ b/dashboard/mini/src/api/http.ts
@@ -1,0 +1,110 @@
+import { v4 as uuidv4 } from 'uuid';
+import { API_BASE_URL, API_TIMEOUT_MS } from '../config/env';
+import { getCurrentApiKey } from '../state/ApiKeyContext';
+
+export class ApiError extends Error {
+  status: number;
+  requestId: string;
+  body?: unknown;
+
+  constructor(
+    message: string,
+    status: number,
+    requestId: string,
+    body?: unknown,
+  ) {
+    super(message);
+    this.status = status;
+    this.requestId = requestId;
+    this.body = body;
+  }
+}
+
+export interface FetchOpts {
+  query?: Record<string, string | number | boolean | undefined>;
+  signal?: AbortSignal;
+}
+
+export async function fetchJson<T>(
+  path: string,
+  opts: FetchOpts = {},
+): Promise<{ data: T; requestId: string }> {
+  const url = new URL(API_BASE_URL + path);
+  if (opts.query) {
+    for (const [key, value] of Object.entries(opts.query)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const requestId = uuidv4();
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'X-Request-ID': requestId,
+  };
+  const apiKey = getCurrentApiKey();
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+
+  const timeoutCtrl = new AbortController();
+  const timeoutId = setTimeout(() => timeoutCtrl.abort(), API_TIMEOUT_MS);
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      timeoutCtrl.abort();
+    } else {
+      opts.signal.addEventListener('abort', () => timeoutCtrl.abort(), {
+        once: true,
+      });
+    }
+  }
+
+  const fetchOnce = () =>
+    fetch(url.toString(), {
+      headers,
+      signal: timeoutCtrl.signal,
+    });
+
+  const maxRetries = 2;
+  const backoff = [200, 500];
+  let attempt = 0;
+  while (true) {
+    try {
+      const res = await fetchOnce();
+      if (res.ok) {
+        clearTimeout(timeoutId);
+        const data = (await res.json()) as T;
+        return { data, requestId };
+      }
+      let body: unknown;
+      const ct = res.headers.get('content-type');
+      if (ct && ct.includes('application/json')) {
+        try {
+          body = await res.json();
+        } catch {
+          body = undefined;
+        }
+      }
+      if (
+        attempt < maxRetries &&
+        (res.status === 429 || (res.status >= 500 && res.status < 600))
+      ) {
+        const delay = backoff[attempt] ?? backoff[backoff.length - 1];
+        attempt++;
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+      clearTimeout(timeoutId);
+      throw new ApiError(
+        `API Error ${res.status}`,
+        res.status,
+        requestId,
+        body,
+      );
+    } catch (err) {
+      clearTimeout(timeoutId);
+      throw err;
+    }
+  }
+}

--- a/dashboard/mini/src/api/types.ts
+++ b/dashboard/mini/src/api/types.ts
@@ -1,0 +1,61 @@
+export type Status =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'canceled'
+  | 'partial';
+
+export interface PageMeta {
+  page: number;
+  page_size: number;
+  total: number;
+}
+export interface Page<T> {
+  items: T[];
+  meta: PageMeta;
+}
+
+export interface Run {
+  id: string;
+  title?: string;
+  status: Status;
+  started_at?: string;
+  ended_at?: string;
+  counters?: { tokens_total?: number; nodes_total?: number; errors?: number };
+}
+
+export interface RunDetail extends Run {
+  summary?: string;
+  dag?: {
+    nodes: Array<{ id: string; label?: string; role?: string; status: Status }>;
+    edges: Array<{ from: string; to: string }>;
+  };
+}
+
+export interface NodeItem {
+  id: string;
+  role?: string;
+  status: Status;
+  started_at?: string;
+  ended_at?: string;
+  duration_ms?: number;
+  checksum?: string;
+}
+
+export interface EventItem {
+  id: string;
+  timestamp: string;
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  request_id?: string;
+}
+
+export interface ArtifactItem {
+  id: string;
+  node_id: string;
+  name: string;
+  kind: 'file' | 'llm_sidecar' | 'log' | 'other';
+  size_bytes?: number;
+  url: string;
+}

--- a/dashboard/mini/src/components/ApiKeyBanner.tsx
+++ b/dashboard/mini/src/components/ApiKeyBanner.tsx
@@ -1,15 +1,16 @@
-import { FormEvent, useState } from "react";
-import { useApiKey } from "../state/ApiKeyContext";
-import { DEMO_API_KEY } from "../config/env";
+import type { JSX } from 'react';
+import { FormEvent, useState } from 'react';
+import { useApiKey } from '../state/ApiKeyContext';
+import { DEMO_API_KEY } from '../config/env';
 
 export const ApiKeyBanner = (): JSX.Element => {
   const { setApiKey, useEnvKey, setUseEnvKey } = useApiKey();
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState('');
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
     setApiKey(input.trim());
-    setInput("");
+    setInput('');
   };
 
   const envKeyDefined = Boolean(DEMO_API_KEY);

--- a/dashboard/mini/src/config/env.ts
+++ b/dashboard/mini/src/config/env.ts
@@ -1,10 +1,14 @@
 // Gestion des variables d'environnement côté front
 
-export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000").replace(/\/+$/, "");
+export const API_BASE_URL = (
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000'
+).replace(/\/+$/, '');
 
 const rawTimeout = Number(import.meta.env.VITE_API_TIMEOUT_MS);
-export const API_TIMEOUT_MS = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 15000;
+export const API_TIMEOUT_MS =
+  Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 15000;
 
-export const DEMO_API_KEY = String(import.meta.env.VITE_DEMO_API_KEY ?? "").trim() || undefined;
+export const DEMO_API_KEY =
+  String(import.meta.env.VITE_DEMO_API_KEY ?? '').trim() || undefined;
 
 export default { API_BASE_URL, API_TIMEOUT_MS, DEMO_API_KEY };

--- a/dashboard/mini/src/state/ApiKeyContext.tsx
+++ b/dashboard/mini/src/state/ApiKeyContext.tsx
@@ -1,4 +1,13 @@
-import { createContext, ReactNode, useContext, useState } from "react";
+import type { JSX, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { DEMO_API_KEY } from '../config/env';
+
+let currentApiKey: string | undefined;
+
+export const getCurrentApiKey = (): string | undefined => currentApiKey;
+export const setCurrentApiKey = (k?: string): void => {
+  currentApiKey = k;
+};
 
 export type ApiKeyState = {
   apiKey: string;
@@ -11,13 +20,21 @@ export type ApiKeyActions = {
 };
 export type ApiKeyContextValue = ApiKeyState & ApiKeyActions;
 
-const defaultState: ApiKeyState = { apiKey: "", useEnvKey: false };
+const defaultState: ApiKeyState = { apiKey: '', useEnvKey: false };
 
 const ApiKeyContext = createContext<ApiKeyContextValue | null>(null);
 
-export const ApiKeyProvider = ({ children }: { children: ReactNode }): JSX.Element => {
+export const ApiKeyProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element => {
   const [apiKey, setApiKey] = useState<string>(defaultState.apiKey);
   const [useEnvKey, setUseEnvKey] = useState<boolean>(defaultState.useEnvKey);
+
+  useEffect(() => {
+    setCurrentApiKey(useEnvKey ? DEMO_API_KEY : apiKey || undefined);
+  }, [apiKey, useEnvKey]);
 
   const reset = (): void => {
     setApiKey(defaultState.apiKey);
@@ -25,7 +42,9 @@ export const ApiKeyProvider = ({ children }: { children: ReactNode }): JSX.Eleme
   };
 
   return (
-    <ApiKeyContext.Provider value={{ apiKey, useEnvKey, setApiKey, setUseEnvKey, reset }}>
+    <ApiKeyContext.Provider
+      value={{ apiKey, useEnvKey, setApiKey, setUseEnvKey, reset }}
+    >
       {children}
     </ApiKeyContext.Provider>
   );
@@ -34,7 +53,7 @@ export const ApiKeyProvider = ({ children }: { children: ReactNode }): JSX.Eleme
 export const useApiKey = (): ApiKeyContextValue => {
   const ctx = useContext(ApiKeyContext);
   if (!ctx) {
-    throw new Error("useApiKey must be used within an ApiKeyProvider");
+    throw new Error('useApiKey must be used within an ApiKeyProvider');
   }
   return ctx;
 };

--- a/dashboard/mini/tsconfig.json
+++ b/dashboard/mini/tsconfig.json
@@ -3,11 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -21,13 +17,7 @@
     "jsx": "react-jsx",
     "noEmit": true,
     "composite": true,
-    "types": [
-      "vitest/globals",
-      "node",
-      "vite/client"
-    ]
+    "types": ["vitest/globals", "node", "vite/client"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/dashboard/mini/vite.config.ts
+++ b/dashboard/mini/vite.config.ts
@@ -5,9 +5,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: true,        // équivaut à 0.0.0.0
+    host: true, // équivaut à 0.0.0.0
     port: 5173,
-    strictPort: true,  // échoue si port occupé
+    strictPort: true, // échoue si port occupé
   },
   preview: {
     host: true,

--- a/dashboard/mini/vitest.config.ts
+++ b/dashboard/mini/vitest.config.ts
@@ -1,16 +1,16 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
+    environment: 'jsdom',
     globals: true,
     env: {
-      VITE_API_BASE_URL: "http://localhost:8000",
-      VITE_API_TIMEOUT_MS: "15000",
-      VITE_DEMO_API_KEY: "demo-key"
-    }
+      VITE_API_BASE_URL: 'http://localhost:8000',
+      VITE_API_TIMEOUT_MS: '15000',
+      VITE_DEMO_API_KEY: 'demo-key',
+    },
   },
   esbuild: {
-    jsx: "automatic"
-  }
+    jsx: 'automatic',
+  },
 });


### PR DESCRIPTION
## Summary
- implement typed HTTP client with request ID, retries, timeouts and API key support
- expose service endpoints and React Query hooks
- add unit tests for API client and HTTP helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e670fda08327af6ac45791b4891c