### PR TITLE
ci: publier un résumé E2E preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,11 @@ jobs:
         with:
           name: playwright-report
           path: dashboard/mini/playwright-report
+      - name: Publish job summary
+        if: always()
+        env:
+          PREVIEW_URL: ${{ needs.vercel-deploy.outputs.preview-url || secrets.PREVIEW_URL }}
+        run: |
+          echo "### E2E Preview" >> $GITHUB_STEP_SUMMARY
+          echo "- URL: $PREVIEW_URL" >> $GITHUB_STEP_SUMMARY
+          echo "- Rapport: voir artifact \`playwright-report\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Résumé
- Ajouter une étape qui publie l'URL testée et le lien vers le rapport Playwright dans le job `e2e-preview`.

## Tests
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48d4eb9c88327b158a830734a3af9