### PR TITLE
chore: config Vercel pour le mini dashboard

### DIFF
--- a/dashboard/mini/.vercelignore
+++ b/dashboard/mini/.vercelignore
@@ -1,0 +1,5 @@
+node_modules
+coverage
+src/__tests__
+**/*.test.*
+**/*.spec.*


### PR DESCRIPTION
## Résumé
- ajoute un `.vercelignore` afin d'exclure les fichiers de tests et de build inutiles
- confirme la configuration existante de `vercel.json` pour pointer vers `dashboard/mini`

## Tests
- `pre-commit run --files dashboard/mini/.vercelignore`
- `CI=1 npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b2afc390848327a0dbfaf7f3a78afe