### PR TITLE
feat: pages runs et routage

### DIFF
--- a/dashboard/mini/package-lock.json
+++ b/dashboard/mini/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.62.8",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2",
         "uuid": "^9.0.1",
         "zod": "^3.23.8"
       },
@@ -5726,6 +5727,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6004,6 +6052,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/dashboard/mini/package.json
+++ b/dashboard/mini/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.62.8",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2",
     "uuid": "^9.0.1",
     "zod": "^3.23.8"
   },

--- a/dashboard/mini/src/App.tsx
+++ b/dashboard/mini/src/App.tsx
@@ -1,13 +1,26 @@
 import type { JSX } from 'react';
-import ApiKeyBanner from './components/ApiKeyBanner';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AppLayout from './layouts/AppLayout';
+import RunsPage from './pages/RunsPage';
+import RunDetailPage from './pages/RunDetailPage';
 import { ApiKeyProvider } from './state/ApiKeyContext';
+
+const queryClient = new QueryClient();
 
 export const App = (): JSX.Element => (
   <ApiKeyProvider>
-    <div>
-      <ApiKeyBanner />
-      <h1>Mini Dashboard (read-only) — Fil G</h1>
-    </div>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AppLayout>
+          <Routes>
+            <Route path="/runs" element={<RunsPage />} />
+            <Route path="/runs/:id" element={<RunDetailPage />} />
+            <Route path="*" element={<Navigate to="/runs" replace />} />
+          </Routes>
+        </AppLayout>
+      </BrowserRouter>
+    </QueryClientProvider>
   </ApiKeyProvider>
 );
 

--- a/dashboard/mini/src/__tests__/ApiKeyBanner.test.tsx
+++ b/dashboard/mini/src/__tests__/ApiKeyBanner.test.tsx
@@ -18,7 +18,7 @@ describe('ApiKeyBanner', () => {
     render(
       <Wrapper>
         <ApiKeyBanner />
-      </Wrapper>
+      </Wrapper>,
     );
     const input = screen.getByTestId('apiKeyInput') as HTMLInputElement;
     const toggle = screen.getByTestId('useEnvToggle') as HTMLInputElement;
@@ -33,7 +33,7 @@ describe('ApiKeyBanner', () => {
       <Wrapper>
         <ApiKeyBanner />
         <Display />
-      </Wrapper>
+      </Wrapper>,
     );
     const input = screen.getByTestId('apiKeyInput') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'secret' } });
@@ -45,21 +45,23 @@ describe('ApiKeyBanner', () => {
     render(
       <Wrapper>
         <ApiKeyBanner />
-      </Wrapper>
+      </Wrapper>,
     );
     const input = screen.getByTestId('apiKeyInput') as HTMLInputElement;
     const toggle = screen.getByTestId('useEnvToggle') as HTMLInputElement;
     fireEvent.click(toggle);
     expect(toggle.checked).toBe(true);
     expect(input.disabled).toBe(true);
-    expect(screen.getByTestId('envActiveBadge').textContent).toContain('active');
+    expect(screen.getByTestId('envActiveBadge').textContent).toContain(
+      'active',
+    );
   });
 
   it('toggle désactivé rend le champ éditable', () => {
     render(
       <Wrapper>
         <ApiKeyBanner />
-      </Wrapper>
+      </Wrapper>,
     );
     const input = screen.getByTestId('apiKeyInput') as HTMLInputElement;
     const toggle = screen.getByTestId('useEnvToggle') as HTMLInputElement;
@@ -74,7 +76,7 @@ describe('ApiKeyBanner', () => {
       <Wrapper>
         <ApiKeyBanner />
         <Display />
-      </Wrapper>
+      </Wrapper>,
     );
     const input = screen.getByTestId('apiKeyInput') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'temp' } });
