### PR TITLE
ci: cache pip dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- cache pip directory in CI

## Testing
- `ruff check .` *(fails: unused import F401 in alembic/versions)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b490632b588327bd6ff74c7a55fd95