### PR TITLE
docs(dashboard): ajoute badges CI et couverture

### DIFF
--- a/dashboard/mini/README.md
+++ b/dashboard/mini/README.md
@@ -1,3 +1,7 @@
+![CI](https://img.shields.io/github/actions/workflow/status/<owner>/<repo>/ci.yml?branch=main)
+[![codecov](https://codecov.io/gh/<owner>/<repo>/branch/main/graph/badge.svg)](https://codecov.io/gh/<owner>/<repo>)
+![E2E](https://img.shields.io/badge/E2E-Playwright-blue)
+
 # Fil G – Mini Dashboard (read-only)
 
 ## Introduction


### PR DESCRIPTION
## Résumé
- ajoute les badges CI, Codecov et E2E dans le README du mini dashboard

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b48d36c7408327ba994993c44a46fa