### PR TITLE
Simplifie la CI pour le déploiement Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Run E2E tests (preview)
         working-directory: dashboard/mini
         env:
-          PREVIEW_URL: ${{ needs.vercel-deploy.outputs.preview-url }}
+          PREVIEW_URL: ${{ needs.vercel-deploy.outputs.preview-url || secrets.PREVIEW_URL }}
         run: npm run e2e:ci
       - name: Upload Playwright report
         if: always()


### PR DESCRIPTION
## Résumé
- retire toute référence à `deploy-pages`
- utilise l’URL de prévisualisation Vercel avec repli sur `secrets.PREVIEW_URL` dans `e2e-preview`

## Tests
- `pytest`
- `npm test -- --run --coverage` *(échec : url.toJSON is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c558dd3c83278bcba1908d650b66