@@ -85,7 +87,7 @@ describe('ApiKeyBanner', () => {
       <Wrapper>
         <ApiKeyBanner />
         <Display />
-      </Wrapper>
+      </Wrapper>,
     );
     expect(screen.getByTestId('currentKey').textContent).toBe('');
   });

--- a/dashboard/mini/src/api/hooks.ts
+++ b/dashboard/mini/src/api/hooks.ts
@@ -17,39 +17,47 @@ import {
   Status,
 } from './types';
 
-export const useRuns = (params: {
-  page: number;
-  pageSize: number;
-  status?: Status[];
-  dateFrom?: string;
-  dateTo?: string;
-  title?: string;
-}) =>
+export const useRuns = (
+  params: {
+    page: number;
+    pageSize: number;
+    status?: Status[];
+    dateFrom?: string;
+    dateTo?: string;
+    title?: string;
+  },
+  opts?: { enabled?: boolean },
+) =>
   useQuery<Page<Run>>({
     queryKey: ['runs', params],
     queryFn: ({ signal }) => listRuns(params, { signal }),
     staleTime: 5_000,
+    enabled: opts?.enabled,
   });
 
-export const useRun = (id: string) =>
+export const useRun = (id: string, opts?: { enabled?: boolean }) =>
   useQuery<RunDetail>({
     queryKey: ['run', id],
     queryFn: ({ signal }) => getRun(id, { signal }),
+    enabled: opts?.enabled,
   });
 
-export const useRunSummary = (id: string) =>
+export const useRunSummary = (id: string, opts?: { enabled?: boolean }) =>
   useQuery<{ summary: string }>({
     queryKey: ['run', id, 'summary'],
     queryFn: ({ signal }) => getRunSummary(id, { signal }),
+    enabled: opts?.enabled,
   });
 
 export const useRunNodes = (
   id: string,
   params: { page: number; pageSize: number },
+  opts?: { enabled?: boolean },
 ) =>
   useQuery<Page<NodeItem>>({
     queryKey: ['run', id, 'nodes', params],
     queryFn: ({ signal }) => listRunNodes(id, params, { signal }),
+    enabled: opts?.enabled,
   });
 
 export const useRunEvents = (
@@ -60,17 +68,21 @@ export const useRunEvents = (
     level?: 'info' | 'warn' | 'error' | 'debug';
     text?: string;
   },
+  opts?: { enabled?: boolean },
 ) =>
   useQuery<Page<EventItem>>({
     queryKey: ['run', id, 'events', params],
     queryFn: ({ signal }) => listRunEvents(id, params, { signal }),
+    enabled: opts?.enabled,
   });
 
 export const useNodeArtifacts = (
   nodeId: string,
   params: { page: number; pageSize: number; kind?: string },
+  opts?: { enabled?: boolean },
 ) =>
   useQuery<Page<ArtifactItem>>({
     queryKey: ['node', nodeId, 'artifacts', params],
     queryFn: ({ signal }) => listNodeArtifacts(nodeId, params, { signal }),
+    enabled: opts?.enabled,
   });

