### PR TITLE
feat: add request id middleware and observability

### DIFF
--- a/api/fastapi_app/observability/__init__.py
+++ b/api/fastapi_app/observability/__init__.py
@@ -1,0 +1,18 @@
+from .metrics import (
+    metrics_enabled,
+    get_http_requests_total,
+    get_http_requests_total_family,
+    get_http_request_duration_seconds,
+    generate_latest,
+)
+from .sentry import init_sentry, SentryContextMiddleware
+
+__all__ = [
+    "metrics_enabled",
+    "get_http_requests_total",
+    "get_http_requests_total_family",
+    "get_http_request_duration_seconds",
+    "generate_latest",
+    "init_sentry",
+    "SentryContextMiddleware",
+]

--- a/api/fastapi_app/observability/metrics.py
+++ b/api/fastapi_app/observability/metrics.py
@@ -1,0 +1,16 @@
+"""Wrappers autour des métriques Prometheus."""
+from core.telemetry.metrics import (
+    metrics_enabled,
+    get_http_requests_total,
+    get_http_requests_total_family,
+    get_http_request_duration_seconds,
+    generate_latest,
+)
+
+__all__ = [
+    "metrics_enabled",
+    "get_http_requests_total",
+    "get_http_requests_total_family",
+    "get_http_request_duration_seconds",
+    "generate_latest",
+]

--- a/api/fastapi_app/observability/sentry.py
+++ b/api/fastapi_app/observability/sentry.py
@@ -1,0 +1,39 @@
+"""Initialisation et middleware Sentry."""
+from __future__ import annotations
+
+import os
+
+import sentry_sdk
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+def init_sentry() -> bool:
+    """Initialise Sentry à partir des variables d'environnement."""
+    dsn = os.getenv("SENTRY_DSN", "")
+    if not dsn:
+        return False
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.getenv("SENTRY_ENV", "dev"),
+        release=os.getenv("RELEASE", "crew_ia@dev"),
+    )
+    return True
+
+
+class SentryContextMiddleware(BaseHTTPMiddleware):
+    """Annote les événements Sentry avec contexte requête."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        rid = getattr(request.state, "request_id", None)
+        if rid:
+            sentry_sdk.set_tag("request_id", rid)
+        try:
+            response = await call_next(request)
+        except Exception:
+            sentry_sdk.set_tag("route", request.url.path)
+            sentry_sdk.set_tag("status", 500)
+            raise
+        sentry_sdk.set_tag("route", request.url.path)
+        sentry_sdk.set_tag("status", response.status_code)
+        return response

--- a/core/telemetry/metrics.py
+++ b/core/telemetry/metrics.py
@@ -18,6 +18,7 @@ _runs_total: Optional[Counter] = None
 _run_duration_seconds: Optional[Histogram] = None
 _llm_tokens_total: Optional[Counter] = None
 _llm_cost_total: Optional[Counter] = None
+_http_requests_total_family: Optional[Counter] = None
 
 
 def metrics_enabled() -> bool:
@@ -40,6 +41,18 @@ def get_http_requests_total() -> Counter:
             registry=registry,
         )
     return _http_requests_total
+
+
+def get_http_requests_total_family() -> Counter:
+    global _http_requests_total_family
+    if _http_requests_total_family is None:
+        _http_requests_total_family = Counter(
+            "http_requests_total_family",
+            "Total des requêtes HTTP par famille",
+            ["route", "method", "status_family"],
+            registry=registry,
+        )
+    return _http_requests_total_family
 
 
 def get_http_request_duration_seconds() -> Histogram:

--- a/tests_api/test_cors.py
+++ b/tests_api/test_cors.py
@@ -8,13 +8,15 @@ async def test_cors_options_localhost(client: AsyncClient):
         "/health",
         headers={
             "Origin": "http://localhost:5173",
-            "Access-Control-Request-Method": "GET",
-            "Access-Control-Request-Headers": "Content-Type,X-API-Key",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type,Authorization,X-API-Key,X-Request-ID",
         },
     )
     assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
     allow_methods = response.headers.get("access-control-allow-methods", "")
-    assert "GET" in allow_methods and "OPTIONS" in allow_methods
+    for method in ("GET", "POST", "PATCH", "OPTIONS"):
+        assert method in allow_methods
     allow_headers = response.headers.get("access-control-allow-headers", "").lower()
-    assert "content-type" in allow_headers and "x-api-key" in allow_headers
+    for header in ("content-type", "authorization", "x-api-key", "x-request-id"):
+        assert header in allow_headers

--- a/tests_api/test_cors_preview.py
+++ b/tests_api/test_cors_preview.py
@@ -24,17 +24,19 @@ async def test_cors_preview(monkeypatch):
                 "/health",
                 headers={
                     "Origin": origin,
-                    "Access-Control-Request-Method": "GET",
-                    "Access-Control-Request-Headers": "Content-Type,X-API-Key",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "Content-Type,Authorization,X-API-Key,X-Request-ID",
                 },
             )
 
     assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == origin
     allow_methods = response.headers.get("access-control-allow-methods", "")
-    assert "GET" in allow_methods and "OPTIONS" in allow_methods
+    for method in ("GET", "POST", "PATCH", "OPTIONS"):
+        assert method in allow_methods
     allow_headers = response.headers.get("access-control-allow-headers", "").lower()
-    assert "content-type" in allow_headers and "x-api-key" in allow_headers
+    for header in ("content-type", "authorization", "x-api-key", "x-request-id"):
+        assert header in allow_headers
 
     if original is not None:
         monkeypatch.setenv("ALLOWED_ORIGINS", original)

--- a/tests_api/test_metrics.py
+++ b/tests_api/test_metrics.py
@@ -45,6 +45,7 @@ async def test_metrics_endpoint_enabled(monkeypatch):
     payload = resp.text
     for name in [
         "http_requests_total",
+        "http_requests_total_family",
         "http_request_duration_seconds_bucket",
         "db_pool_in_use",
         "orchestrator_node_duration_seconds_bucket",

--- a/tests_api/test_request_id_header.py
+++ b/tests_api/test_request_id_header.py
@@ -1,0 +1,15 @@
+import json
+import logging
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_request_id_header_and_log(client, caplog):
+    with caplog.at_level(logging.INFO, logger="api.access"):
+        resp = await client.get("/health")
+    assert resp.status_code == 200
+    rid = resp.headers.get("X-Request-ID")
+    assert rid
+    logged = [json.loads(r.message)["request_id"] for r in caplog.records]
+    assert rid in logged


### PR DESCRIPTION
## Summary
- propager X-Request-ID et annoter Sentry
- exposer métriques Prometheus avec comptage par code et par famille
- autoriser Authorization/X-Request-ID côté CORS

## Testing
- `pytest tests_api/test_request_id_header.py tests_api/test_request_id_event.py tests_api/test_metrics.py tests_api/test_health.py tests_api/test_cors.py tests_api/test_cors_preview.py`

------
https://chatgpt.com/codex/tasks/task_e_68b49af1dd448327b5546320e8736721