### PR TITLE
feat: orchestrator stubs and JSON-compatible models

### DIFF
--- a/app/models/assignment.py
+++ b/app/models/assignment.py
@@ -5,8 +5,8 @@ from datetime import datetime, UTC
 from typing import Optional, Dict, Any
 
 import sqlalchemy as sa
-from sqlalchemy import Column, DateTime, ForeignKey, Text, func, Index, JSON
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy import Column, DateTime, ForeignKey, Text, func, Index
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
 from sqlmodel import SQLModel, Field
 
 
@@ -31,7 +31,10 @@ class Assignment(SQLModel, table=True):
     llm_model: str = Field(sa_column=Column(Text, nullable=False))
     params: Optional[Dict[str, Any]] = Field(
         default=None,
-        sa_column=Column(JSON, nullable=True),
+        sa_column=Column(
+            sa.JSON().with_variant(JSONB, "postgresql"),
+            nullable=True,
+        ),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/app/models/plan.py
+++ b/app/models/plan.py
@@ -7,7 +7,7 @@ from typing import Dict, Any
 
 import sqlalchemy as sa
 from sqlalchemy import Column, DateTime, Enum as SAEnum, ForeignKey, Integer, func, Index
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
 from sqlmodel import SQLModel, Field
 
 

--- a/app/services/orchestrator_adapter.py
+++ b/app/services/orchestrator_adapter.py
@@ -1,2 +1,30 @@
 from __future__ import annotations
 
+import uuid
+from typing import Any, Dict
+
+
+async def start(plan_id: uuid.UUID, dry_run: bool = False) -> uuid.UUID:
+    """Démarre un plan via l'orchestrateur.
+
+    Cette implémentation simplifiée se contente de générer et retourner un
+    identifiant de run aléatoire. L'orchestrateur réel se chargerait de
+    l'exécution asynchrone du plan.
+    """
+
+    return uuid.uuid4()
+
+
+async def node_action(
+    node_id: uuid.UUID, action: str, payload: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
+    """Applique une action sur un nœud.
+
+    On retourne le statut après action (ici l'action elle-même) et un indicateur
+    `sidecar_updated` si un override de prompt ou de paramètres est présent.
+    """
+
+    sidecar_updated = bool(payload) and bool(
+        (payload.get("override_prompt") or payload.get("params"))
+    )
+    return {"status_after": action, "sidecar_updated": sidecar_updated}


### PR DESCRIPTION
## Summary
- stub orchestrator adapter for starting plans and node actions
- ensure Plan.graph and Assignment.params use portable JSON columns

## Testing
- `pytest tests_api/test_tasks_write_api.py tests_api/test_tasks_plan.py tests_api/test_task_start.py tests_api/test_plan_assignments.py -q`
- `pytest api/tests/test_tasks_meta_e2e.py -q`
- `pytest tests/test_llm_meta_fallback_fs.py tests/test_orchestrator_service.py -q`
- `cd dashboard/mini && npm test src/__tests__/lib/http.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5d2a2aa608327bf98596dbf6cc33d