### PR TITLE
feat(dashboard/mini): ajoute fallback 404 pour GitHub Pages

### DIFF
--- a/dashboard/mini/package.json
+++ b/dashboard/mini/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest",
+    "postbuild": "node scripts/copy-404.js"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.8",

--- a/dashboard/mini/scripts/copy-404.js
+++ b/dashboard/mini/scripts/copy-404.js
@@ -1,0 +1,18 @@
+import { copyFile } from 'fs/promises';
+import { resolve } from 'path';
+
+const distDir = resolve('dist');
+const src = resolve(distDir, 'index.html');
+const dest = resolve(distDir, '404.html');
+
+async function main() {
+  try {
+    await copyFile(src, dest);
+    console.log('404.html created');
+  } catch (error) {
+    console.error('Unable to create 404.html', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Résumé
- copie `dist/index.html` en `dist/404.html` après build pour la compatibilité SPA sur GitHub Pages
- exécute le script de copie via `postbuild`

## Tests
- `npm --prefix dashboard/mini test`
- `npm --prefix dashboard/mini run build` *(échoue : Property 'orderBy' does not exist on type ...)*
- `npx vite build` puis `node scripts/copy-404.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2afb08e7c83278637deb229b9451d