### PR TITLE
fix: add run ordering options in mini dashboard

### DIFF
--- a/dashboard/mini/src/__tests__/RunsTable.navigation.test.tsx
+++ b/dashboard/mini/src/__tests__/RunsTable.navigation.test.tsx
@@ -108,7 +108,9 @@ describe('RunsTable navigation', () => {
       };
     });
     const Wrapper = () => {
-      const [orderBy, setOrderBy] = React.useState('started_at');
+      const [orderBy, setOrderBy] = React.useState<
+        'started_at' | 'ended_at' | 'title' | 'status'
+      >('started_at');
       return (
         <RunsTable
           page={1}

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -53,6 +53,10 @@ export const listRuns = async (
     dateFrom?: string;
     dateTo?: string;
     title?: string;
+    /** colonne de tri côté API (ex: 'started_at' | 'ended_at' | 'title' | 'status') */
+    orderBy?: 'started_at' | 'ended_at' | 'title' | 'status';
+    /** sens du tri */
+    orderDir?: 'asc' | 'desc';
   },
   opts: FetchOpts = {},
 ): Promise<Page<Run>> => {
@@ -66,8 +70,8 @@ export const listRuns = async (
     started_from: params.dateFrom,
     started_to: params.dateTo,
     title_contains: params.title,
-    order_by: params.orderBy,
-    order_dir: params.orderDir,
+    ...(params.orderBy ? { order_by: params.orderBy } : {}),
+    ...(params.orderDir ? { order_dir: params.orderDir } : {}),
   };
   const { data, headers } = await fetchJson<{ items: BackendRun[] }>('/runs', {
     ...opts,

--- a/dashboard/mini/src/api/hooks.ts
+++ b/dashboard/mini/src/api/hooks.ts
@@ -26,7 +26,7 @@ export const useRuns = (
     dateFrom?: string;
     dateTo?: string;
     title?: string;
-    orderBy?: string;
+    orderBy?: 'started_at' | 'ended_at' | 'title' | 'status';
     orderDir?: 'asc' | 'desc';
   },
   opts?: { enabled?: boolean },

--- a/dashboard/mini/src/components/RunsTable.tsx
+++ b/dashboard/mini/src/components/RunsTable.tsx
@@ -11,11 +11,13 @@ export type RunsTableProps = {
   dateFrom?: string;
   dateTo?: string;
   title?: string;
-  orderBy: string;
+  orderBy: 'started_at' | 'ended_at' | 'title' | 'status';
   orderDir: 'asc' | 'desc';
   onPageChange: (nextPage: number) => void;
   onPageSizeChange: (size: number) => void;
-  onOrderByChange: (field: string) => void;
+  onOrderByChange: (
+    field: 'started_at' | 'ended_at' | 'title' | 'status',
+  ) => void;
   onOrderDirChange: (dir: 'asc' | 'desc') => void;
   onOpenRun: (id: string) => void;
 };
@@ -172,19 +174,21 @@ export const RunsTable = ({
             </option>
           ))}
         </select>
-        <label style={{ marginLeft: '8px' }}>
-          Trier par
-          <select
-            aria-label="order-by"
-            value={orderBy}
-            onChange={(e) => {
-              onOrderByChange(e.target.value);
-              onPageChange(1);
-            }}
-            style={{ marginLeft: '4px' }}
-          >
-            {['started_at', 'ended_at', 'title', 'status'].map((f) => (
-              <option key={f} value={f}>
+          <label style={{ marginLeft: '8px' }}>
+            Trier par
+            <select
+              aria-label="order-by"
+              value={orderBy}
+              onChange={(e) => {
+                onOrderByChange(
+                  e.target.value as 'started_at' | 'ended_at' | 'title' | 'status',
+                );
+                onPageChange(1);
+              }}
+              style={{ marginLeft: '4px' }}
+            >
+              {['started_at', 'ended_at', 'title', 'status'].map((f) => (
+                <option key={f} value={f}>
                 {f}
               </option>
             ))}

--- a/dashboard/mini/src/pages/RunsPage.tsx
+++ b/dashboard/mini/src/pages/RunsPage.tsx
@@ -17,7 +17,9 @@ const RunsPage = (): JSX.Element => {
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [titleInput, setTitleInput] = useState('');
-  const [orderBy, setOrderBy] = useState('started_at');
+  const [orderBy, setOrderBy] = useState<
+    'started_at' | 'ended_at' | 'title' | 'status'
+  >('started_at');
   const [orderDir, setOrderDir] = useState<'asc' | 'desc'>('desc');
 
   const title = useDebouncedValue(titleInput, 300);


### PR DESCRIPTION
## Summary
- allow specifying orderBy/orderDir when listing runs
- propagate ordering types through hooks and components

## Testing
- `make dash-mini-build` *(interrupted après le lancement du serveur de preview)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d93e16348327a209edf778256ad4