### PR TITLE
feat: tri des tables du dashboard

### DIFF
--- a/dashboard/mini/src/__tests__/RunsTable.navigation.test.tsx
+++ b/dashboard/mini/src/__tests__/RunsTable.navigation.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi, describe, it, beforeEach, expect } from 'vitest';
 import type { Mock } from 'vitest';
@@ -17,8 +18,12 @@ const setup = (props: Partial<RunsTableProps> = {}) => {
   const defaultProps: RunsTableProps = {
     page: 1,
     pageSize: 20,
+    orderBy: 'started_at',
+    orderDir: 'desc',
     onPageChange: vi.fn(),
     onPageSizeChange: vi.fn(),
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
     onOpenRun: vi.fn(),
   };
   render(
@@ -79,5 +84,54 @@ describe('RunsTable navigation', () => {
     setup({ page: 3 });
     expect(screen.getByText('Précédent')).not.toBeDisabled();
     expect(screen.getByText('Suivant')).toBeDisabled();
+  });
+
+  it('change de tri met à jour prev/next', () => {
+    (useRuns as unknown as Mock).mockImplementation((params) => {
+      if (params.orderBy === 'started_at') {
+        return {
+          data: {
+            items: [{ id: 'r1', status: 'running' }],
+            meta: { page: 1, page_size: 20, total: 20, next: '/runs?page=2' },
+          },
+          isLoading: false,
+          isError: false,
+        };
+      }
+      return {
+        data: {
+          items: [{ id: 'r1', status: 'running' }],
+          meta: { page: 1, page_size: 20, total: 20 },
+        },
+        isLoading: false,
+        isError: false,
+      };
+    });
+    const Wrapper = () => {
+      const [orderBy, setOrderBy] = React.useState('started_at');
+      return (
+        <RunsTable
+          page={1}
+          pageSize={20}
+          orderBy={orderBy}
+          orderDir="desc"
+          onOrderByChange={setOrderBy}
+          onOrderDirChange={() => {}}
+          onPageChange={() => {}}
+          onPageSizeChange={() => {}}
+          onOpenRun={() => {}}
+        />
+      );
+    };
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <Wrapper />
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText('Suivant')).not.toBeDisabled();
+    const select = screen.getByLabelText('order-by');
+    fireEvent.change(select, { target: { value: 'ended_at' } });
+    expect(screen.getByText('Suivant')).toBeDisabled();
+    expect(screen.getByText('Précédent')).toBeDisabled();
   });
 });

--- a/dashboard/mini/src/__tests__/RunsTable.test.tsx
+++ b/dashboard/mini/src/__tests__/RunsTable.test.tsx
@@ -15,8 +15,12 @@ const setup = (props: Partial<RunsTableProps> = {}) => {
   const defaultProps: RunsTableProps = {
     page: 1,
     pageSize: 20,
+    orderBy: 'started_at',
+    orderDir: 'desc',
     onPageChange: vi.fn(),
     onPageSizeChange: vi.fn(),
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
     onOpenRun: vi.fn(),
   };
   const view = render(
@@ -80,8 +84,12 @@ describe('RunsTable', () => {
           page={1}
           pageSize={20}
           status={['running' as Status]}
+          orderBy="started_at"
+          orderDir="desc"
           onPageChange={vi.fn()}
           onPageSizeChange={vi.fn()}
+          onOrderByChange={vi.fn()}
+          onOrderDirChange={vi.fn()}
           onOpenRun={vi.fn()}
         />
       </QueryClientProvider>,
@@ -104,5 +112,23 @@ describe('RunsTable', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     const url = new URL(fetchMock.mock.calls[0][0] as string);
     expect(url.searchParams.get('status')).toBe('pending');
+  });
+
+  it('envoie les paramètres de tri', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ items: [], total: 0, limit: 20, offset: 0 }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    setup({ orderBy: 'ended_at', orderDir: 'asc' });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('order_by')).toBe('ended_at');
+    expect(url.searchParams.get('order_dir')).toBe('asc');
   });
 });

