### PR TITLE
feat(ci): deploy mini dashboard to pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,43 @@ jobs:
         with:
           files: "coverage/**/coverage.xml,coverage/**/lcov.info"
           fail_ci_if_error: false
+
+  deploy-pages:
+    needs: lint-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: dashboard/mini/package-lock.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Installer et build du frontend
+        working-directory: dashboard/mini
+        run: |
+          npm ci
+          npm run build
+
+      - name: Upload artifact pour Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboard/mini/dist
+
+      - id: deployment
+        name: Déployer sur GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/dashboard/mini/README.md
+++ b/dashboard/mini/README.md
@@ -6,6 +6,19 @@ Le tableau de bord est **en lecture seule** et vise principalement les
 équipes de développement, d'exploitation et de test souhaitant consulter
 l'état des runs.
 
+## Preview
+
+Une version de production est déployée sur GitHub Pages :
+`https://<utilisateur>.github.io/crew_ia/`.
+
+### Comment tester la preview
+
+1. Ouvrir l'URL ci-dessus.
+2. Dans le panneau **API URL**, saisir l'adresse de l'API (`VITE_API_BASE_URL`),
+   par exemple `https://api.example.com`.
+3. Renseigner la clé API dans le champ **api-key** de la bannière.
+4. Les paramètres sont sauvegardés dans le navigateur et utilisés par toutes les requêtes.
+
 ## Installation locale
 Node.js 20 LTS ou supérieur est requis.
 

--- a/dashboard/mini/vite.config.ts
+++ b/dashboard/mini/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Détecte le nom du dépôt pour configurer la base GitHub Pages
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? '';
+
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: repo ? `/${repo}/` : '/',
   plugins: [react()],
   server: {
     host: true, // équivaut à 0.0.0.0


### PR DESCRIPTION
## Summary
- déploiement automatique du dashboard mini sur GitHub Pages
- configuration dynamique du `base` Vite pour Pages
- documentation de la preview et configuration API/clé

## Testing
- `npm test -- --run`
- `npm run lint` (échec : erreurs de formatage Prettier)
- `npm run typecheck` (échec : propriétés manquantes `orderBy/orderDir`)
- `npm run build` (échec : mêmes erreurs de typage)

------
https://chatgpt.com/codex/tasks/task_e_68b2a527158c83278695f005ecabd6ca