### PR TITLE
feat: orchestrator start with sidecars and recovery

### DIFF
--- a/api/tests/test_tasks_meta_e2e.py
+++ b/api/tests/test_tasks_meta_e2e.py
@@ -10,7 +10,7 @@ from api.database.models import Run, Node, Artifact, Event
 
 @pytest.mark.asyncio
 async def test_events_include_llm_metadata(async_client, monkeypatch, tmp_path, db_session):
-    async def fake_run_graph(dag, storage, run_id, override_completed, dry_run, on_node_start, on_node_end):
+    async def fake_run_graph(dag, storage, run_id, override_completed, dry_run, on_node_start, on_node_end, **kwargs):
         node = {"title": "T1"}
         node_key = "n1"
         await on_node_start(node, node_key)

--- a/apps/orchestrator/service.py
+++ b/apps/orchestrator/service.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import uuid
+import asyncio
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Set
+
+from core.planning.task_graph import TaskGraph
+from core.storage.db_models import Run, RunStatus, Node, NodeStatus
+from core.storage.composite_adapter import CompositeAdapter
+from apps.orchestrator.executor import run_graph
+
+
+class OrchestratorService:
+    """Service simple pour lancer un plan depuis ``plans.graph``."""
+
+    def __init__(self, storage: CompositeAdapter, plans_path: str | Path | None = None):
+        self.storage = storage
+        self.plans_path = Path(plans_path or "plans.graph")
+        self._pause_event: asyncio.Event = asyncio.Event()
+        self._pause_event.set()
+        self._task: Optional[asyncio.Task] = None
+        self._skip: Set[str] = set()
+        self._overrides: Dict[str, Dict[str, Any]] = {}
+        self._node_ids: Dict[str, uuid.UUID] = {}
+        self.run_id: Optional[str] = None
+
+    def override(self, node_key: str, *, prompt: str | None = None, params: Dict[str, Any] | None = None) -> None:
+        self._overrides[node_key] = {"prompt": prompt, "params": params}
+
+    def skip(self, node_key: str) -> None:
+        self._skip.add(node_key)
+
+    async def pause(self) -> None:
+        self._pause_event.clear()
+
+    async def resume(self) -> None:
+        self._pause_event.set()
+
+    async def start(self, plan_id: str, *, dry_run: bool = False) -> str:
+        data = json.loads(self.plans_path.read_text(encoding="utf-8"))
+        if data.get("version") != "1.0":
+            raise ValueError("plans.graph version non supportée")
+        plan_spec = data.get("plans", {}).get(plan_id)
+        if not plan_spec:
+            raise ValueError("plan introuvable")
+        dag = TaskGraph.from_plan(plan_spec)
+
+        run_uuid = uuid.uuid4()
+        self.run_id = str(run_uuid)
+        now = datetime.now(timezone.utc)
+        await self.storage.save_run(
+            Run(id=run_uuid, title=plan_spec.get("title") or plan_id, status=RunStatus.running, started_at=now)
+        )
+
+        for n in dag.nodes.values():
+            nid = uuid.uuid4()
+            self._node_ids[n.id] = nid
+            await self.storage.save_node(
+                Node(id=nid, run_id=run_uuid, key=n.id, title=n.title, status=NodeStatus.pending)
+            )
+
+        async def on_start(node, node_key):
+            nid = self._node_ids.get(node_key)
+            if nid:
+                await self.storage.save_node(
+                    Node(id=nid, run_id=run_uuid, key=node_key, title=getattr(node, "title", node_key), status=NodeStatus.running, started_at=datetime.now(timezone.utc))
+                )
+                setattr(node, "db_id", str(nid))
+
+        async def on_end(node, node_key, status):
+            nid = self._node_ids.get(node_key)
+            if nid:
+                await self.storage.save_node(
+                    Node(id=nid, run_id=run_uuid, key=node_key, title=getattr(node, "title", node_key), status=NodeStatus.completed if status=="completed" else NodeStatus.failed, updated_at=datetime.now(timezone.utc))
+                )
+
+        self._task = asyncio.create_task(
+            run_graph(
+                dag,
+                self.storage,
+                self.run_id,
+                dry_run=dry_run,
+                on_node_start=on_start,
+                on_node_end=on_end,
+                pause_event=self._pause_event,
+                skip_nodes=self._skip,
+                overrides=self._overrides,
+            )
+        )
+        return self.run_id
+
+    async def wait(self) -> None:
+        if self._task:
+            await self._task

--- a/plans.graph
+++ b/plans.graph
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "plans": {
+    "demo": {
+      "title": "Plan de démonstration",
+      "plan": [
+        {"id": "n1", "title": "Étape 1", "llm": {"provider": "openai", "model": "test-model"}},
+        {"id": "n2", "title": "Étape 2", "deps": ["n1"], "llm": {"provider": "openai", "model": "test-model"}}
+      ]
+    }
+  }
+}