--- a/dashboard/mini/src/__tests__/components/EventsTable.filters.test.tsx
+++ b/dashboard/mini/src/__tests__/components/EventsTable.filters.test.tsx
@@ -20,6 +20,10 @@ const setup = (props: Partial<EventsTableProps> = {}) => {
     pageSize: 20,
     onPageChange: vi.fn(),
     onPageSizeChange: vi.fn(),
+    orderBy: 'timestamp',
+    orderDir: 'desc',
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
   };
   const view = render(
     <QueryClientProvider client={queryClient}>

--- a/dashboard/mini/src/__tests__/components/EventsTable.order.test.tsx
+++ b/dashboard/mini/src/__tests__/components/EventsTable.order.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom';
+import 'whatwg-fetch';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect } from 'vitest';
+import EventsTable, { EventsTableProps } from '../../components/EventsTable';
+
+const setup = (props: Partial<EventsTableProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: EventsTableProps = {
+    runId: 'r1',
+    page: 1,
+    pageSize: 20,
+    orderBy: 'timestamp',
+    orderDir: 'desc',
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
+  };
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EventsTable {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('EventsTable order params', () => {
+  it('envoie order_by et order_dir', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ items: [], meta: { page: 1, page_size: 20, total: 0 } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    setup({ orderBy: 'level', orderDir: 'asc' });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('order_by')).toBe('level');
+    expect(url.searchParams.get('order_dir')).toBe('asc');
+  });
+});

--- a/dashboard/mini/src/__tests__/components/EventsTable.test.tsx
+++ b/dashboard/mini/src/__tests__/components/EventsTable.test.tsx
@@ -21,6 +21,10 @@ const setup = (props: Partial<EventsTableProps> = {}) => {
     pageSize: 20,
     onPageChange: vi.fn(),
     onPageSizeChange: vi.fn(),
+    orderBy: 'timestamp',
+    orderDir: 'desc',
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
   };
   const view = render(
     <QueryClientProvider client={queryClient}>

--- a/dashboard/mini/src/__tests__/components/NodesTable.order.test.tsx
+++ b/dashboard/mini/src/__tests__/components/NodesTable.order.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom';
+import 'whatwg-fetch';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi, describe, it, expect } from 'vitest';
+import NodesTable, { NodesTableProps } from '../../components/NodesTable';
+
+const setup = (props: Partial<NodesTableProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: NodesTableProps = {
+    runId: 'r1',
+    page: 1,
+    pageSize: 20,
+    orderBy: 'created_at',
+    orderDir: 'desc',
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
+  };
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NodesTable {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('NodesTable order params', () => {
+  it('envoie order_by et order_dir', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ items: [], meta: { page: 1, page_size: 20, total: 0 } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    setup({ orderBy: 'title', orderDir: 'asc' });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('order_by')).toBe('title');
+    expect(url.searchParams.get('order_dir')).toBe('asc');
+  });
+});