--- a/dashboard/mini/src/layouts/AppLayout.tsx
+++ b/dashboard/mini/src/layouts/AppLayout.tsx
@@ -1,0 +1,18 @@
+import type { JSX, ReactNode } from 'react';
+import ApiKeyBanner from '../components/ApiKeyBanner';
+
+export const AppLayout = ({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element => (
+  <div>
+    <header>
+      <h1>Mini Dashboard (read-only) — Fil G</h1>
+    </header>
+    <ApiKeyBanner />
+    <main>{children}</main>
+  </div>
+);
+
+export default AppLayout;

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRun, useRunSummary } from '../api/hooks';
+import { ApiError } from '../api/http';
+import { useApiKey } from '../state/ApiKeyContext';
+
+const RunDetailPage = (): JSX.Element => {
+  const { apiKey, useEnvKey } = useApiKey();
+  const hasKey = Boolean(apiKey) || useEnvKey;
+  const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+  const runQuery = useRun(id ?? '', { enabled: hasKey && Boolean(id) });
+  const summaryQuery = useRunSummary(id ?? '', {
+    enabled: hasKey && Boolean(id),
+  });
+
+  const retry = (): void => {
+    queryClient.invalidateQueries({ queryKey: ['run', id] });
+    queryClient.invalidateQueries({ queryKey: ['run', id, 'summary'] });
+  };
+
+  if (!hasKey) {
+    return <div>Veuillez saisir une clé API pour continuer.</div>;
+  }
+
+  if (runQuery.isLoading || summaryQuery.isLoading) {
+    return <div className="skeleton">Chargement...</div>;
+  }
+
+  if (runQuery.isError || summaryQuery.isError) {
+    const err = (runQuery.error ?? summaryQuery.error) as unknown;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  }
+
+  const run = runQuery.data;
+  if (!run) {
+    return <p>Aucune donnée.</p>;
+  }
+
+  return (
+    <div>
+      <h2>{run.title ?? run.id}</h2>
+      <p>{summaryQuery.data?.summary ?? ''}</p>
+      <section>DagView (placeholder)</section>
+      <section>Nodes (placeholder)</section>
+      <section>Events (placeholder)</section>
+      <section>Artifacts (placeholder)</section>
+    </div>
+  );
+};
+
+export default RunDetailPage;

--- a/dashboard/mini/src/pages/RunsPage.tsx
+++ b/dashboard/mini/src/pages/RunsPage.tsx
@@ -1,0 +1,76 @@
+import type { JSX } from 'react';
+import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRuns } from '../api/hooks';
+import { ApiError } from '../api/http';
+import { useApiKey } from '../state/ApiKeyContext';
+
+const RunsPage = (): JSX.Element => {
+  const { apiKey, useEnvKey } = useApiKey();
+  const hasKey = Boolean(apiKey) || useEnvKey;
+
+  const queryClient = useQueryClient();
+  const runsQuery = useRuns({ page: 1, pageSize: 20 }, { enabled: hasKey });
+
+  const retry = (): void => {
+    queryClient.invalidateQueries({ queryKey: ['runs'] });
+  };
+
+  if (!hasKey) {
+    return <div>Veuillez saisir une clé API pour continuer.</div>;
+  }
+
+  let content: JSX.Element;
+  if (runsQuery.isLoading) {
+    content = (
+      <ul>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <li key={i} className="skeleton">
+            Chargement...
+          </li>
+        ))}
+      </ul>
+    );
+  } else if (runsQuery.isError) {
+    const err = runsQuery.error;
+    content = (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  } else {
+    const items = runsQuery.data?.items ?? [];
+    if (items.length === 0) {
+      content = <p>Aucune donnée.</p>;
+    } else {
+      content = (
+        <ul>
+          {items.map((run) => (
+            <li key={run.id}>
+              <Link to={`/runs/${run.id}`}>{run.title ?? run.id}</Link>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          border: '1px solid #ccc',
+          padding: '8px',
+          marginBottom: '16px',
+        }}
+      >
+        Filtres (placeholder)
+      </div>
+      {content}
+    </div>
+  );
+};
+
+export default RunsPage;


### PR DESCRIPTION
## Résumé
- ajout d'un layout global avec bannière de clé API
- création des pages `/runs` et `/runs/:id` avec gestion des états et lien de navigation
- intégration de react-router-dom et des hooks de données avec invalidation via React Query

## Tests
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `pre-commit run --files dashboard/mini/package.json dashboard/mini/package-lock.json dashboard/mini/src/App.tsx dashboard/mini/src/layouts/AppLayout.tsx dashboard/mini/src/pages/RunsPage.tsx dashboard/mini/src/pages/RunDetailPage.tsx dashboard/mini/src/api/hooks.ts dashboard/mini/src/__tests__/ApiKeyBanner.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a9eaa7f28c83279eefaaad9c08f8af