### PR TITLE
feat: node selection and event filters

### DIFF
--- a/dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx
+++ b/dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx
@@ -77,6 +77,16 @@ describe('ArtifactsList', () => {
     expect(screen.getByText('Aucun artefact.')).toBeInTheDocument();
   });
 
+  it("affiche le message lorsqu'aucun nœud n'est sélectionné", () => {
+    (useNodeArtifacts as unknown as Mock).mockReturnValue({
+      data: { items: [], meta: { page: 1, page_size: 50, total: 0 } },
+      isLoading: false,
+      isError: false,
+    });
+    setup({ nodeId: undefined });
+    expect(screen.getByText('Aucun nœud sélectionné.')).toBeInTheDocument();
+  });
+
   it("affiche l'erreur et relance sur retry", () => {
     (useNodeArtifacts as unknown as Mock).mockReturnValue({
       data: undefined,

--- a/dashboard/mini/src/__tests__/components/EventsTable.filters.test.tsx
+++ b/dashboard/mini/src/__tests__/components/EventsTable.filters.test.tsx
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import EventsTable, { EventsTableProps } from '../../components/EventsTable';
+
+vi.mock('../../api/hooks', () => ({
+  useRunEvents: vi.fn(),
+}));
+import { useRunEvents } from '../../api/hooks';
+
+const setup = (props: Partial<EventsTableProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: EventsTableProps = {
+    runId: 'r1',
+    page: 1,
+    pageSize: 20,
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+  };
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <EventsTable {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+  return { ...view, queryClient };
+};
+
+describe('EventsTable filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it('déclenche les callbacks de filtre', () => {
+    (useRunEvents as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'e1',
+            timestamp: '2023-01-01T00:00:00Z',
+            level: 'info',
+            message: 'hello',
+            request_id: 'r1',
+          },
+        ],
+        meta: { page: 1, page_size: 20, total: 1 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    const onLevelChange = vi.fn();
+    const onTextChange = vi.fn();
+    const onPageChange = vi.fn();
+    setup({ onLevelChange, onTextChange, onPageChange });
+
+    fireEvent.change(screen.getByTestId('events-level-filter'), {
+      target: { value: 'error' },
+    });
+    expect(onLevelChange).toHaveBeenCalledWith('error');
+
+    fireEvent.change(screen.getByTestId('events-text-filter'), {
+      target: { value: 'abc' },
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(onTextChange).toHaveBeenCalledWith('abc');
+
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/mini/src/__tests__/components/EventsTable.test.tsx
+++ b/dashboard/mini/src/__tests__/components/EventsTable.test.tsx
@@ -54,7 +54,7 @@ describe('EventsTable', () => {
     });
     setup();
     expect(screen.getByText('hello')).toBeInTheDocument();
-    expect(screen.getByText('info')).toBeInTheDocument();
+    expect(screen.getAllByText('info')[1]).toBeInTheDocument();
   });
 
   it("affiche l'état loading", () => {

--- a/dashboard/mini/src/__tests__/components/NodesTable.select.test.tsx
+++ b/dashboard/mini/src/__tests__/components/NodesTable.select.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import NodesTable, { NodesTableProps } from '../../components/NodesTable';
+
+vi.mock('../../api/hooks', () => ({
+  useRunNodes: vi.fn(),
+}));
+import { useRunNodes } from '../../api/hooks';
+
+const setup = (props: Partial<NodesTableProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: NodesTableProps = {
+    runId: 'r1',
+    page: 1,
+    pageSize: 20,
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+  };
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <NodesTable {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+  return { ...view, queryClient };
+};
+
+describe('NodesTable selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('appelle onSelectNode lors du clic', () => {
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          { id: 'n1', status: 'succeeded', role: 'r1' },
+          { id: 'n2', status: 'succeeded', role: 'r2' },
+        ],
+        meta: { page: 1, page_size: 20, total: 2 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    const onSelect = vi.fn();
+    setup({ onSelectNode: onSelect });
+    fireEvent.click(screen.getByTestId('node-row-n1'));
+    expect(onSelect).toHaveBeenCalledWith('n1');
+  });
+
+  it('applique le style sélectionné', () => {
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          { id: 'n1', status: 'succeeded', role: 'r1' },
+          { id: 'n2', status: 'succeeded', role: 'r2' },
+        ],
+        meta: { page: 1, page_size: 20, total: 2 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    setup({ selectedNodeId: 'n1' });
+    const row = screen.getByTestId('node-row-n1');
+    expect(row).toHaveStyle({ background: '#eef' });
+    expect(row).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/dashboard/mini/src/__tests__/pages/RunDetailPage.events-and-artifacts.test.tsx
+++ b/dashboard/mini/src/__tests__/pages/RunDetailPage.events-and-artifacts.test.tsx
@@ -1,0 +1,150 @@
+import '@testing-library/jest-dom';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  within,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('../../state/ApiKeyContext', () => ({
+  useApiKey: () => ({ apiKey: 'k', useEnvKey: false }),
+}));
+
+vi.mock('../../api/hooks', () => ({
+  useRun: vi.fn(),
+  useRunSummary: vi.fn(),
+  useRunNodes: vi.fn(),
+  useRunEvents: vi.fn(),
+  useNodeArtifacts: vi.fn(),
+}));
+
+import {
+  useRun,
+  useRunSummary,
+  useRunNodes,
+  useRunEvents,
+  useNodeArtifacts,
+} from '../../api/hooks';
+import RunDetailPage from '../../pages/RunDetailPage';
+
+describe('RunDetailPage events and artifacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gère la sélection et les filtres', async () => {
+    const run = { id: '1', title: 'r1', status: 'queued' as const };
+    (useRun as unknown as Mock).mockReturnValue({
+      data: run,
+      isLoading: false,
+      isError: false,
+    });
+    (useRunSummary as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+    (useRunNodes as unknown as Mock).mockReturnValue({
+      data: {
+        items: [
+          { id: 'n1', status: 'succeeded', role: 'r1' },
+          { id: 'n2', status: 'succeeded', role: 'r2' },
+        ],
+        meta: { page: 1, page_size: 20, total: 2 },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    (useRunEvents as unknown as Mock).mockImplementation(
+      (
+        _id: string,
+        params: {
+          page: number;
+          pageSize: number;
+          level?: string;
+          text?: string;
+        },
+      ) => ({
+        data: {
+          items: [
+            {
+              id: 'e1',
+              timestamp: '2023-01-01T00:00:00Z',
+              level: 'info',
+              message: 'hello',
+              request_id: 'r1',
+            },
+          ],
+          meta: { page: params.page, page_size: params.pageSize, total: 40 },
+        },
+        isLoading: false,
+        isError: false,
+      }),
+    );
+    (useNodeArtifacts as unknown as Mock).mockReturnValue({
+      data: { items: [], meta: { page: 1, page_size: 50, total: 0 } },
+      isLoading: false,
+      isError: false,
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/runs/1']}>
+          <Routes>
+            <Route path="/runs/:id" element={<RunDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId('node-row-n1'));
+    await waitFor(() => {
+      const calls = (useNodeArtifacts as unknown as Mock).mock.calls;
+      const last = calls[calls.length - 1];
+      expect(last?.[0]).toBe('n1');
+    });
+
+    const eventsSection = screen
+      .getByRole('heading', { name: 'Events' })
+      .closest('section');
+    if (!eventsSection) throw new Error('section not found');
+    fireEvent.click(within(eventsSection).getByText('Suivant'));
+    await waitFor(() => {
+      const calls = (useRunEvents as unknown as Mock).mock.calls;
+      const last = calls[calls.length - 1];
+      expect(last?.[1].page).toBe(2);
+    });
+
+    fireEvent.change(screen.getByLabelText('level-filter'), {
+      target: { value: 'error' },
+    });
+    await waitFor(() => {
+      const calls = (useRunEvents as unknown as Mock).mock.calls;
+      const last = calls[calls.length - 1];
+      expect(last?.[1].level).toBe('error');
+      expect(last?.[1].page).toBe(1);
+    });
+
+    fireEvent.change(screen.getByLabelText('text-filter'), {
+      target: { value: 'foo' },
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 350));
+    });
+    await waitFor(() => {
+      const calls = (useRunEvents as unknown as Mock).mock.calls;
+      const last = calls[calls.length - 1];
+      expect(last?.[1].text).toBe('foo');
+      expect(last?.[1].page).toBe(1);
+    });
+  });
+});

--- a/dashboard/mini/src/components/NodesTable.tsx
+++ b/dashboard/mini/src/components/NodesTable.tsx
@@ -7,6 +7,8 @@ export type NodesTableProps = {
   runId: string;
   page: number;
   pageSize: number;
+  selectedNodeId?: string;
+  onSelectNode?: (nodeId: string) => void;
   onPageChange: (nextPage: number) => void;
   onPageSizeChange: (size: number) => void;
 };
@@ -21,6 +23,8 @@ const NodesTable = ({
   runId,
   page,
   pageSize,
+  selectedNodeId,
+  onSelectNode,
   onPageChange,
   onPageSizeChange,
 }: NodesTableProps): JSX.Element => {
@@ -117,7 +121,15 @@ const NodesTable = ({
         </thead>
         <tbody>
           {items.map((node) => (
-            <tr key={node.id}>
+            <tr
+              key={node.id}
+              data-testid={`node-row-${node.id}`}
+              onClick={onSelectNode ? () => onSelectNode(node.id) : undefined}
+              style={{
+                background: node.id === selectedNodeId ? '#eef' : undefined,
+              }}
+              aria-selected={node.id === selectedNodeId}
+            >
               <td>{node.id}</td>
               <td>{node.role ?? '-'}</td>
               <td>

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -25,6 +25,13 @@ const RunDetailPage = (): JSX.Element => {
   const [nodesPageSize, setNodesPageSize] = useState(20);
   const [eventsPage, setEventsPage] = useState(1);
   const [eventsPageSize, setEventsPageSize] = useState(20);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>(
+    undefined,
+  );
+  const [eventsLevel, setEventsLevel] = useState<
+    'debug' | 'info' | 'warn' | 'error' | undefined
+  >(undefined);
+  const [eventsText, setEventsText] = useState('');
 
   const retry = (): void => {
     queryClient.invalidateQueries({ queryKey: ['run', id] });
@@ -76,6 +83,8 @@ const RunDetailPage = (): JSX.Element => {
           runId={run.id}
           page={nodesPage}
           pageSize={nodesPageSize}
+          selectedNodeId={selectedNodeId}
+          onSelectNode={setSelectedNodeId}
           onPageChange={setNodesPage}
           onPageSizeChange={(s) => {
             setNodesPageSize(s);
@@ -89,6 +98,16 @@ const RunDetailPage = (): JSX.Element => {
           runId={run.id}
           page={eventsPage}
           pageSize={eventsPageSize}
+          level={eventsLevel}
+          text={eventsText}
+          onLevelChange={(lvl) => {
+            setEventsLevel(lvl);
+            setEventsPage(1);
+          }}
+          onTextChange={(t) => {
+            setEventsText(t);
+            setEventsPage(1);
+          }}
           onPageChange={setEventsPage}
           onPageSizeChange={(s) => {
             setEventsPageSize(s);
@@ -98,7 +117,7 @@ const RunDetailPage = (): JSX.Element => {
       </section>
       <section>
         <h3>Artifacts</h3>
-        <ArtifactsList runId={run.id} />
+        <ArtifactsList runId={run.id} nodeId={selectedNodeId} />
       </section>
     </div>
   );


### PR DESCRIPTION
## Résumé
- ajout de la sélection de nœud dans NodesTable et affichage des artefacts associés
- ajout de filtres par niveau et texte sur EventsTable avec debounce
- couverture de tests pour la sélection, les artefacts et les filtres d'événements

## Tests
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68aa1aa1957c83279e78accea3863d92