### PR TITLE
fix: ignorer node-websocket dans vitest

### DIFF
--- a/dashboard/mini/vite.config.ts
+++ b/dashboard/mini/vite.config.ts
@@ -8,6 +8,12 @@ const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? '';
 export default defineConfig({
   base: repo ? `/${repo}/` : '/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      'node-websocket': false,
+      ws: false,
+    },
+  },
   server: {
     host: true, // équivaut à 0.0.0.0
     port: 5173,

--- a/dashboard/mini/vitest.config.ts
+++ b/dashboard/mini/vitest.config.ts
@@ -1,10 +1,16 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'node-websocket': false,
+      ws: false,
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['tests-e2e/**'],
+    exclude: [...defaultExclude, 'tests-e2e/**'],
     env: {
       VITE_API_BASE_URL: 'http://localhost:8000',
       VITE_API_TIMEOUT_MS: '15000',


### PR DESCRIPTION
## Résumé
- ignore `node-websocket` et `ws` via des alias Vite/Vitest
- réintroduit l'exclusion par défaut de Vitest pour écarter `node_modules`

## Tests
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b2cfc68c0c8327b04533fd6f3d2296