### PR TITLE
feat(dashboard): ajoute des onglets sur la page de run

### DIFF
--- a/dashboard/mini/src/__tests__/RunDetailPage.tabs.test.tsx
+++ b/dashboard/mini/src/__tests__/RunDetailPage.tabs.test.tsx
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('../state/ApiKeyContext', () => ({
+  useApiKey: () => ({ apiKey: 'k', useEnvKey: false }),
+}));
+
+const run = { id: '1', title: 'r1', status: 'queued' as const };
+const nodes = [{ id: 'n1', status: 'succeeded', role: 'r1' }];
+
+type UseReturn = {
+  data: unknown;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+vi.mock('../api/hooks', () => ({
+  useRun: (): UseReturn => ({ data: run, isLoading: false, isError: false }),
+  useRunSummary: (): UseReturn => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  }),
+  useRunNodes: (): UseReturn => ({
+    data: { items: nodes, meta: { page: 1, page_size: 20, total: 1 } },
+    isLoading: false,
+    isError: false,
+  }),
+  useRunEvents: (): UseReturn => ({
+    data: { items: [], meta: { page: 1, page_size: 20, total: 0 } },
+    isLoading: false,
+    isError: false,
+  }),
+  useNodeArtifacts: (): UseReturn => ({
+    data: { items: [], meta: { page: 1, page_size: 50, total: 0 } },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+import RunDetailPage from '../pages/RunDetailPage';
+
+describe('RunDetailPage tabs', () => {
+  it('affiche et utilise les onglets', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/runs/1']}>
+          <Routes>
+            <Route path="/runs/:id" element={<RunDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    ['Résumé', 'DAG', 'Nodes', 'Events', 'Artifacts'].forEach((t) =>
+      expect(screen.getByRole('tab', { name: t })).toBeInTheDocument(),
+    );
+
+    expect(screen.getByRole('tab', { name: 'Résumé' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Nodes' }));
+    expect(screen.getByRole('tab', { name: 'Nodes' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await screen.findByRole('table', { name: 'Nodes' });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Artifacts' }));
+    expect(screen.getByRole('tab', { name: 'Artifacts' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await screen.findByText('Aucun nœud sélectionné.');
+  });
+});

--- a/dashboard/mini/src/__tests__/pages/RunDetailPage.events-and-artifacts.test.tsx
+++ b/dashboard/mini/src/__tests__/pages/RunDetailPage.events-and-artifacts.test.tsx
@@ -5,7 +5,6 @@ import {
   fireEvent,
   waitFor,
   act,
-  within,
 } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
@@ -106,18 +105,17 @@ describe('RunDetailPage events and artifacts', () => {
       </QueryClientProvider>,
     );
 
+    fireEvent.click(screen.getByRole('tab', { name: 'Nodes' }));
     fireEvent.click(await screen.findByTestId('node-row-n1'));
+    fireEvent.click(screen.getByRole('tab', { name: 'Artifacts' }));
     await waitFor(() => {
       const calls = (useNodeArtifacts as unknown as Mock).mock.calls;
       const last = calls[calls.length - 1];
       expect(last?.[0]).toBe('n1');
     });
 
-    const eventsSection = screen
-      .getByRole('heading', { name: 'Events' })
-      .closest('section');
-    if (!eventsSection) throw new Error('section not found');
-    fireEvent.click(within(eventsSection).getByText('Suivant'));
+    fireEvent.click(screen.getByRole('tab', { name: 'Events' }));
+    fireEvent.click(screen.getByText('Suivant'));
     await waitFor(() => {
       const calls = (useRunEvents as unknown as Mock).mock.calls;
       const last = calls[calls.length - 1];

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -21,6 +21,9 @@ const RunDetailPage = (): JSX.Element => {
     enabled: hasKey && Boolean(id),
   });
 
+  const [activeTab, setActiveTab] = useState<
+    'summary' | 'dag' | 'nodes' | 'events' | 'artifacts'
+  >('summary');
   const [nodesPage, setNodesPage] = useState(1);
   const [nodesPageSize, setNodesPageSize] = useState(20);
   const [eventsPage, setEventsPage] = useState(1);
@@ -71,54 +74,96 @@ const RunDetailPage = (): JSX.Element => {
   return (
     <div>
       <h2>{run.title ?? run.id}</h2>
-      {summary && <RunSummary run={run} summary={summary} />}
-      {run.dag && (
+      <nav role="tablist">
+        <button
+          role="tab"
+          aria-selected={activeTab === 'summary'}
+          onClick={() => setActiveTab('summary')}
+        >
+          Résumé
+        </button>
+        <button
+          role="tab"
+          aria-selected={activeTab === 'dag'}
+          onClick={() => setActiveTab('dag')}
+        >
+          DAG
+        </button>
+        <button
+          role="tab"
+          aria-selected={activeTab === 'nodes'}
+          onClick={() => setActiveTab('nodes')}
+        >
+          Nodes
+        </button>
+        <button
+          role="tab"
+          aria-selected={activeTab === 'events'}
+          onClick={() => setActiveTab('events')}
+        >
+          Events
+        </button>
+        <button
+          role="tab"
+          aria-selected={activeTab === 'artifacts'}
+          onClick={() => setActiveTab('artifacts')}
+        >
+          Artifacts
+        </button>
+      </nav>
+      {activeTab === 'summary' && summary && (
+        <RunSummary run={run} summary={summary} />
+      )}
+      {activeTab === 'dag' && run.dag && (
         <section>
           <DagView dag={run.dag} />
         </section>
       )}
-      <section>
-        <h3>Nodes</h3>
-        <NodesTable
-          runId={run.id}
-          page={nodesPage}
-          pageSize={nodesPageSize}
-          selectedNodeId={selectedNodeId}
-          onSelectNode={setSelectedNodeId}
-          onPageChange={setNodesPage}
-          onPageSizeChange={(s) => {
-            setNodesPageSize(s);
-            setNodesPage(1);
-          }}
-        />
-      </section>
-      <section>
-        <h3>Events</h3>
-        <EventsTable
-          runId={run.id}
-          page={eventsPage}
-          pageSize={eventsPageSize}
-          level={eventsLevel}
-          text={eventsText}
-          onLevelChange={(lvl) => {
-            setEventsLevel(lvl);
-            setEventsPage(1);
-          }}
-          onTextChange={(t) => {
-            setEventsText(t);
-            setEventsPage(1);
-          }}
-          onPageChange={setEventsPage}
-          onPageSizeChange={(s) => {
-            setEventsPageSize(s);
-            setEventsPage(1);
-          }}
-        />
-      </section>
-      <section>
-        <h3>Artifacts</h3>
-        <ArtifactsList runId={run.id} nodeId={selectedNodeId} />
-      </section>
+      {activeTab === 'nodes' && (
+        <section>
+          <NodesTable
+            runId={run.id}
+            page={nodesPage}
+            pageSize={nodesPageSize}
+            selectedNodeId={selectedNodeId}
+            onSelectNode={setSelectedNodeId}
+            onPageChange={setNodesPage}
+            onPageSizeChange={(s) => {
+              setNodesPageSize(s);
+              setNodesPage(1);
+            }}
+          />
+        </section>
+      )}
+      {activeTab === 'events' && (
+        <section>
+          <EventsTable
+            runId={run.id}
+            page={eventsPage}
+            pageSize={eventsPageSize}
+            level={eventsLevel}
+            text={eventsText}
+            onLevelChange={(lvl) => {
+              setEventsLevel(lvl);
+              setEventsPage(1);
+            }}
+            onTextChange={(t) => {
+              setEventsText(t);
+              setEventsPage(1);
+            }}
+            onPageChange={setEventsPage}
+            onPageSizeChange={(s) => {
+              setEventsPageSize(s);
+              setEventsPage(1);
+            }}
+          />
+        </section>
+      )}
+      {activeTab === 'artifacts' && (
+        <section>
+          <ArtifactsList runId={run.id} nodeId={selectedNodeId} />
+        </section>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Résumé
- navigation par onglets pour Résumé, DAG, Nodes, Events et Artifacts
- mise à jour des tests existants et ajout d'un test des onglets

## Tests
- `cd dashboard/mini && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68aa200e89d8832798f6439aa62504af