### PR TITLE
Ajout du fichier .env.example pour l'API

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,2 @@
+ALLOWED_ORIGINS=http://localhost:5173,https://<org>-<project>-<hash>.vercel.app
+API_KEY=changeme


### PR DESCRIPTION
## Résumé
- ajoute un `.env.example` pour le backend avec la configuration CORS et une clé API factice

## Tests
- `pre-commit run --files api/.env.example`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48d420ca48327a5b9eebdbdbe0711