### PR TITLE
Fix: lien “Télécharger” vers le nouvel endpoint API

### DIFF
--- a/dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx
+++ b/dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx
@@ -55,6 +55,12 @@ describe('ArtifactsList', () => {
     setup();
     expect(screen.getByText('f1')).toBeInTheDocument();
     expect(screen.getByText('file')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'Télécharger' });
+    expect(link).toHaveAttribute(
+      'href',
+      'http://localhost:8000/artifacts/a1/download',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
   });
 
   it("affiche l'état loading", () => {

--- a/dashboard/mini/src/components/ArtifactsList.tsx
+++ b/dashboard/mini/src/components/ArtifactsList.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 import { useNodeArtifacts } from '../api/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { ApiError } from '../api/http';
+import { getApiBaseUrl } from '../config/env';
 
 export type ArtifactsListProps = {
   runId: string;
@@ -106,7 +107,11 @@ const ArtifactsList = ({
             <td>{a.kind}</td>
             <td>{formatSize(a.size_bytes)}</td>
             <td>
-              <a href={a.url} target="_blank" rel="noreferrer">
+              <a
+                href={`${getApiBaseUrl()}/artifacts/${a.id}/download`}
+                target="_blank"
+                rel="noreferrer"
+              >
                 Télécharger
               </a>
             </td>


### PR DESCRIPTION
## Résumé
- redirige le lien de téléchargement des artefacts vers `/artifacts/{id}/download`
- couvre la nouvelle URL dans le test de la liste des artefacts

## Tests
- `pre-commit run --files dashboard/mini/src/components/ArtifactsList.tsx dashboard/mini/src/__tests__/components/ArtifactsList.test.tsx`
- `npm test --prefix dashboard/mini`


------
https://chatgpt.com/codex/tasks/task_e_68b1f096011c83279ad0121305494fd2