### PR TITLE
Exécuter alembic-heads aussi sur PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,12 @@ jobs:
           pip install -e .
       - name: Check Alembic heads
         run: |
-          alembic heads
-          test $(alembic heads | wc -l) -eq 1
+          HEADS=$(alembic heads | tee /tmp/heads | wc -l)
+          if [ "$HEADS" -ne 1 ]; then
+            echo "Multiple Alembic heads detected:"
+            cat /tmp/heads
+            exit 1
+          fi
 
   coverage-merge:
     needs: lint-and-test


### PR DESCRIPTION
## Summary
- exécute un contrôle Alembic indépendant qui échoue en cas de têtes multiples

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b48d61646c8327a9d2837e4d7aacdd