--- a/tests/test_llm_meta_fallback_fs.py
+++ b/tests/test_llm_meta_fallback_fs.py
@@ -44,7 +44,7 @@ async def test_llm_meta_fallback_fs(tmp_path, monkeypatch):
     run_id = str(uuid.uuid4())
 
     async def fake_run_graph(
-        dag, storage, run_id, override_completed, dry_run, on_node_start, on_node_end
+        dag, storage, run_id, override_completed, dry_run, on_node_start, on_node_end, **kwargs
     ):
         node = {"title": "T1"}
         node_key = "n1"

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -1,0 +1,102 @@
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from apps.orchestrator.service import OrchestratorService
+from core.storage.file_adapter import FileAdapter
+from core.storage.composite_adapter import CompositeAdapter
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    runs_root = tmp_path / ".runs"
+    runs_root.mkdir()
+    monkeypatch.setenv("RUNS_ROOT", str(runs_root))
+    plans = {
+        "version": "1.0",
+        "plans": {
+            "p1": {
+                "title": "Test",
+                "plan": [
+                    {"id": "n1", "title": "A", "llm": {"provider": "openai", "model": "x"}},
+                    {"id": "n2", "title": "B", "deps": ["n1"], "llm": {"provider": "openai", "model": "x"}},
+                ],
+            }
+        },
+    }
+    plan_path = tmp_path / "plans.graph"
+    plan_path.write_text(json.dumps(plans))
+    monkeypatch.chdir(tmp_path)
+    return CompositeAdapter([FileAdapter(str(runs_root))])
+
+
+@pytest.mark.asyncio
+async def test_start(storage, monkeypatch):
+    calls = []
+
+    async def fake_agent(node):
+        calls.append(node.id)
+        return {"markdown": node.id, "llm": {"provider": "openai", "model_used": "x", "prompts": {"final": node.llm.get("prompt", "")}}}
+
+    monkeypatch.setattr("apps.orchestrator.executor.agent_runner", fake_agent)
+    svc = OrchestratorService(storage)
+    run_id = await svc.start("p1")
+    await svc.wait()
+    assert calls == ["n1", "n2"]
+    side = json.loads((Path(os.getenv("RUNS_ROOT")) / run_id / "nodes" / "n1" / "artifact_n1.llm.json").read_text())
+    assert side["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_dry_run(storage, monkeypatch):
+    calls = []
+
+    async def fake_agent(node):
+        calls.append(node.id)
+        return {"markdown": node.id, "llm": {"provider": "openai", "model_used": "x"}}
+
+    monkeypatch.setattr("apps.orchestrator.executor.agent_runner", fake_agent)
+    svc = OrchestratorService(storage)
+    run_id = await svc.start("p1", dry_run=True)
+    await svc.wait()
+    assert calls == []
+    side = json.loads((Path(os.getenv("RUNS_ROOT")) / run_id / "nodes" / "n1" / "artifact_n1.llm.json").read_text())
+    assert side["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_override(storage, monkeypatch):
+    async def fake_agent(node):
+        return {"markdown": node.id, "llm": {"provider": "openai", "model_used": "x", "prompts": {"final": node.llm.get("prompt", "")}}}
+
+    monkeypatch.setattr("apps.orchestrator.executor.agent_runner", fake_agent)
+    svc = OrchestratorService(storage)
+    svc.override("n1", prompt="OVR")
+    run_id = await svc.start("p1")
+    await svc.wait()
+    side = json.loads((Path(os.getenv("RUNS_ROOT")) / run_id / "nodes" / "n1" / "artifact_n1.llm.json").read_text())
+    assert side["prompt"] == "OVR"
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_skip(storage, monkeypatch):
+    calls = []
+
+    async def fake_agent(node):
+        calls.append(node.id)
+        await asyncio.sleep(0.01)
+        return {"markdown": node.id, "llm": {"provider": "openai", "model_used": "x"}}
+
+    monkeypatch.setattr("apps.orchestrator.executor.agent_runner", fake_agent)
+    svc = OrchestratorService(storage)
+    await svc.pause()
+    run_id = await svc.start("p1")
+    svc.skip("n2")
+    await svc.resume()
+    await svc.wait()
+    assert calls == ["n1"]
+    side = json.loads((Path(os.getenv("RUNS_ROOT")) / run_id / "nodes" / "n2" / "artifact_n2.llm.json").read_text())
+    assert side["dry_run"] is True


### PR DESCRIPTION
## Summary
- add OrchestratorService capable of loading plans.graph and running DAGs with pause/resume, skip and override controls
- extend executor to emit v1.0 sidecars, support dry-run, overrides and cooperative pausing
- include integration tests for start, dry_run, override and pause/skip behavior

## Testing
- `pytest tests/test_orchestrator_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4a2f0fc948327a81a53efa2645d1a