### PR TITLE
test: vérifie tri et pagination en e2e

### DIFF
--- a/dashboard/mini/tests-e2e/preview.spec.ts
+++ b/dashboard/mini/tests-e2e/preview.spec.ts
@@ -52,4 +52,14 @@ test('preview UI fonctionne avec API mockée', async ({ page }) => {
   // Navigue vers Runs et attend l'affichage d'au moins un item
   await page.goto(`${PREVIEW_URL}/runs`);
   await expect(page.getByRole('row', { name: /run-1/ })).toBeVisible();
+
+  // Contrôles de tri visibles
+  const orderBySelect = page.locator('[aria-label="order-by"]');
+  const orderDirSelect = page.locator('[aria-label="order-dir"]');
+  await expect(orderBySelect).toBeVisible();
+  await expect(orderDirSelect).toBeVisible();
+
+  // Change l'ordre et vérifie la pagination
+  await orderBySelect.selectOption('ended_at');
+  await expect(page.getByRole('button', { name: 'Suivant' })).toBeEnabled();
 });


### PR DESCRIPTION
## Résumé
- teste la visibilité des sélecteurs de tri sur /runs
- vérifie l'état de la pagination après changement de tri

## Tests
- `npm test`
- `npm run e2e` (skipped: PREVIEW_URL non défini)


------
https://chatgpt.com/codex/tasks/task_e_68b48d484b008327aff141fc998f3e42