### PR TITLE
test: vérifier la bannière de clé API

### DIFF
--- a/dashboard/mini/src/__tests__/ApiKeyBanner.test.tsx
+++ b/dashboard/mini/src/__tests__/ApiKeyBanner.test.tsx
@@ -16,26 +16,21 @@ describe('ApiKeyBanner', () => {
     vi.unstubAllEnvs();
   });
 
-  it('affiche la bannière si aucune clé', () => {
-    render(
-      <ApiKeyProvider>
-        <ApiKeyBanner />
-      </ApiKeyProvider>,
-    );
-    expect(screen.getByRole('alert')).toHaveTextContent('API Key requise');
-  });
-
-  it('cache la bannière après saisie', () => {
+  it("affiche l'alerte puis la cache après enregistrement", () => {
     render(
       <ApiKeyProvider>
         <ApiKeyInput />
         <ApiKeyBanner />
       </ApiKeyProvider>,
     );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('API Key requise');
+
     fireEvent.change(screen.getByLabelText('api-key'), {
       target: { value: 'abc' },
     });
     fireEvent.click(screen.getByText('Enregistrer'));
+
     expect(screen.queryByRole('alert')).toBeNull();
   });
 


### PR DESCRIPTION
## Résumé
- Teste l'apparition de l'alerte "API Key requise" sans clé
- Simule la saisie de la clé puis vérifie que la bannière disparaît
- Confirme l'absence de bannière lorsqu'une clé .env est présente

## Tests
- `cd dashboard/mini && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b485afcf748327aa3ff4bf5625bf65