### PR TITLE
feat: run detail tables for nodes, events and artifacts

### DIFF
--- a/dashboard/mini/src/__tests__/RunDetailPage.summary.test.tsx
+++ b/dashboard/mini/src/__tests__/RunDetailPage.summary.test.tsx
@@ -32,6 +32,21 @@ vi.mock('../api/hooks', () => ({
     isError: true,
     error: new Error('nope'),
   }),
+  useRunNodes: () => ({
+    data: { items: [], meta: { page: 1, page_size: 20, total: 0 } },
+    isLoading: false,
+    isError: false,
+  }),
+  useRunEvents: () => ({
+    data: { items: [], meta: { page: 1, page_size: 20, total: 0 } },
+    isLoading: false,
+    isError: false,
+  }),
+  useNodeArtifacts: () => ({
+    data: { items: [], meta: { page: 1, page_size: 50, total: 0 } },
+    isLoading: false,
+    isError: false,
+  }),
 }));
 
 import RunDetailPage from '../pages/RunDetailPage';

--- a/dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx
+++ b/dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import ArtifactsList, {
+  ArtifactsListProps,
+} from '../../components/ArtifactsList';
+import { ApiError } from '../../api/http';
+
+vi.mock('../../api/hooks', () => ({
+  useNodeArtifacts: vi.fn(),
+}));
+import { useNodeArtifacts } from '../../api/hooks';
+
+const setup = (props: Partial<ArtifactsListProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: ArtifactsListProps = {
+    runId: 'r1',
+    nodeId: 'n1',
+  };
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <ArtifactsList {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+  return { ...view, queryClient };
+};
+
+describe('ArtifactsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('affiche les artefacts', () => {
+    (useNodeArtifacts as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'a1',
+            node_id: 'n1',
+            name: 'f1',
+            kind: 'file',
+            size_bytes: 2048,
+            url: 'http://example.com',
+          },
+        ],
+        meta: { page: 1, page_size: 50, total: 1 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    setup();
+    expect(screen.getByText('f1')).toBeInTheDocument();
+    expect(screen.getByText('file')).toBeInTheDocument();
+  });
+
+  it("affiche l'état loading", () => {
+    (useNodeArtifacts as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    setup();
+    expect(screen.getAllByText('Chargement...').length).toBeGreaterThan(0);
+  });
+
+  it("affiche l'état vide", () => {
+    (useNodeArtifacts as unknown as Mock).mockReturnValue({
+      data: { items: [], meta: { page: 1, page_size: 50, total: 0 } },
+      isLoading: false,
+      isError: false,
+    });
+    setup();
+    expect(screen.getByText('Aucun artefact.')).toBeInTheDocument();
+  });
+
+  it("affiche l'erreur et relance sur retry", () => {
+    (useNodeArtifacts as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new ApiError('boom', 500, 'req-1'),
+    });
+    const { queryClient } = setup();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    fireEvent.click(screen.getByText('Réessayer'));
+    expect(spy).toHaveBeenCalled();
+    expect(screen.getByText('Request ID: req-1')).toBeInTheDocument();
+  });
+});

--- a/dashboard/mini/src/__tests__/components/EventsTable.test.tsx
+++ b/dashboard/mini/src/__tests__/components/EventsTable.test.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import EventsTable, { EventsTableProps } from '../../components/EventsTable';
+import { ApiError } from '../../api/http';
+
+vi.mock('../../api/hooks', () => ({
+  useRunEvents: vi.fn(),
+}));
+import { useRunEvents } from '../../api/hooks';
+
+const setup = (props: Partial<EventsTableProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: EventsTableProps = {
+    runId: 'r1',
+    page: 1,
+    pageSize: 20,
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+  };
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <EventsTable {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+  return { ...view, queryClient };
+};
+
+describe('EventsTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('affiche les événements', () => {
+    (useRunEvents as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'e1',
+            timestamp: '2023-01-01T00:00:00Z',
+            level: 'info',
+            message: 'hello',
+            request_id: 'r-1',
+          },
+        ],
+        meta: { page: 1, page_size: 20, total: 1 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    setup();
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.getByText('info')).toBeInTheDocument();
+  });
+
+  it("affiche l'état loading", () => {
+    (useRunEvents as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    setup();
+    expect(screen.getAllByText('Chargement...').length).toBeGreaterThan(0);
+  });
+
+  it("affiche l'état vide", () => {
+    (useRunEvents as unknown as Mock).mockReturnValue({
+      data: { items: [], meta: { page: 1, page_size: 20, total: 0 } },
+      isLoading: false,
+      isError: false,
+    });
+    setup();
+    expect(screen.getByText('Aucune donnée.')).toBeInTheDocument();
+  });
+
+  it("affiche l'erreur et relance sur retry", () => {
+    (useRunEvents as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new ApiError('boom', 500, 'req-1'),
+    });
+    const { queryClient } = setup();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    fireEvent.click(screen.getByText('Réessayer'));
+    expect(spy).toHaveBeenCalled();
+    expect(screen.getByText('Request ID: req-1')).toBeInTheDocument();
+  });
+});

