### PR TITLE
feat(api): filtres et tri supplémentaires

### DIFF
--- a/api/fastapi_app/routes/events.py
+++ b/api/fastapi_app/routes/events.py
@@ -34,6 +34,7 @@ async def list_events(
     q: Optional[str] = Query(None, description="Recherche plein texte (message ILIKE)"),
     ts_from: Optional[datetime] = Query(None),
     ts_to: Optional[datetime] = Query(None),
+    request_id: Optional[str] = Query(None),
     order_by: Optional[str] = Query("-timestamp"),
     order_dir: Optional[Literal["asc", "desc"]] = Query(None),
 ):
@@ -55,6 +56,8 @@ async def list_events(
         where.append(Event.timestamp >= ts_from)
     if ts_to:
         where.append(Event.timestamp <= ts_to)
+    if request_id:
+        where.append(Event.request_id == request_id)
 
     base = select(Event).where(and_(*where))
     total = (
@@ -73,6 +76,7 @@ async def list_events(
             level=e.level,
             message=e.message,
             timestamp=e.timestamp,
+            request_id=getattr(e, "request_id", None),
         )
         for e in rows
     ]

--- a/api/fastapi_app/routes/nodes.py
+++ b/api/fastapi_app/routes/nodes.py
@@ -41,6 +41,8 @@ async def list_nodes(
     status: Optional[str] = Query(None),
     key: Optional[str] = Query(None),
     title_contains: Optional[str] = Query(None),
+    role: Optional[str] = Query(None),
+    checksum: Optional[str] = Query(None),
     order_by: Optional[str] = Query("-created_at"),
     order_dir: Optional[Literal["asc", "desc"]] = Query(None),
 ):
@@ -52,6 +54,10 @@ async def list_nodes(
         where.append(Node.key == key)
     if title_contains:
         where.append(Node.title.ilike(f"%{title_contains}%"))
+    if role:
+        where.append(Node.role == role)
+    if checksum:
+        where.append(Node.checksum == checksum)
 
     base = select(Node).where(and_(*where))
     total = (
@@ -71,6 +77,7 @@ async def list_nodes(
             key=n.key,
             title=n.title,
             status=n.status,
+            role=n.role,
             checksum=n.checksum,
             created_at=to_tz(n.created_at, tz),
             updated_at=to_tz(n.updated_at, tz),

--- a/api/fastapi_app/schemas.py
+++ b/api/fastapi_app/schemas.py
@@ -114,6 +114,7 @@ class NodeOut(BaseModel):
     key: Optional[str] = None
     title: str
     status: str
+    role: Optional[str] = None
     checksum: Optional[str] = None
     deps: Optional[List[str]] = None
     created_at: datetime
@@ -136,6 +137,7 @@ class EventOut(BaseModel):
     level: str
     message: str
     timestamp: datetime
+    request_id: Optional[str] = None
 
 __all__ = [
     name

--- a/core/storage/db_models.py
+++ b/core/storage/db_models.py
@@ -65,6 +65,7 @@ class Node(SQLModel, table=True):
     key: Optional[str] = Field(default=None, sa_column=Column(String, index=True))
     title: str = Field(sa_column=Column(String, nullable=False))
     status: NodeStatus = Field(sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False))
+    role: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True, index=True))
     deps: Optional[List[str]] = Field(default=None, sa_column=Column(JSON, nullable=True))
     checksum: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
     created_at: datetime = Field(
@@ -110,3 +111,4 @@ class Event(SQLModel, table=True):
     )
     level: str = Field(sa_column=Column(String, nullable=False))
     message: str = Field(sa_column=Column(Text, nullable=False))
+    request_id: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True, index=True))

--- a/tests_api/conftest.py
+++ b/tests_api/conftest.py
@@ -180,9 +180,10 @@ async def seed_sample(db_session: AsyncSession):
                 "key": f"n{i}",
                 "title": f"Node {i}",
                 "status": "completed" if i < 3 else "failed",
