### PR TITLE
chore: lint e2e tests

### DIFF
--- a/dashboard/mini/.eslintignore
+++ b/dashboard/mini/.eslintignore
@@ -1,0 +1,7 @@
+# Rapports et résultats générés par Playwright
+# Ces dossiers contiennent des fichiers temporaires qui ne doivent pas être lintés
+
+# Rapports HTML générés
+tests-e2e/playwright-report/
+# Résultats bruts des tests
+tests-e2e/test-results/


### PR DESCRIPTION
## Summary
- ignore Playwright output directories for linting

## Testing
- `npm run lint` *(fails: Prettier errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d57b55c83278916ef56325e22d1