--- a/dashboard/mini/src/__tests__/components/NodesTable.select.test.tsx
+++ b/dashboard/mini/src/__tests__/components/NodesTable.select.test.tsx
@@ -20,6 +20,10 @@ const setup = (props: Partial<NodesTableProps> = {}) => {
     pageSize: 20,
     onPageChange: vi.fn(),
     onPageSizeChange: vi.fn(),
+    orderBy: 'created_at',
+    orderDir: 'desc',
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
   };
   const view = render(
     <QueryClientProvider client={queryClient}>

--- a/dashboard/mini/src/__tests__/components/NodesTable.test.tsx
+++ b/dashboard/mini/src/__tests__/components/NodesTable.test.tsx
@@ -21,6 +21,10 @@ const setup = (props: Partial<NodesTableProps> = {}) => {
     pageSize: 20,
     onPageChange: vi.fn(),
     onPageSizeChange: vi.fn(),
+    orderBy: 'created_at',
+    orderDir: 'desc',
+    onOrderByChange: vi.fn(),
+    onOrderDirChange: vi.fn(),
   };
   const view = render(
     <QueryClientProvider client={queryClient}>

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -66,6 +66,8 @@ export const listRuns = async (
     started_from: params.dateFrom,
     started_to: params.dateTo,
     title_contains: params.title,
+    order_by: params.orderBy,
+    order_dir: params.orderDir,
   };
   const { data, headers } = await fetchJson<{ items: BackendRun[] }>('/runs', {
     ...opts,
@@ -116,12 +118,22 @@ export const getRunSummary = async (
 
 export const listRunNodes = async (
   id: string,
-  params: { page: number; pageSize: number },
+  params: {
+    page: number;
+    pageSize: number;
+    orderBy?: string;
+    orderDir?: 'asc' | 'desc';
+  },
   opts: FetchOpts = {},
 ): Promise<Page<NodeItem>> => {
   const limit = Math.min(params.pageSize, 50);
   const offset = (params.page - 1) * limit;
-  const query = { limit, offset };
+  const query: Record<string, string | number | boolean | undefined> = {
+    limit,
+    offset,
+    order_by: params.orderBy,
+    order_dir: params.orderDir,
+  };
   type BackendNode = Omit<NodeItem, 'status'> & { status: ApiStatus };
   const { data, headers } = await fetchJson<{ items: BackendNode[] }>(
     `/runs/${id}/nodes`,
@@ -151,6 +163,8 @@ export const listRunEvents = async (
     pageSize: number;
     level?: 'info' | 'warn' | 'error' | 'debug';
     text?: string;
+    orderBy?: string;
+    orderDir?: 'asc' | 'desc';
   },
   opts: FetchOpts = {},
 ): Promise<Page<EventItem>> => {
@@ -161,6 +175,8 @@ export const listRunEvents = async (
     offset,
     level: params.level,
     q: params.text,
+    order_by: params.orderBy,
+    order_dir: params.orderDir,
   };
   const { data, headers } = await fetchJson<{ items: EventItem[] }>(
     `/runs/${id}/events`,

--- a/dashboard/mini/src/api/hooks.ts
+++ b/dashboard/mini/src/api/hooks.ts
@@ -26,6 +26,8 @@ export const useRuns = (
     dateFrom?: string;
     dateTo?: string;
     title?: string;
+    orderBy?: string;
+    orderDir?: 'asc' | 'desc';
   },
   opts?: { enabled?: boolean },
 ) =>
@@ -52,7 +54,12 @@ export const useRunSummary = (id: string, opts?: { enabled?: boolean }) =>
 
 export const useRunNodes = (
   id: string,
-  params: { page: number; pageSize: number },
+  params: {
+    page: number;
+    pageSize: number;
+    orderBy?: string;
+    orderDir?: 'asc' | 'desc';
+  },
   opts?: { enabled?: boolean },
 ) =>
   useQuery<Page<NodeItem>>({
@@ -68,6 +75,8 @@ export const useRunEvents = (
     pageSize: number;
     level?: 'info' | 'warn' | 'error' | 'debug';
     text?: string;
+    orderBy?: string;
+    orderDir?: 'asc' | 'desc';
   },
   opts?: { enabled?: boolean },
 ) =>

--- a/dashboard/mini/src/components/EventsTable.tsx
+++ b/dashboard/mini/src/components/EventsTable.tsx
@@ -15,6 +15,10 @@ export type EventsTableProps = {
   onTextChange?: (text: string) => void;
   onPageChange: (nextPage: number) => void;
   onPageSizeChange: (size: number) => void;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
+  onOrderByChange: (field: string) => void;
+  onOrderDirChange: (dir: 'asc' | 'desc') => void;
 };
 
 const formatDate = (d?: string): string =>
@@ -30,8 +34,12 @@ const EventsTable = ({
   onTextChange,
   onPageChange,
   onPageSizeChange,
+  orderBy,
+  orderDir,
+  onOrderByChange,
+  onOrderDirChange,
 }: EventsTableProps): JSX.Element => {
-  const params = { page, pageSize, level, text };
+  const params = { page, pageSize, level, text, orderBy, orderDir };
   const queryClient = useQueryClient();
   const eventsQuery = useRunEvents(runId, params, {
     enabled: Boolean(runId),
@@ -180,6 +188,39 @@ const EventsTable = ({
             </option>
           ))}
         </select>
+        <label style={{ marginLeft: '8px' }}>
+          Trier par
+          <select
+            aria-label="order-by"
+            value={orderBy}
+            onChange={(e) => {
+              onOrderByChange(e.target.value);
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            {['timestamp', 'level'].map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: '8px' }}>
+          Direction
+          <select
+            aria-label="order-dir"
+            value={orderDir}
+            onChange={(e) => {
+              onOrderDirChange(e.target.value as 'asc' | 'desc');
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            <option value="asc">asc</option>
+            <option value="desc">desc</option>
+          </select>
+        </label>
       </div>
     </div>
   );

--- a/dashboard/mini/src/components/NodesTable.tsx
+++ b/dashboard/mini/src/components/NodesTable.tsx
@@ -11,6 +11,10 @@ export type NodesTableProps = {
   onSelectNode?: (nodeId: string) => void;
   onPageChange: (nextPage: number) => void;
   onPageSizeChange: (size: number) => void;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
+  onOrderByChange: (field: string) => void;
+  onOrderDirChange: (dir: 'asc' | 'desc') => void;
 };
 
 const formatDate = (d?: string): string =>
@@ -27,8 +31,12 @@ const NodesTable = ({
   onSelectNode,
   onPageChange,
   onPageSizeChange,
+  orderBy,
+  orderDir,
+  onOrderByChange,
+  onOrderDirChange,
 }: NodesTableProps): JSX.Element => {
-  const params = { page, pageSize };
+  const params = { page, pageSize, orderBy, orderDir };
   const queryClient = useQueryClient();
   const nodesQuery = useRunNodes(runId, params, {
     enabled: Boolean(runId),
@@ -172,6 +180,39 @@ const NodesTable = ({
             </option>
           ))}
         </select>
+        <label style={{ marginLeft: '8px' }}>
+          Trier par
+          <select
+            aria-label="order-by"
+            value={orderBy}
+            onChange={(e) => {
+              onOrderByChange(e.target.value);
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            {['created_at', 'updated_at', 'key', 'title', 'status'].map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: '8px' }}>
+          Direction
+          <select
+            aria-label="order-dir"
+            value={orderDir}
+            onChange={(e) => {
+              onOrderDirChange(e.target.value as 'asc' | 'desc');
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            <option value="asc">asc</option>
+            <option value="desc">desc</option>
+          </select>
+        </label>
       </div>
     </div>
   );

--- a/dashboard/mini/src/components/RunsTable.tsx
+++ b/dashboard/mini/src/components/RunsTable.tsx
@@ -11,8 +11,12 @@ export type RunsTableProps = {
   dateFrom?: string;
   dateTo?: string;
   title?: string;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
   onPageChange: (nextPage: number) => void;
   onPageSizeChange: (size: number) => void;
+  onOrderByChange: (field: string) => void;
+  onOrderDirChange: (dir: 'asc' | 'desc') => void;
   onOpenRun: (id: string) => void;
 };
 
@@ -23,11 +27,24 @@ export const RunsTable = ({
   dateFrom,
   dateTo,
   title,
+  orderBy,
+  orderDir,
   onPageChange,
   onPageSizeChange,
+  onOrderByChange,
+  onOrderDirChange,
   onOpenRun,
 }: RunsTableProps): JSX.Element => {
-  const params = { page, pageSize, status, dateFrom, dateTo, title };
+  const params = {
+    page,
+    pageSize,
+    status,
+    dateFrom,
+    dateTo,
+    title,
+    orderBy,
+    orderDir,
+  };
   const queryClient = useQueryClient();
   const runsQuery = useRuns(params);
 
@@ -155,6 +172,39 @@ export const RunsTable = ({
             </option>
           ))}
         </select>
+        <label style={{ marginLeft: '8px' }}>
+          Trier par
+          <select
+            aria-label="order-by"
+            value={orderBy}
+            onChange={(e) => {
+              onOrderByChange(e.target.value);
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            {['started_at', 'ended_at', 'title', 'status'].map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: '8px' }}>
+          Direction
+          <select
+            aria-label="order-dir"
+            value={orderDir}
+            onChange={(e) => {
+              onOrderDirChange(e.target.value as 'asc' | 'desc');
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            <option value="asc">asc</option>
+            <option value="desc">desc</option>
+          </select>
+        </label>
       </div>
     </div>
   );

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -26,8 +26,12 @@ const RunDetailPage = (): JSX.Element => {
   >('summary');
   const [nodesPage, setNodesPage] = useState(1);
   const [nodesPageSize, setNodesPageSize] = useState(20);
+  const [nodesOrderBy, setNodesOrderBy] = useState('created_at');
+  const [nodesOrderDir, setNodesOrderDir] = useState<'asc' | 'desc'>('desc');
   const [eventsPage, setEventsPage] = useState(1);
   const [eventsPageSize, setEventsPageSize] = useState(20);
+  const [eventsOrderBy, setEventsOrderBy] = useState('timestamp');
+  const [eventsOrderDir, setEventsOrderDir] = useState<'asc' | 'desc'>('desc');
   const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>(
     undefined,
   );
@@ -132,6 +136,16 @@ const RunDetailPage = (): JSX.Element => {
               setNodesPageSize(s);
               setNodesPage(1);
             }}
+            orderBy={nodesOrderBy}
+            orderDir={nodesOrderDir}
+            onOrderByChange={(f) => {
+              setNodesOrderBy(f);
+              setNodesPage(1);
+            }}
+            onOrderDirChange={(d) => {
+              setNodesOrderDir(d);
+              setNodesPage(1);
+            }}
           />
         </section>
       )}
@@ -154,6 +168,16 @@ const RunDetailPage = (): JSX.Element => {
             onPageChange={setEventsPage}
             onPageSizeChange={(s) => {
               setEventsPageSize(s);
+              setEventsPage(1);
+            }}
+            orderBy={eventsOrderBy}
+            orderDir={eventsOrderDir}
+            onOrderByChange={(f) => {
+              setEventsOrderBy(f);
+              setEventsPage(1);
+            }}
+            onOrderDirChange={(d) => {
+              setEventsOrderDir(d);
               setEventsPage(1);
             }}
           />

--- a/dashboard/mini/src/pages/RunsPage.tsx
+++ b/dashboard/mini/src/pages/RunsPage.tsx
@@ -17,6 +17,8 @@ const RunsPage = (): JSX.Element => {
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [titleInput, setTitleInput] = useState('');
+  const [orderBy, setOrderBy] = useState('started_at');
+  const [orderDir, setOrderDir] = useState<'asc' | 'desc'>('desc');
 
   const title = useDebouncedValue(titleInput, 300);
 
@@ -35,7 +37,7 @@ const RunsPage = (): JSX.Element => {
 
   useEffect(() => {
     setPage(1);
-  }, [status, dateFrom, dateTo, title]);
+  }, [status, dateFrom, dateTo, title, orderBy, orderDir]);
 
   if (!hasKey) {
     return <div>Veuillez saisir une clé API pour continuer.</div>;
@@ -112,11 +114,15 @@ const RunsPage = (): JSX.Element => {
         dateFrom={dateFrom || undefined}
         dateTo={dateTo || undefined}
         title={title || undefined}
+        orderBy={orderBy}
+        orderDir={orderDir}
         onPageChange={setPage}
         onPageSizeChange={(s) => {
           setPageSize(s);
           setPage(1);
         }}
+        onOrderByChange={setOrderBy}
+        onOrderDirChange={setOrderDir}
         onOpenRun={onOpenRun}
       />
     </div>


### PR DESCRIPTION
## Résumé
- ajout des sélecteurs de tri et direction pour les runs, nœuds et événements
- prise en charge de `order_by`/`order_dir` côté client
- tests de navigation et des paramètres de requête

## Tests
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68b1f08f615483279bb8bd646b75c346