### PR TITLE
Cap de 31 jours sur les filtres temporels

### DIFF
--- a/api/fastapi_app/routes/events.py
+++ b/api/fastapi_app/routes/events.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Query, HTTPException, Request, Response
 from sqlalchemy import select, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..deps import get_session, strict_api_key_auth, cap_limit, DEFAULT_LIMIT
+from ..deps import get_session, strict_api_key_auth, cap_limit, cap_date_range, DEFAULT_LIMIT
 from ..schemas import Page, EventOut
 from ..pagination import set_pagination_headers
 from ..ordering import apply_order
@@ -46,6 +46,7 @@ async def list_events(
         _deprecated_warned = True
     if run_id is None:
         raise HTTPException(status_code=400, detail="run_id requis")
+    cap_date_range(ts_from, ts_to)
 
     where = [Event.run_id == run_id]
     if level:

--- a/api/fastapi_app/routes/runs.py
+++ b/api/fastapi_app/routes/runs.py
@@ -14,6 +14,7 @@ from ..deps import (
     to_tz,
     strict_api_key_auth,
     cap_limit,
+    cap_date_range,
     DEFAULT_LIMIT,
 )
 from ..schemas import Page, RunListItemOut, RunOut, RunSummaryOut
@@ -49,6 +50,7 @@ async def list_runs(
     order_dir: Optional[Literal["asc", "desc"]] = Query(None),
 ):
     limit = cap_limit(limit)
+    cap_date_range(started_from, started_to)
     where_clauses = []
     if status:
         where_clauses.append(Run.status == status)

--- a/tests_api/test_limits.py
+++ b/tests_api/test_limits.py
@@ -1,0 +1,13 @@
+import pytest
+import datetime as dt
+
+
+@pytest.mark.asyncio
+async def test_runs_date_range_cap(client):
+    start = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    end = start + dt.timedelta(days=120)
+    r = await client.get(
+        "/runs",
+        params={"started_from": start.isoformat(), "started_to": end.isoformat()},
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Résumé
- Refuse les requêtes dont l'intervalle temporel dépasse 31 jours sur `/runs` et `/events`
- Facteur commun `cap_date_range` pour valider les bornes temporelles
- Ajout d'un test vérifiant le rejet d'un intervalle de 120 jours

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7dbc7bc83278984534979880b88