### PR TITLE
Rendre le PREVIEW_URL plus robuste dans e2e-preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,13 @@ jobs:
       - name: Install Playwright
         working-directory: dashboard/mini
         run: npx playwright install --with-deps
+      - name: Echo PREVIEW_URL
+        run: |
+          if [ -n "${{ needs.vercel-deploy.outputs.preview-url }}" ]; then
+            echo "Using Vercel preview URL"
+          else
+            echo "Using PREVIEW_URL secret"
+          fi
       - name: Run E2E tests (preview)
         working-directory: dashboard/mini
         env:


### PR DESCRIPTION
## Résumé
- journalise la source de l'URL de prévisualisation utilisée pour les tests E2E
- conserve la logique existante pour sélectionner l'URL

## Tests
- `yamllint .github/workflows/ci.yml` *(échoue: line-length, document-start, truthy)*

------
https://chatgpt.com/codex/tasks/task_e_68b485d73bec832781ffd44bc5b4bf89