### PR TITLE
feat(front): configuration runtime de l'URL API

### DIFF
--- a/dashboard/mini/src/__tests__/api/ping.test.ts
+++ b/dashboard/mini/src/__tests__/api/ping.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pingApi } from '../../api/ping';
+import { setCurrentApiKey } from '../../state/ApiKeyContext';
+
+describe('pingApi', () => {
+  it('retourne ok=true et le status quand la connexion réussit', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    await expect(pingApi('http://test')).resolves.toEqual({ ok: true, status: 200 });
+  });
+
+  it("retourne ok=false en cas d'erreur réseau", async () => {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error('fail'));
+    await expect(pingApi('http://fail')).resolves.toEqual({ ok: false });
+  });
+
+  it('ajoute l\'en-tête X-API-Key si une clé est définie', async () => {
+    setCurrentApiKey('key');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    global.fetch = fetchMock;
+    await pingApi('http://test');
+    expect(fetchMock).toHaveBeenCalledWith('http://test/runs?limit=1', {
+      headers: { 'X-API-Key': 'key' },
+    });
+    setCurrentApiKey(undefined);
+  });
+});

--- a/dashboard/mini/src/__tests__/config/env.test.ts
+++ b/dashboard/mini/src/__tests__/config/env.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('config/env', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it('utilise la valeur de l\'env par défaut', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://env-url');
+    const { getApiBaseUrl } = await import('../../config/env');
+    expect(getApiBaseUrl()).toBe('http://env-url');
+  });
+
+  it('utilise la valeur sauvegardée', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://env-url');
+    const { getApiBaseUrl, setApiBaseUrl } = await import('../../config/env');
+    setApiBaseUrl('http://override/');
+    expect(getApiBaseUrl()).toBe('http://override');
+  });
+
+  it('retourne le fallback local', async () => {
+    const { getApiBaseUrl } = await import('../../config/env');
+    expect(getApiBaseUrl()).toBe('http://localhost:8000');
+  });
+});

