### PR TITLE
feat: résumé et dag des runs

### DIFF
--- a/dashboard/mini/src/__tests__/components/DagView.test.tsx
+++ b/dashboard/mini/src/__tests__/components/DagView.test.tsx
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import DagView from '../../components/DagView';
+import type { RunDetail } from '../../api/types';
+
+describe('DagView', () => {
+  it('rend les nodes et les edges à partir du dag', () => {
+    const dag: NonNullable<RunDetail['dag']> = {
+      nodes: [
+        { id: 'n1', role: 'start', status: 'succeeded' },
+        { id: 'n2', role: 'end', status: 'failed' },
+      ],
+      edges: [{ from: 'n1', to: 'n2' }],
+    };
+    render(<DagView dag={dag} />);
+    expect(screen.getByTestId('dag-node-n1')).toBeInTheDocument();
+    expect(screen.getByTestId('dag-node-n2')).toBeInTheDocument();
+    expect(screen.getByTestId('dag-edge-n1-n2')).toBeInTheDocument();
+  });
+});

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -6,6 +6,7 @@ import {
   Page,
   Run,
   RunDetail,
+  RunSummary,
   Status,
 } from './types';
 
@@ -43,11 +44,8 @@ export const getRun = async (
 export const getRunSummary = async (
   id: string,
   opts: FetchOpts = {},
-): Promise<{ summary: string }> => {
-  const { data } = await fetchJson<{ summary: string }>(
-    `/runs/${id}/summary`,
-    opts,
-  );
+): Promise<RunSummary> => {
+  const { data } = await fetchJson<RunSummary>(`/runs/${id}/summary`, opts);
   return data;
 };
 

--- a/dashboard/mini/src/api/hooks.ts
+++ b/dashboard/mini/src/api/hooks.ts
@@ -14,6 +14,7 @@ import {
   Page,
   Run,
   RunDetail,
+  RunSummary,
   Status,
 } from './types';
 
@@ -43,7 +44,7 @@ export const useRun = (id: string, opts?: { enabled?: boolean }) =>
   });
 
 export const useRunSummary = (id: string, opts?: { enabled?: boolean }) =>
