### PR TITLE
Nettoyage des runs générés par les tests

### DIFF
--- a/api/tests/test_tasks_meta_e2e.py
+++ b/api/tests/test_tasks_meta_e2e.py
@@ -3,10 +3,13 @@ import json
 import time
 
 import pytest
+import uuid
+from sqlalchemy import delete, select
+from api.database.models import Run, Node, Artifact, Event
 
 
 @pytest.mark.asyncio
-async def test_events_include_llm_metadata(async_client, monkeypatch, tmp_path):
+async def test_events_include_llm_metadata(async_client, monkeypatch, tmp_path, db_session):
     async def fake_run_graph(dag, storage, run_id, override_completed, dry_run, on_node_start, on_node_end):
         node = {"title": "T1"}
         node_key = "n1"
@@ -35,6 +38,7 @@ async def test_events_include_llm_metadata(async_client, monkeypatch, tmp_path):
     r = await async_client.post("/tasks", headers=headers, json=payload)
     assert r.status_code == 202
     run_id = r.json()["run_id"]
+    run_uuid = uuid.UUID(run_id)
 
     deadline = time.monotonic() + 10.0  # 10s max
     while time.monotonic() < deadline:
@@ -56,3 +60,14 @@ async def test_events_include_llm_metadata(async_client, monkeypatch, tmp_path):
     assert meta.get("latency_ms") == 123
     assert meta.get("usage") == {"prompt_tokens": 1, "completion_tokens": 0}
     assert meta.get("request_id") == "req-456"
+
+    # nettoyage des données créées pendant le test
+    await db_session.execute(delete(Event).where(Event.run_id == run_uuid))
+    await db_session.execute(
+        delete(Artifact).where(
+            Artifact.node_id.in_(select(Node.id).where(Node.run_id == run_uuid))
+        )
+    )
+    await db_session.execute(delete(Node).where(Node.run_id == run_uuid))
+    await db_session.execute(delete(Run).where(Run.id == run_uuid))
+    await db_session.commit()

--- a/tests_api/test_node_completed_meta.py
+++ b/tests_api/test_node_completed_meta.py
@@ -1,8 +1,10 @@
 # api/tests/test_node_completed_meta.py
-import asyncio, json, pytest
+import asyncio, json, pytest, uuid
+from sqlalchemy import delete, select
+from api.database.models import Run, Node, Artifact, Event
 
 @pytest.mark.asyncio
-async def test_node_completed_has_meta(async_client):
+async def test_node_completed_has_meta(async_client, db_session):
     r = await async_client.post("/tasks",
         headers={"X-API-Key":"test-key"},
         json={
@@ -12,6 +14,7 @@ async def test_node_completed_has_meta(async_client):
         }
     )
     rid = r.json()["run_id"]
+    run_uuid = uuid.UUID(rid)
     for _ in range(80):
         rs = await async_client.get(f"/runs/{rid}", headers={"X-API-Key":"test-key"})
         if rs.json()["status"] in ("completed","failed"):
@@ -26,3 +29,14 @@ async def test_node_completed_has_meta(async_client):
     assert msgs, "missing NODE_COMPLETED"
     meta = json.loads(msgs[0])
     assert isinstance(meta, dict)
+
+    # nettoyage de la base pour éviter les effets de bord
+    await db_session.execute(delete(Event).where(Event.run_id == run_uuid))
+    await db_session.execute(
+        delete(Artifact).where(
+            Artifact.node_id.in_(select(Node.id).where(Node.run_id == run_uuid))
+        )
+    )
+    await db_session.execute(delete(Node).where(Node.run_id == run_uuid))
+    await db_session.execute(delete(Run).where(Run.id == run_uuid))
+    await db_session.commit()

--- a/tests_api/test_tasks_happy_e2e.py
+++ b/tests_api/test_tasks_happy_e2e.py
@@ -1,18 +1,25 @@
 import asyncio, json, pytest
 
+import uuid
+from sqlalchemy import delete, select
+from api.database.models import Run, Node, Artifact, Event
+
+
 @pytest.mark.asyncio
-async def test_post_tasks_and_follow(async_client):
+async def test_post_tasks_and_follow(async_client, db_session):
     # 202 + run_id
-    r = await async_client.post("/tasks",
-        headers={"X-API-Key":"test-key"},
+    r = await async_client.post(
+        "/tasks",
+        headers={"X-API-Key": "test-key"},
         json={
-            "title":"Demo",
-            "task":{"title":"Demo","plan":[{"id":"n1","title":"T1"}]},
-            "options":{"resume":False,"dry_run":False,"override":[]}
-        }
+            "title": "Demo",
+            "task": {"title": "Demo", "plan": [{"id": "n1", "title": "T1"}]},
+            "options": {"resume": False, "dry_run": False, "override": []},
+        },
     )
     assert r.status_code == 202
     rid = r.json()["run_id"]
+    run_uuid = uuid.UUID(rid)
 
     # poll jusqu'à fin
     for _ in range(80):
@@ -29,3 +36,14 @@ async def test_post_tasks_and_follow(async_client):
     )
     assert events.status_code == 200
     assert any(e["level"].startswith("RUN_") for e in events.json()["items"])
+
+    # nettoyage
+    await db_session.execute(delete(Event).where(Event.run_id == run_uuid))
+    await db_session.execute(
+        delete(Artifact).where(
+            Artifact.node_id.in_(select(Node.id).where(Node.run_id == run_uuid))
+        )
+    )
+    await db_session.execute(delete(Node).where(Node.run_id == run_uuid))
+    await db_session.execute(delete(Run).where(Run.id == run_uuid))
+    await db_session.commit()


### PR DESCRIPTION
## Résumé
- Nettoie les runs, événements, noeuds et artefacts créés lors des tests de tâches
- Évite les effets de bord sur les tests de pagination en assurant une base de données propre

## Tests
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b4811609e88327b4f81543659c3996