--- a/dashboard/mini/src/__tests__/components/NodesTable.test.tsx
+++ b/dashboard/mini/src/__tests__/components/NodesTable.test.tsx
@@ -1,0 +1,96 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import NodesTable, { NodesTableProps } from '../../components/NodesTable';
+import { ApiError } from '../../api/http';
+
+vi.mock('../../api/hooks', () => ({
+  useRunNodes: vi.fn(),
+}));
+import { useRunNodes } from '../../api/hooks';
+
+const setup = (props: Partial<NodesTableProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: NodesTableProps = {
+    runId: 'r1',
+    page: 1,
+    pageSize: 20,
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+  };
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <NodesTable {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+  return { ...view, queryClient };
+};
+
+describe('NodesTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('affiche les items', () => {
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'n1',
+            role: 'start',
+            status: 'succeeded',
+            started_at: '2023-01-01T00:00:00Z',
+            ended_at: '2023-01-01T00:00:05Z',
+            duration_ms: 5000,
+            checksum: 'abc',
+          },
+        ],
+        meta: { page: 1, page_size: 20, total: 1 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    setup();
+    expect(screen.getByText('n1')).toBeInTheDocument();
+    expect(screen.getByText('start')).toBeInTheDocument();
+    expect(screen.getByText('abc')).toBeInTheDocument();
+  });
+
+  it("affiche l'état loading", () => {
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    setup();
+    expect(screen.getAllByText('Chargement...').length).toBeGreaterThan(0);
+  });
+
+  it("affiche l'état vide", () => {
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: { items: [], meta: { page: 1, page_size: 20, total: 0 } },
+      isLoading: false,
+      isError: false,
+    });
+    setup();
+    expect(screen.getByText('Aucune donnée.')).toBeInTheDocument();
+  });
+
+  it("affiche l'erreur et relance sur retry", () => {
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new ApiError('boom', 500, 'req-1'),
+    });
+    const { queryClient } = setup();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    fireEvent.click(screen.getByText('Réessayer'));
+    expect(spy).toHaveBeenCalled();
+    expect(screen.getByText('Request ID: req-1')).toBeInTheDocument();
+  });
+});

