### PR TITLE
ci: mettre en cache Playwright pour e2e preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
       - name: Install dependencies
         working-directory: dashboard/mini
         run: npm ci
+      - name: Cache Playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('dashboard/mini/package-lock.json') }}
       - name: Install Playwright
         working-directory: dashboard/mini
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Résumé
- ajoute une étape de cache Playwright dans le job `e2e-preview`

## Tests
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b485a781b4832789a5982f6069915d