### PR TITLE
ci: fiabilise déploiement Vercel preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,58 @@
+name: Deploy Preview
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - preview
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      preview-url: ${{ steps.vercel-deploy.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull Vercel Environment Information
+        uses: vercel/actions/pull@v1
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: dashboard/mini
+
+      - name: Deploy to Vercel
+        id: vercel-deploy
+        uses: vercel/actions/deploy@v1
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: dashboard/mini
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = process.env.DEPLOY_URL;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Preview Vercel disponible: ${url}`
+            });
+        env:
+          DEPLOY_URL: ${{ steps.vercel-deploy.outputs.url }}

--- a/docs/vercel-preview.md
+++ b/docs/vercel-preview.md
@@ -1,0 +1,13 @@
+# Déploiement Vercel (preview)
+
+Ce dépôt déclenche un déploiement automatique du mini dashboard sur Vercel à chaque push sur `main` et pour chaque pull request vers `main` ou `preview`. La construction de l'application est réalisée côté Vercel.
+
+## Secrets requis
+
+Configurez les secrets GitHub suivants dans les **Repository secrets** pour que le workflow `deploy-preview.yml` fonctionne :
+
+- `VERCEL_TOKEN` – jeton d'accès personnel généré depuis votre compte Vercel.
+- `VERCEL_ORG_ID` – identifiant de l’organisation Vercel.
+- `VERCEL_PROJECT_ID` – identifiant du projet Vercel associé au dashboard.
+
+Lors de l’exécution du workflow, l’URL de prévisualisation est exposée en sortie du job (`preview-url`) et un commentaire est publié sur la pull request avec cette URL.


### PR DESCRIPTION
## Résumé
- build du mini dashboard réalisée côté Vercel
- ajout des permissions et d'une stratégie de concurrence pour les commentaires de PR
- documentation alignée avec le nouveau flux de déploiement

## Tests
- `pre-commit run --files .github/workflows/deploy-preview.yml docs/vercel-preview.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1dcf57cf083279017a0b16eadf3b7