### PR TITLE
feat(api): add pagination link headers

### DIFF
--- a/api/fastapi_app/pagination.py
+++ b/api/fastapi_app/pagination.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from fastapi import Request, Response
+
+
+def set_pagination_headers(response: Response, request: Request, total: int, limit: int, offset: int) -> None:
+    """Ajoute les en-têtes RFC5988 Link et X-Total-Count."""
+    links: list[str] = []
+    if offset > 0:
+        prev_offset = max(offset - limit, 0)
+        prev_url = str(request.url.include_query_params(offset=prev_offset, limit=limit))
+        links.append(f"<{prev_url}>; rel=\"prev\"")
+    if offset + limit < total:
+        next_url = str(request.url.include_query_params(offset=offset + limit, limit=limit))
+        links.append(f"<{next_url}>; rel=\"next\"")
+    if links:
+        response.headers["Link"] = ", ".join(links)
+    response.headers["X-Total-Count"] = str(total)

--- a/tests_api/test_link_headers.py
+++ b/tests_api/test_link_headers.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_nodes_link_headers(client, seed_sample):
+    run_id = seed_sample["run_id"]
+    # page 1
+    r1 = await client.get(f"/runs/{run_id}/nodes", params={"limit": 1})
+    assert r1.status_code == 200
+    total = r1.json()["total"]
+    assert r1.headers["X-Total-Count"] == str(total)
+    link1 = r1.headers["Link"]
+    assert 'rel="prev"' not in link1
+    assert 'rel="next"' in link1 and 'offset=1' in link1
+
+    # middle page
+    r2 = await client.get(f"/runs/{run_id}/nodes", params={"limit": 1, "offset": 1})
+    link2 = r2.headers["Link"]
+    assert 'rel="prev"' in link2 and 'rel="next"' in link2
+    assert 'offset=0' in link2 and 'offset=2' in link2
+
+    # last page
+    r3 = await client.get(f"/runs/{run_id}/nodes", params={"limit": 1, "offset": 2})
+    link3 = r3.headers["Link"]
+    assert 'rel="next"' not in link3
+    assert 'rel="prev"' in link3 and 'offset=1' in link3
+
+
+@pytest.mark.asyncio
+async def test_nodes_links_preserve_filters(client, seed_sample):
+    run_id = seed_sample["run_id"]
+    r = await client.get(
+        f"/runs/{run_id}/nodes",
+        params={"limit": 1, "status": "completed", "order_by": "key"},
+    )
+    link = r.headers["Link"]
+    assert "status=completed" in link
+    assert "order_by=key" in link


### PR DESCRIPTION
## Summary
- add helper for RFC5988 Link & X-Total-Count headers
- expose Link headers on paginated runs, nodes, artifacts and events endpoints
- test pagination navigation and preservation of filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e243d08c8327a8ae0669354ec083