### PR TITLE
Ajouter la concurrence au workflow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Résumé
- annule automatiquement les exécutions CI obsolètes sur la même ref

## Tests
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48d2333248327b1e5633fca0abbbc