### PR TITLE
ci: réactive le job alembic-heads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,25 @@ jobs:
             htmlcov
             dashboard/mini/coverage
 
+  alembic-heads:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Check Alembic heads
+        run: |
+          alembic heads
+          test $(alembic heads | wc -l) -eq 1
+
   coverage-merge:
     needs: lint-and-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Résumé
- réintroduit un job `alembic-heads` indépendant
- vérifie qu'une seule tête Alembic est présente

## Tests
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b483a11b5c83278cac5b54ed956d6e