+                "role": f"r{i}",
                 "created_at": now - dt.timedelta(minutes=5 - i),
                 "updated_at": now - dt.timedelta(minutes=4 - i),
-                "checksum": None,
+                "checksum": f"cs{i}",
             }
             for i, nid in enumerate(node_ids, start=1)
         ],
@@ -222,6 +223,7 @@ async def seed_sample(db_session: AsyncSession):
                 "level": "INFO",
                 "message": "start",
                 "timestamp": now - dt.timedelta(minutes=5),
+                "request_id": "req-1",
             },
             {
                 "id": uuid.uuid4(),
@@ -230,6 +232,7 @@ async def seed_sample(db_session: AsyncSession):
                 "level": "ERROR",
                 "message": "boom",
                 "timestamp": now - dt.timedelta(minutes=1),
+                "request_id": "req-2",
             },
         ],
     )

--- a/tests_api/test_artifacts.py
+++ b/tests_api/test_artifacts.py
@@ -27,6 +27,17 @@ async def test_get_artifact_ok(client: AsyncClient, seed_sample):
     assert "content" in data  # présent dans le schema
 
 
+async def test_artifacts_filter_name_contains(client: AsyncClient, seed_sample):
+    node_id = seed_sample["node_ids"][0]
+    r = await client.get(
+        f"/nodes/{node_id}/artifacts", params={"name_contains": "a1"}
+    )
+    assert r.status_code == 200
+    js = r.json()
+    assert js["total"] == 1
+    assert js["items"][0]["path"].endswith("a1.md")
+
+
 async def test_artifacts_ordering(client: AsyncClient, db_session, seed_sample):
     node_id = seed_sample["node_ids"][0]
     now = dt.datetime.now(dt.timezone.utc)

--- a/tests_api/test_events.py
+++ b/tests_api/test_events.py
@@ -24,6 +24,16 @@ async def test_list_events_filter_q(client, seed_sample):
 
 
 @pytest.mark.asyncio
+async def test_list_events_filter_request_id(client, seed_sample):
+    run_id = seed_sample["run_id"]
+    r = await client.get("/events", params={"run_id": run_id, "request_id": "req-1"})
+    assert r.status_code == 200
+    js = r.json()
+    assert js["total"] == 1
+    assert js["items"][0]["request_id"] == "req-1"
+
+
+@pytest.mark.asyncio
 async def test_events_old_and_new_routes(client, seed_sample):
     run_id = seed_sample["run_id"]
     r1 = await client.get("/events", params={"run_id": run_id})

--- a/tests_api/test_nodes.py
+++ b/tests_api/test_nodes.py
@@ -11,6 +11,22 @@ async def test_list_nodes_for_run(client, seed_sample):
 
 
 @pytest.mark.asyncio
+async def test_list_nodes_filter_role_checksum(client, seed_sample):
+    run_id = seed_sample["run_id"]
+    r = await client.get(f"/runs/{run_id}/nodes", params={"role": "r1"})
+    assert r.status_code == 200
+    js = r.json()
+    assert js["total"] == 1
+    assert js["items"][0]["role"] == "r1"
+
+    r2 = await client.get(f"/runs/{run_id}/nodes", params={"checksum": "cs2"})
+    assert r2.status_code == 200
+    js2 = r2.json()
+    assert js2["total"] == 1
+    assert js2["items"][0]["checksum"] == "cs2"
+
+
+@pytest.mark.asyncio
 async def test_nodes_ordering(client, seed_sample):
     run_id = seed_sample["run_id"]
     r = await client.get(f"/runs/{run_id}/nodes?order_by=created_at&order_dir=asc")


### PR DESCRIPTION
## Résumé
- ajout des colonnes `role` pour les nœuds et `request_id` pour les événements
- nouveaux filtres `role`/`checksum` sur `/runs/{run_id}/nodes`
- filtres `request_id` sur `/events` et `name_contains` sur `/nodes/{node_id}/artifacts`

## Tests
- `pytest tests_api/test_nodes.py tests_api/test_events.py tests_api/test_artifacts.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1f07d8b8c83279889a75cf68bfe7a