--- a/dashboard/mini/src/components/ArtifactsList.tsx
+++ b/dashboard/mini/src/components/ArtifactsList.tsx
@@ -1,0 +1,116 @@
+import type { JSX } from 'react';
+import { useNodeArtifacts } from '../api/hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { ApiError } from '../api/http';
+
+export type ArtifactsListProps = {
+  runId: string;
+  nodeId?: string;
+};
+
+const formatSize = (bytes?: number): string => {
+  if (bytes === undefined) return '-';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let i = -1;
+  let value = bytes;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  return `${value.toFixed(1)} ${units[i]}`;
+};
+
+const ArtifactsList = ({
+  runId: _runId,
+  nodeId,
+}: ArtifactsListProps): JSX.Element => {
+  void _runId;
+  const params = { page: 1, pageSize: 50 };
+  const queryClient = useQueryClient();
+  const artifactsQuery = useNodeArtifacts(nodeId ?? '', params, {
+    enabled: Boolean(nodeId),
+  });
+
+  const retry = (): void => {
+    if (nodeId) {
+      queryClient.invalidateQueries({
+        queryKey: ['node', nodeId, 'artifacts', params],
+      });
+    }
+  };
+
+  if (!nodeId) {
+    return <p>Aucun nœud sélectionné.</p>;
+  }
+
+  if (artifactsQuery.isLoading) {
+    return (
+      <table>
+        <caption>Artifacts</caption>
+        <thead>
+          <tr>
+            <th>Nom</th>
+            <th>Type</th>
+            <th>Taille</th>
+            <th>Télécharger</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <tr key={i} className="skeleton">
+              <td colSpan={4}>Chargement...</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  if (artifactsQuery.isError) {
+    const err = artifactsQuery.error as unknown;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  }
+
+  const items = artifactsQuery.data?.items ?? [];
+
+  if (items.length === 0) {
+    return <p>Aucun artefact.</p>;
+  }
+
+  return (
+    <table>
+      <caption>Artifacts</caption>
+      <thead>
+        <tr>
+          <th>Nom</th>
+          <th>Type</th>
+          <th>Taille</th>
+          <th>Télécharger</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((a) => (
+          <tr key={a.id}>
+            <td>{a.name}</td>
+            <td>{a.kind}</td>
+            <td>{formatSize(a.size_bytes)}</td>
+            <td>
+              <a href={a.url} target="_blank" rel="noreferrer">
+                Télécharger
+              </a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default ArtifactsList;

--- a/dashboard/mini/src/components/EventsTable.tsx
+++ b/dashboard/mini/src/components/EventsTable.tsx
@@ -1,0 +1,139 @@
+import type { JSX } from 'react';
+import { useRunEvents } from '../api/hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { ApiError } from '../api/http';
+
+export type EventsTableProps = {
+  runId: string;
+  page: number;
+  pageSize: number;
+  level?: 'info' | 'warn' | 'error' | 'debug';
+  text?: string;
+  onPageChange: (nextPage: number) => void;
+  onPageSizeChange: (size: number) => void;
+};
+
+const formatDate = (d?: string): string =>
+  d ? new Date(d).toLocaleString() : '-';
+
+const EventsTable = ({
+  runId,
+  page,
+  pageSize,
+  level,
+  text,
+  onPageChange,
+  onPageSizeChange,
+}: EventsTableProps): JSX.Element => {
+  const params = { page, pageSize, level, text };
+  const queryClient = useQueryClient();
+  const eventsQuery = useRunEvents(runId, params, {
+    enabled: Boolean(runId),
+  });
+
+  const retry = (): void => {
+    queryClient.invalidateQueries({
+      queryKey: ['run', runId, 'events', params],
+    });
+  };
+
+  if (eventsQuery.isLoading) {
+    return (
+      <table>
+        <caption>Events</caption>
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>Niveau</th>
+            <th>Message</th>
+            <th>Request ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <tr key={i} className="skeleton">
+              <td colSpan={4}>Chargement...</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  if (eventsQuery.isError) {
+    const err = eventsQuery.error as unknown;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  }
+
+  const items = eventsQuery.data?.items ?? [];
+  const meta = eventsQuery.data?.meta;
+
+  if (items.length === 0) {
+    return <p>Aucune donnée.</p>;
+  }
+
+  const total = meta?.total ?? 0;
+  const currentPage = meta?.page ?? page;
+  const size = meta?.page_size ?? pageSize;
+  const maxPage = size > 0 ? Math.ceil(total / size) : 1;
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < maxPage;
+
+  return (
+    <div>
+      <table>
+        <caption>Events</caption>
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>Niveau</th>
+            <th>Message</th>
+            <th>Request ID</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((ev) => (
+            <tr key={ev.id}>
+              <td>{formatDate(ev.timestamp)}</td>
+              <td>
+                <span className={`badge level-${ev.level}`}>{ev.level}</span>
+              </td>
+              <td>{ev.message}</td>
+              <td>{ev.request_id ?? '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{ marginTop: '8px' }}>
+        <button onClick={() => onPageChange(page - 1)} disabled={!hasPrev}>
+          Précédent
+        </button>
+        <span style={{ margin: '0 8px' }}>
+          Page {currentPage} / {maxPage || 1}
+        </span>
+        <button onClick={() => onPageChange(page + 1)} disabled={!hasNext}>
+          Suivant
+        </button>
+        <select
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value))}
+          style={{ marginLeft: '8px' }}
+        >
+          {[10, 20, 50].map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default EventsTable;

--- a/dashboard/mini/src/components/NodesTable.tsx
+++ b/dashboard/mini/src/components/NodesTable.tsx
@@ -1,0 +1,164 @@
+import type { JSX } from 'react';
+import { useRunNodes } from '../api/hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { ApiError } from '../api/http';
+
+export type NodesTableProps = {
+  runId: string;
+  page: number;
+  pageSize: number;
+  onPageChange: (nextPage: number) => void;
+  onPageSizeChange: (size: number) => void;
+};
+
+const formatDate = (d?: string): string =>
+  d ? new Date(d).toLocaleString() : '-';
+
+const formatDuration = (ms?: number): string =>
+  ms !== undefined ? `${Math.round(ms / 1000)}s` : '-';
+
+const NodesTable = ({
+  runId,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}: NodesTableProps): JSX.Element => {
+  const params = { page, pageSize };
+  const queryClient = useQueryClient();
+  const nodesQuery = useRunNodes(runId, params, {
+    enabled: Boolean(runId),
+  });
+
+  const retry = (): void => {
+    queryClient.invalidateQueries({
+      queryKey: ['run', runId, 'nodes', params],
+    });
+  };
+
+  if (nodesQuery.isLoading) {
+    return (
+      <table>
+        <caption>Nodes</caption>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Rôle</th>
+            <th>Statut</th>
+            <th>Début</th>
+            <th>Fin</th>
+            <th>Durée</th>
+            <th>Checksum</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <tr key={i} className="skeleton">
+              <td colSpan={7}>Chargement...</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  if (nodesQuery.isError) {
+    const err = nodesQuery.error as unknown;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  }
+
+  const items = nodesQuery.data?.items ?? [];
+  const meta = nodesQuery.data?.meta;
+
+  if (items.length === 0) {
+    return <p>Aucune donnée.</p>;
+  }
+
+  const total = meta?.total ?? 0;
+  const currentPage = meta?.page ?? page;
+  const size = meta?.page_size ?? pageSize;
+  const maxPage = size > 0 ? Math.ceil(total / size) : 1;
+
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < maxPage;
+
+  const calcDuration = (
+    started?: string,
+    ended?: string,
+    dms?: number,
+  ): string => {
+    let ms = dms;
+    if (ms === undefined && started && ended) {
+      ms = new Date(ended).getTime() - new Date(started).getTime();
+    }
+    return formatDuration(ms);
+  };
+
+  return (
+    <div>
+      <table>
+        <caption>Nodes</caption>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Rôle</th>
+            <th>Statut</th>
+            <th>Début</th>
+            <th>Fin</th>
+            <th>Durée</th>
+            <th>Checksum</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((node) => (
+            <tr key={node.id}>
+              <td>{node.id}</td>
+              <td>{node.role ?? '-'}</td>
+              <td>
+                <span className={`badge status-${node.status}`}>
+                  {node.status}
+                </span>
+              </td>
+              <td>{formatDate(node.started_at)}</td>
+              <td>{formatDate(node.ended_at)}</td>
+              <td>
+                {calcDuration(node.started_at, node.ended_at, node.duration_ms)}
+              </td>
+              <td>{node.checksum ?? '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{ marginTop: '8px' }}>
+        <button onClick={() => onPageChange(page - 1)} disabled={!hasPrev}>
+          Précédent
+        </button>
+        <span style={{ margin: '0 8px' }}>
+          Page {currentPage} / {maxPage || 1}
+        </span>
+        <button onClick={() => onPageChange(page + 1)} disabled={!hasNext}>
+          Suivant
+        </button>
+        <select
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value))}
+          style={{ marginLeft: '8px' }}
+        >
+          {[10, 20, 50].map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default NodesTable;

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRun, useRunSummary } from '../api/hooks';
@@ -6,6 +7,9 @@ import { ApiError } from '../api/http';
 import { useApiKey } from '../state/ApiKeyContext';
 import RunSummary from '../components/RunSummary';
 import DagView from '../components/DagView';
+import NodesTable from '../components/NodesTable';
+import EventsTable from '../components/EventsTable';
+import ArtifactsList from '../components/ArtifactsList';
 
 const RunDetailPage = (): JSX.Element => {
   const { apiKey, useEnvKey } = useApiKey();
@@ -16,6 +20,11 @@ const RunDetailPage = (): JSX.Element => {
   const summaryQuery = useRunSummary(id ?? '', {
     enabled: hasKey && Boolean(id),
   });
+
+  const [nodesPage, setNodesPage] = useState(1);
+  const [nodesPageSize, setNodesPageSize] = useState(20);
+  const [eventsPage, setEventsPage] = useState(1);
+  const [eventsPageSize, setEventsPageSize] = useState(20);
 
   const retry = (): void => {
     queryClient.invalidateQueries({ queryKey: ['run', id] });
@@ -61,9 +70,36 @@ const RunDetailPage = (): JSX.Element => {
           <DagView dag={run.dag} />
         </section>
       )}
-      <section>Nodes (placeholder)</section>
-      <section>Events (placeholder)</section>
-      <section>Artifacts (placeholder)</section>
+      <section>
+        <h3>Nodes</h3>
+        <NodesTable
+          runId={run.id}
+          page={nodesPage}
+          pageSize={nodesPageSize}
+          onPageChange={setNodesPage}
+          onPageSizeChange={(s) => {
+            setNodesPageSize(s);
+            setNodesPage(1);
+          }}
+        />
+      </section>
+      <section>
+        <h3>Events</h3>
+        <EventsTable
+          runId={run.id}
+          page={eventsPage}
+          pageSize={eventsPageSize}
+          onPageChange={setEventsPage}
+          onPageSizeChange={(s) => {
+            setEventsPageSize(s);
+            setEventsPage(1);
+          }}
+        />
+      </section>
+      <section>
+        <h3>Artifacts</h3>
+        <ArtifactsList runId={run.id} />
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add NodesTable, EventsTable and ArtifactsList components
- show these tables on RunDetailPage with pagination
- cover loading, empty and error states with unit tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa15773b4c8327a756a8678ba37aa8