### PR TITLE
CORS restreint aux origines autorisées

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -104,13 +104,17 @@ if metrics_enabled():
         )
 
 # CORS
-# Permettre l'accès depuis le frontend de développement
+# Origines autorisées via variable d'env ALLOWED_ORIGINS (CSV)
+ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+    if origin.strip()
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://192.168.1.50:5173"],  # origine du frontend
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["GET", "OPTIONS"],
+    allow_headers=["Content-Type", "X-API-Key"],
 )
 
 # -------- Routes --------

--- a/tests_api/test_cors.py
+++ b/tests_api/test_cors.py
@@ -1,0 +1,20 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_cors_options_localhost(client: AsyncClient):
+    response = await client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Content-Type,X-API-Key",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
+    allow_methods = response.headers.get("access-control-allow-methods", "")
+    assert "GET" in allow_methods and "OPTIONS" in allow_methods
+    allow_headers = response.headers.get("access-control-allow-headers", "").lower()
+    assert "content-type" in allow_headers and "x-api-key" in allow_headers


### PR DESCRIPTION
## Résumé
- Ajout d'un middleware CORS configuré par la variable d'environnement `ALLOWED_ORIGINS`.
- Limitation aux méthodes `GET` et `OPTIONS` ainsi qu'aux en-têtes `Content-Type` et `X-API-Key`.
- Ajout d'un test garantissant le bon comportement CORS pour `http://localhost:5173`.

## Tests
- `pytest tests_api/test_cors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7d4231c8327ac66c9016bc69dd2