--- a/dashboard/mini/src/api/http.ts
+++ b/dashboard/mini/src/api/http.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { API_BASE_URL, API_TIMEOUT_MS } from '../config/env';
+import { getApiBaseUrl, API_TIMEOUT_MS } from '../config/env';
 import { getCurrentApiKey } from '../state/ApiKeyContext';
 
 export class ApiError extends Error {
@@ -29,7 +29,7 @@ export async function fetchJson<T>(
   path: string,
   opts: FetchOpts = {},
 ): Promise<{ data: T; requestId: string }> {
-  const url = new URL(API_BASE_URL + path);
+  const url = new URL(getApiBaseUrl() + path);
   if (opts.query) {
     for (const [key, value] of Object.entries(opts.query)) {
       if (value !== undefined) {

--- a/dashboard/mini/src/api/ping.ts
+++ b/dashboard/mini/src/api/ping.ts
@@ -1,0 +1,20 @@
+import { getCurrentApiKey } from '../state/ApiKeyContext';
+
+export async function pingApi(
+  baseUrl: string,
+): Promise<{ ok: boolean; status?: number }> {
+  const clean = baseUrl.replace(/\/+$/, '');
+  const headers: Record<string, string> = {};
+  const apiKey = getCurrentApiKey();
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+  try {
+    const res = await fetch(`${clean}/runs?limit=1`, { headers });
+    return { ok: res.ok, status: res.status };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export default pingApi;

--- a/dashboard/mini/src/components/ConfigPanel.tsx
+++ b/dashboard/mini/src/components/ConfigPanel.tsx
@@ -1,0 +1,69 @@
+import type { JSX } from 'react';
+import { FormEvent, useState } from 'react';
+import { getApiBaseUrl, setApiBaseUrl, DEFAULT_API_BASE_URL } from '../config/env';
+import { pingApi } from '../api/ping';
+
+export const ConfigPanel = (): JSX.Element => {
+  const [input, setInput] = useState<string>(getApiBaseUrl());
+  const [message, setMessage] = useState<string>('');
+
+  const isValidUrl = (url: string): boolean => /^https?:\/\//.test(url);
+
+  const onSave = (e: FormEvent) => {
+    e.preventDefault();
+    if (!isValidUrl(input)) {
+      setMessage('URL invalide');
+      return;
+    }
+    setApiBaseUrl(input);
+    setMessage('Enregistré');
+  };
+
+  const onTest = async (): Promise<void> => {
+    if (!isValidUrl(input)) {
+      setMessage('URL invalide');
+      return;
+    }
+    setMessage('Test...');
+    const res = await pingApi(input);
+    if (res.ok) {
+      setMessage('Connexion OK');
+    } else if (res.status === 401 || res.status === 403) {
+      setMessage('Clé API requise — à renseigner dans la bannière');
+    } else {
+      setMessage('Échec de connexion');
+    }
+  };
+
+  const onReset = (): void => {
+    setInput(DEFAULT_API_BASE_URL);
+    setApiBaseUrl(DEFAULT_API_BASE_URL);
+    setMessage('Réinitialisé');
+  };
+
+  return (
+    <div>
+      <form onSubmit={onSave}>
+        <label>
+          API URL
+          <input
+            data-testid="apiUrlInput"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+        </label>
+        <button type="submit">Enregistrer</button>
+        <button type="button" onClick={onTest}>
+          Tester
+        </button>
+        <button type="button" onClick={onReset}>
+          Réinitialiser
+        </button>
+      </form>
+      {message && <p data-testid="apiUrlMessage">{message}</p>}
+    </div>
+  );
+};
+
+export default ConfigPanel;

--- a/dashboard/mini/src/config/env.ts
+++ b/dashboard/mini/src/config/env.ts
@@ -1,8 +1,19 @@
 // Gestion des variables d'environnement côté front
 
-export const API_BASE_URL = (
+const STORAGE_KEY = 'apiBaseUrl';
+
+export const DEFAULT_API_BASE_URL = (
   import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000'
 ).replace(/\/+$/, '');
+
+export const getApiBaseUrl = (): string =>
+  (localStorage.getItem(STORAGE_KEY) ?? DEFAULT_API_BASE_URL).replace(/\/+$/, '');
+
+export const setApiBaseUrl = (url: string): void => {
+  const clean = url.trim().replace(/\/+$/, '');
+  if (clean) localStorage.setItem(STORAGE_KEY, clean);
+  else localStorage.removeItem(STORAGE_KEY);
+};
 
 const rawTimeout = Number(import.meta.env.VITE_API_TIMEOUT_MS);
 export const API_TIMEOUT_MS =
@@ -11,4 +22,10 @@ export const API_TIMEOUT_MS =
 export const DEMO_API_KEY =
   String(import.meta.env.VITE_DEMO_API_KEY ?? '').trim() || undefined;
 
-export default { API_BASE_URL, API_TIMEOUT_MS, DEMO_API_KEY };
+export default {
+  getApiBaseUrl,
+  setApiBaseUrl,
+  DEFAULT_API_BASE_URL,
+  API_TIMEOUT_MS,
+  DEMO_API_KEY,
+};

--- a/dashboard/mini/src/layouts/AppLayout.tsx
+++ b/dashboard/mini/src/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import type { JSX, ReactNode } from 'react';
 import ApiKeyBanner from '../components/ApiKeyBanner';
+import ConfigPanel from '../components/ConfigPanel';
 
 export const AppLayout = ({
   children,
@@ -10,6 +11,7 @@ export const AppLayout = ({
     <header>
       <h1>Mini Dashboard (read-only) — Fil G</h1>
     </header>
+    <ConfigPanel />
     <ApiKeyBanner />
     <main>{children}</main>
   </div>


### PR DESCRIPTION
## Résumé
- ping inclut l'en-tête X-API-Key et renvoie le status
- ConfigPanel affiche un message dédié aux 401/403 et valide l'URL
- tests ajustés pour couvrir le header API key

## Tests
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b1dcda7ea88327a7e0bcf4d38f4c59