-  useQuery<{ summary: string }>({
+  useQuery<RunSummary>({
     queryKey: ['run', id, 'summary'],
     queryFn: ({ signal }) => getRunSummary(id, { signal }),
     enabled: opts?.enabled,

--- a/dashboard/mini/src/api/types.ts
+++ b/dashboard/mini/src/api/types.ts
@@ -25,8 +25,17 @@ export interface Run {
   counters?: { tokens_total?: number; nodes_total?: number; errors?: number };
 }
 
+export interface RunSummary {
+  nodes_total: number;
+  nodes_completed: number;
+  nodes_failed: number;
+  artifacts_total: number;
+  events_total: number;
+  duration_ms?: number;
+}
+
 export interface RunDetail extends Run {
-  summary?: string;
+  summary?: RunSummary;
   dag?: {
     nodes: Array<{ id: string; label?: string; role?: string; status: Status }>;
     edges: Array<{ from: string; to: string }>;

--- a/dashboard/mini/src/components/DagView.tsx
+++ b/dashboard/mini/src/components/DagView.tsx
@@ -1,0 +1,103 @@
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import type { RunDetail } from '../api/types';
+
+interface DagViewProps {
+  dag?: RunDetail['dag'];
+}
+
+const DagView = ({ dag }: DagViewProps): JSX.Element | null => {
+  const [rf, setRf] = useState<any>(null);
+
+  useEffect(() => {
+    const pkg = 'reactflow';
+    // @ts-ignore - résolution dynamique sans dépendance
+    import(/* @vite-ignore */ pkg)
+      .then((mod: any) => setRf(mod))
+      .catch(() => {
+        /* ignore, fallback */
+      });
+  }, []);
+
+  if (!dag) return null;
+
+  if (rf) {
+    const ReactFlow = rf.default;
+    const nodes = dag.nodes.map((n, idx) => ({
+      id: n.id,
+      position: { x: idx * 200, y: 0 },
+      data: { label: `${n.role ?? n.id} (${n.status})` },
+    }));
+    const edges = dag.edges.map((e) => ({
+      id: `${e.from}-${e.to}`,
+      source: e.from,
+      target: e.to,
+    }));
+    return (
+      <div style={{ width: '100%', height: 200 }} data-testid="dag-reactflow">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          panOnDrag
+          zoomOnScroll
+          fitView
+        />
+      </div>
+    );
+  }
+
+  const width = dag.nodes.length * 120 + 40;
+  const height = 120;
+  return (
+    <svg
+      width={width}
+      height={height}
+      data-testid="dag-fallback"
+      style={{ border: '1px solid #ccc' }}
+    >
+      {dag.edges.map((e, idx) => {
+        const fromIndex = dag.nodes.findIndex((n) => n.id === e.from);
+        const toIndex = dag.nodes.findIndex((n) => n.id === e.to);
+        const x1 = 60 + fromIndex * 120;
+        const x2 = 60 + toIndex * 120;
+        return (
+          <line
+            key={idx}
+            x1={x1}
+            y1={60}
+            x2={x2}
+            y2={60}
+            stroke="black"
+            markerEnd="url(#arrow)"
+            data-testid={`dag-edge-${e.from}-${e.to}`}
+          />
+        );
+      })}
+      <defs>
+        <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L9,3 z" fill="black" />
+        </marker>
+      </defs>
+      {dag.nodes.map((n, idx) => (
+        <g
+          key={n.id}
+          transform={`translate(${40 + idx * 120},40)`}
+          data-testid={`dag-node-${n.id}`}
+        >
+          <rect width="80" height="40" fill="#eee" stroke="#333" rx="4" />
+          <text x="40" y="18" dominantBaseline="middle" textAnchor="middle" fontSize="10">
+            {n.role ?? n.id}
+          </text>
+          <text x="40" y="32" dominantBaseline="middle" textAnchor="middle" fontSize="8">
+            {n.status}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+};
+
+export default DagView;

--- a/dashboard/mini/src/components/RunSummary.tsx
+++ b/dashboard/mini/src/components/RunSummary.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from 'react';
+import type { Run, RunSummary as RunSummaryType } from '../api/types';
+
+interface RunSummaryProps {
+  run: Run;
+  summary?: RunSummaryType;
+}
+
+const formatDate = (value?: string): string =>
+  value ? new Date(value).toLocaleString() : '—';
+
+const RunSummary = ({ run, summary }: RunSummaryProps): JSX.Element => {
+  return (
+    <div className="run-summary" data-testid="run-summary">
+      <p>
+        Statut: <span className={`badge status-${run.status}`}>{run.status}</span>
+      </p>
+      <p>Début: {formatDate(run.started_at)}</p>
+      <p>Fin: {formatDate(run.ended_at)}</p>
+      {summary && (
+        <ul>
+          {summary.duration_ms !== undefined && (
+            <li>Durée: {Math.round(summary.duration_ms / 1000)}s</li>
+          )}
+          <li>
+            Nœuds: {summary.nodes_completed}/{summary.nodes_total} (échecs: {summary.nodes_failed})
+          </li>
+          <li>Artifacts: {summary.artifacts_total}</li>
+          <li>Événements: {summary.events_total}</li>
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default RunSummary;

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -4,6 +4,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRun, useRunSummary } from '../api/hooks';
 import { ApiError } from '../api/http';
 import { useApiKey } from '../state/ApiKeyContext';
+import RunSummary from '../components/RunSummary';
+import DagView from '../components/DagView';
 
 const RunDetailPage = (): JSX.Element => {
   const { apiKey, useEnvKey } = useApiKey();
@@ -47,8 +49,10 @@ const RunDetailPage = (): JSX.Element => {
   return (
     <div>
       <h2>{run.title ?? run.id}</h2>
-      <p>{summaryQuery.data?.summary ?? ''}</p>
-      <section>DagView (placeholder)</section>
+      <RunSummary run={run} summary={summaryQuery.data} />
+      <section>
+        <DagView dag={run.dag} />
+      </section>
       <section>Nodes (placeholder)</section>
       <section>Events (placeholder)</section>
       <section>Artifacts (placeholder)</section>


### PR DESCRIPTION
## Résumé
- ajout du composant RunSummary pour afficher statut, horaires et compteurs d'un run
- ajout du composant DagView en lecture seule avec fallback SVG
- intégration du résumé et du DAG dans la page de détail d'un run
- test de rendu des noeuds et arêtes du DAG

## Tests
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a9f6b4fc4c8327acdfb8f2208ca868