### PR TITLE
feat(api): tri personnalisable

### DIFF
--- a/api/fastapi_app/ordering.py
+++ b/api/fastapi_app/ordering.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import Mapping, Literal
+from fastapi import HTTPException
+from sqlalchemy import asc, desc
+
+def apply_order(stmt, order_by: str | None, order_dir: Literal["asc", "desc"] | None, allowed: Mapping[str, object], default: str):
+    field = order_by or default
+    if field.startswith("-"):
+        key = field[1:]
+        direction = desc
+    else:
+        key = field
+        dir_val = order_dir or "asc"
+        direction = asc if dir_val == "asc" else desc
+    if key not in allowed:
+        allowed_cols = ", ".join(sorted(allowed.keys()))
+        raise HTTPException(status_code=422, detail=f"order_by doit être parmi: {allowed_cols}")
+    return stmt.order_by(direction(allowed[key]))

--- a/tests_api/test_artifacts.py
+++ b/tests_api/test_artifacts.py
@@ -1,6 +1,9 @@
 import uuid
+import datetime as dt
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import insert, delete
+from api.database.models import Artifact
 
 pytestmark = pytest.mark.asyncio
 
@@ -22,3 +25,41 @@ async def test_get_artifact_ok(client: AsyncClient, seed_sample):
     data = resp.json()
     assert data["id"] == art_id
     assert "content" in data  # présent dans le schema
+
+
+async def test_artifacts_ordering(client: AsyncClient, db_session, seed_sample):
+    node_id = seed_sample["node_ids"][0]
+    now = dt.datetime.now(dt.timezone.utc)
+    extra = {
+        "id": uuid.uuid4(),
+        "node_id": node_id,
+        "type": "markdown",
+        "path": "/tmp/x.md",
+        "content": "# x",
+        "summary": "x",
+        "created_at": now - dt.timedelta(minutes=1),
+    }
+    await db_session.execute(insert(Artifact), [extra])
+    await db_session.commit()
+    try:
+        r = await client.get(f"/nodes/{node_id}/artifacts?order_by=created_at&order_dir=asc")
+        items = r.json()["items"]
+        dates = [it["created_at"] for it in items]
+        assert dates == sorted(dates)
+
+        r = await client.get(f"/nodes/{node_id}/artifacts?order_by=-created_at")
+        items = r.json()["items"]
+        dates = [it["created_at"] for it in items]
+        assert dates == sorted(dates, reverse=True)
+
+        r = await client.get(f"/nodes/{node_id}/artifacts?order_by=foo")
+        assert r.status_code == 422
+
+        r = await client.get(
+            f"/nodes/{node_id}/artifacts?type=markdown&order_by=created_at&order_dir=asc&offset=1"
+        )
+        items = r.json()["items"]
+        assert len(items) == 1
+    finally:
+        await db_session.execute(delete(Artifact).where(Artifact.id == extra["id"]))
+        await db_session.commit()

--- a/tests_api/test_nodes.py
+++ b/tests_api/test_nodes.py
@@ -8,3 +8,27 @@ async def test_list_nodes_for_run(client, seed_sample):
     js = r.json()
     assert js["total"] == 3
     assert all("status" in n for n in js["items"])
+
+
+@pytest.mark.asyncio
+async def test_nodes_ordering(client, seed_sample):
+    run_id = seed_sample["run_id"]
+    r = await client.get(f"/runs/{run_id}/nodes?order_by=created_at&order_dir=asc")
+    items = r.json()["items"]
+    dates = [it["created_at"] for it in items]
+    assert dates == sorted(dates)
+
+    r = await client.get(f"/runs/{run_id}/nodes?order_by=-created_at")
+    items = r.json()["items"]
+    dates = [it["created_at"] for it in items]
+    assert dates == sorted(dates, reverse=True)
+
+    r = await client.get(f"/runs/{run_id}/nodes?order_by=foo")
+    assert r.status_code == 422
+
+    r = await client.get(
+        f"/runs/{run_id}/nodes?status=completed&order_by=created_at&order_dir=asc&offset=1"
+    )
+    items = r.json()["items"]
+    assert len(items) == 1
+    assert items[0]["key"] == "n2"

--- a/tests_api/test_runs.py
+++ b/tests_api/test_runs.py
@@ -1,4 +1,8 @@
 import pytest
+import datetime as dt
+import uuid
+from sqlalchemy import insert, delete
+from api.database.models import Run
 
 @pytest.mark.asyncio
 async def test_list_runs(client, seed_sample):
@@ -33,3 +37,46 @@ async def test_title_filter(client, seed_sample):
 async def test_auth_required(client_noauth):
     r = await client_noauth.get("/runs")
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_runs_ordering(client, db_session, seed_sample):
+    now = dt.datetime.now(dt.timezone.utc)
+    run1 = {
+        "id": uuid.uuid4(),
+        "title": "Run1",
+        "status": "completed",
+        "started_at": now - dt.timedelta(minutes=10),
+        "ended_at": now - dt.timedelta(minutes=9),
+    }
+    run2 = {
+        "id": uuid.uuid4(),
+        "title": "Run2",
+        "status": "completed",
+        "started_at": now - dt.timedelta(minutes=1),
+        "ended_at": now,
+    }
+    await db_session.execute(insert(Run), [run1, run2])
+    await db_session.commit()
+    try:
+        r = await client.get("/runs?order_by=started_at&order_dir=asc")
+        times = [it["started_at"] for it in r.json()["items"][:3]]
+        assert times == sorted(times)
+
+        r = await client.get("/runs?order_by=-started_at")
+        times_desc = [it["started_at"] for it in r.json()["items"][:3]]
+        assert times_desc == sorted(times_desc, reverse=True)
+
+        r = await client.get("/runs?order_by=foo")
+        assert r.status_code == 422
+
+        r = await client.get(
+            "/runs?status=completed&order_by=started_at&order_dir=desc&offset=1&limit=1"
+        )
+        assert r.status_code == 200
+        items = r.json()["items"]
+        assert len(items) == 1
+        assert items[0]["started_at"] == times_desc[1]
+    finally:
+        await db_session.execute(delete(Run).where(Run.id.in_([run1["id"], run2["id"]])))
+        await db_session.commit()


### PR DESCRIPTION
## Résumé
- ajout d'un utilitaire `apply_order` gérant `order_by` et `order_dir` avec contrôle strict des colonnes
- support du tri asc/desc sur `/runs`, `/runs/{run_id}/nodes`, `/nodes/{node_id}/artifacts` et `/events`
- couverture de tests pour le tri, la pagination et les colonnes invalides

## Tests
- `pre-commit run --files api/fastapi_app/ordering.py api/fastapi_app/routes/runs.py api/fastapi_app/routes/nodes.py api/fastapi_app/routes/artifacts.py api/fastapi_app/routes/events.py tests_api/test_runs.py tests_api/test_nodes.py tests_api/test_artifacts.py tests_api/test_events.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1e42d3ce88327a4b87d6408cb9051