### PR TITLE
feat: ajouter gestion des tâches

### DIFF
--- a/dashboard/mini/src/App.tsx
+++ b/dashboard/mini/src/App.tsx
@@ -4,22 +4,29 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AppLayout from './layouts/AppLayout';
 import RunsPage from './pages/RunsPage';
 import RunDetailPage from './pages/RunDetailPage';
+import TasksPage from './pages/Tasks';
+import TaskDetailPage from './pages/TaskDetail';
 import { ApiKeyProvider } from './state/ApiKeyContext';
+import { ToastProvider } from './components/ToastProvider';
 
 const queryClient = new QueryClient();
 
 export const App = (): JSX.Element => (
   <ApiKeyProvider>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppLayout>
-          <Routes>
-            <Route path="/runs" element={<RunsPage />} />
-            <Route path="/runs/:id" element={<RunDetailPage />} />
-            <Route path="*" element={<Navigate to="/runs" replace />} />
-          </Routes>
-        </AppLayout>
-      </BrowserRouter>
+      <ToastProvider>
+        <BrowserRouter>
+          <AppLayout>
+            <Routes>
+              <Route path="/runs" element={<RunsPage />} />
+              <Route path="/runs/:id" element={<RunDetailPage />} />
+              <Route path="/tasks" element={<TasksPage />} />
+              <Route path="/tasks/:id" element={<TaskDetailPage />} />
+              <Route path="*" element={<Navigate to="/runs" replace />} />
+            </Routes>
+          </AppLayout>
+        </BrowserRouter>
+      </ToastProvider>
     </QueryClientProvider>
   </ApiKeyProvider>
 );

--- a/dashboard/mini/src/__tests__/pages/TaskDetailPage.plan.test.tsx
+++ b/dashboard/mini/src/__tests__/pages/TaskDetailPage.plan.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../../state/ApiKeyContext', () => ({
+  useApiKey: () => ({ apiKey: 'k', useEnvKey: false, setApiKey: vi.fn() }),
+}));
+
+const useTaskMock = vi.fn(() => ({
+  data: { id: '1', title: 't1', status: 'draft', plan: { status: 'draft' } },
+  isLoading: false,
+  isError: false,
+}));
+
+const mutateAsync = vi.fn();
+const useGenerateTaskPlanMock = vi.fn(() => ({ mutateAsync }));
+
+vi.mock('../../api/hooks', () => ({
+  useTask: () => useTaskMock(),
+  useGenerateTaskPlan: () => useGenerateTaskPlanMock(),
+}));
+
+import TaskDetailPage from '../../pages/TaskDetail';
+import { ToastProvider } from '../../components/ToastProvider';
+
+const setup = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/tasks/1']}>
+          <Routes>
+            <Route path="/tasks/:id" element={<TaskDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('TaskDetailPage plan generation', () => {
+  beforeEach(() => {
+    mutateAsync.mockReset();
+  });
+
+  it('success', async () => {
+    mutateAsync.mockResolvedValueOnce({ status: 'ready' });
+    setup();
+    fireEvent.click(screen.getByText('Générer le plan'));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(screen.getByText('Plan généré')).toBeInTheDocument();
+  });
+
+  it('invalid', async () => {
+    mutateAsync.mockResolvedValueOnce({ status: 'invalid', errors: ['oops'] });
+    setup();
+    fireEvent.click(screen.getByText('Générer le plan'));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(screen.getByText('Plan invalide')).toBeInTheDocument();
+    expect(screen.getByText('oops')).toBeInTheDocument();
+  });
+});

--- a/dashboard/mini/src/__tests__/pages/TasksPage.create.test.tsx
+++ b/dashboard/mini/src/__tests__/pages/TasksPage.create.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../../state/ApiKeyContext', () => ({
+  useApiKey: () => ({ apiKey: 'k', useEnvKey: false, setApiKey: vi.fn() }),
+}));
+
+const useTasksMock = vi.fn(() => ({
+  data: { items: [], meta: { page: 1, page_size: 20, total: 0 } },
+  isLoading: false,
+  isError: false,
+}));
+
+const mutateAsync = vi.fn().mockResolvedValue({});
+const useCreateTaskMock = vi.fn(() => ({ mutateAsync }));
+
+vi.mock('../../api/hooks', () => ({
+  useTasks: () => useTasksMock(),
+  useCreateTask: () => useCreateTaskMock(),
+}));
+
+import TasksPage from '../../pages/Tasks';
+import { ToastProvider } from '../../components/ToastProvider';
+
+const setup = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/tasks']}>
+          <Routes>
+            <Route path="/tasks" element={<TasksPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('TasksPage create task', () => {
+  beforeEach(() => {
+    useTasksMock.mockClear();
+    useCreateTaskMock.mockClear();
+  });
+
+  it('open modal and create task', async () => {
+    setup();
+    fireEvent.click(screen.getByText('Nouvelle tâche'));
+    const input = screen.getByPlaceholderText('Titre');
+    fireEvent.change(input, { target: { value: 't1' } });
+    fireEvent.click(screen.getByText('Créer'));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(screen.getByText('Tâche créée')).toBeInTheDocument();
+  });
+});

--- a/dashboard/mini/src/api/http.ts
+++ b/dashboard/mini/src/api/http.ts
@@ -23,6 +23,8 @@ export class ApiError extends Error {
 export interface FetchOpts {
   query?: Record<string, string | number | boolean | undefined>;
   signal?: AbortSignal;
+  method?: 'GET' | 'POST';
+  body?: unknown;
 }
 
 export async function fetchJson<T>(
@@ -44,6 +46,9 @@ export async function fetchJson<T>(
   if (apiKey) {
     headers['X-API-Key'] = apiKey;
   }
+  if (opts.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
 
   const timeoutCtrl = new AbortController();
   const timeoutId = setTimeout(() => timeoutCtrl.abort(), API_TIMEOUT_MS);
@@ -59,8 +64,10 @@ export async function fetchJson<T>(
 
   const fetchOnce = () =>
     fetch(url.toString(), {
+      method: opts.method ?? 'GET',
       headers,
       signal: timeoutCtrl.signal,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
     });
 
   const maxRetries = 2;

--- a/dashboard/mini/src/api/types.ts
+++ b/dashboard/mini/src/api/types.ts
@@ -75,6 +75,30 @@ export interface ArtifactItem {
   url: string;
 }
 
+export type TaskStatus =
+  | 'draft'
+  | 'ready'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'failed';
+
+export interface Plan {
+  status: 'draft' | 'ready' | 'invalid';
+  errors?: string[];
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  created_at?: string;
+  plan?: Plan;
+}
+
+export type TaskDetail = Task;
+
 // Run type as returned by the backend with API status values
 export type BackendRun = Omit<Run, 'status'> & { status: ApiStatus };
 

--- a/dashboard/mini/src/components/TaskFormModal.tsx
+++ b/dashboard/mini/src/components/TaskFormModal.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { useCreateTask } from '../api/hooks';
+import { useToast } from './ToastProvider';
+
+export const TaskFormModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
+  const [title, setTitle] = useState('');
+  const createTask = useCreateTask();
+  const toast = useToast();
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createTask.mutateAsync({ title });
+      toast('Tâche créée', 'success');
+      onClose();
+    } catch {
+      toast("Erreur lors de la création", 'error');
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <form onSubmit={submit} style={{ background: '#fff', padding: '16px' }}>
+        <h3>Nouvelle tâche</h3>
+        <label>
+          Titre
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Titre"
+          />
+        </label>
+        <div style={{ marginTop: '8px' }}>
+          <button type="submit">Créer</button>
+          <button type="button" onClick={onClose} style={{ marginLeft: '8px' }}>
+            Annuler
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default TaskFormModal;

--- a/dashboard/mini/src/components/TasksTable.tsx
+++ b/dashboard/mini/src/components/TasksTable.tsx
@@ -1,0 +1,180 @@
+import type { JSX } from 'react';
+import { Task } from '../api/types';
+import { useTasks } from '../api/hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { ApiError } from '../api/http';
+
+export type TasksTableProps = {
+  page: number;
+  pageSize: number;
+  orderBy: 'created_at' | 'title' | 'status';
+  orderDir: 'asc' | 'desc';
+  onPageChange: (next: number) => void;
+  onPageSizeChange: (s: number) => void;
+  onOrderByChange: (f: 'created_at' | 'title' | 'status') => void;
+  onOrderDirChange: (d: 'asc' | 'desc') => void;
+  onOpenTask: (id: string) => void;
+};
+
+export const TasksTable = ({
+  page,
+  pageSize,
+  orderBy,
+  orderDir,
+  onPageChange,
+  onPageSizeChange,
+  onOrderByChange,
+  onOrderDirChange,
+  onOpenTask,
+}: TasksTableProps): JSX.Element => {
+  const params = { page, pageSize, orderBy, orderDir };
+  const queryClient = useQueryClient();
+  const tasksQuery = useTasks(params);
+
+  const retry = (): void => {
+    queryClient.invalidateQueries({ queryKey: ['tasks', params] });
+  };
+
+  if (tasksQuery.isLoading) {
+    return (
+      <table>
+        <caption>Tâches</caption>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Titre</th>
+            <th>Statut</th>
+            <th>Créée</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <tr key={i} className="skeleton">
+              <td colSpan={4}>Chargement...</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  if (tasksQuery.isError) {
+    const err = tasksQuery.error;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  }
+
+  const items = tasksQuery.data?.items ?? [];
+  const meta = tasksQuery.data?.meta;
+
+  if (items.length === 0) {
+    return <p>Aucune donnée.</p>;
+  }
+
+  const total = meta?.total;
+  const size = pageSize;
+  const maxPage = total !== undefined ? Math.ceil(total / size) : undefined;
+  const hasPrev = Boolean(meta?.prev);
+  const hasNext = Boolean(meta?.next);
+
+  const formatDate = (d?: string): string =>
+    d ? new Date(d).toLocaleString() : '-';
+
+  return (
+    <div>
+      <table>
+        <caption>Tâches</caption>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Titre</th>
+            <th>Statut</th>
+            <th>Créée</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((t: Task) => (
+            <tr
+              key={t.id}
+              onClick={() => onOpenTask(t.id)}
+              style={{ cursor: 'pointer' }}
+            >
+              <td>{t.id}</td>
+              <td>{t.title}</td>
+              <td>{t.status}</td>
+              <td>{formatDate(t.created_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{ marginTop: '8px' }}>
+        <button onClick={() => onPageChange(page - 1)} disabled={!hasPrev}>
+          Précédent
+        </button>
+        <span style={{ margin: '0 8px' }}>
+          Page {page}
+          {maxPage ? ` / ${maxPage}` : ''}
+        </span>
+        {total !== undefined && (
+          <span style={{ marginRight: '8px' }}>Total: {total}</span>
+        )}
+        <button onClick={() => onPageChange(page + 1)} disabled={!hasNext}>
+          Suivant
+        </button>
+        <select
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value))}
+          style={{ marginLeft: '8px' }}
+        >
+          {[10, 20, 50].map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <label style={{ marginLeft: '8px' }}>
+          Trier par
+          <select
+            aria-label="order-by"
+            value={orderBy}
+            onChange={(e) => {
+              onOrderByChange(
+                e.target.value as 'created_at' | 'title' | 'status',
+              );
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            {['created_at', 'title', 'status'].map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: '8px' }}>
+          Direction
+          <select
+            aria-label="order-dir"
+            value={orderDir}
+            onChange={(e) => {
+              onOrderDirChange(e.target.value as 'asc' | 'desc');
+              onPageChange(1);
+            }}
+            style={{ marginLeft: '4px' }}
+          >
+            <option value="asc">asc</option>
+            <option value="desc">desc</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default TasksTable;

--- a/dashboard/mini/src/components/ToastProvider.tsx
+++ b/dashboard/mini/src/components/ToastProvider.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+  type?: 'success' | 'error';
+}
+
+interface ToastContextValue {
+  add: (msg: string, type?: 'success' | 'error') => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }): JSX.Element => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const add = useCallback((message: string, type?: 'success' | 'error') => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ add }}>
+      {children}
+      <div aria-live="assertive" style={{ position: 'fixed', top: 0, right: 0 }}>
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className="toast"
+            style={{
+              margin: '4px',
+              padding: '8px',
+              background: t.type === 'error' ? '#fdd' : '#dfd',
+              border: '1px solid #ccc',
+            }}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = (): ((msg: string, type?: 'success' | 'error') => void) => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx.add;
+};
+
+export default ToastProvider;

--- a/dashboard/mini/src/pages/TaskDetail.tsx
+++ b/dashboard/mini/src/pages/TaskDetail.tsx
@@ -1,0 +1,90 @@
+import type { JSX } from 'react';
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTask, useGenerateTaskPlan } from '../api/hooks';
+import { useApiKey } from '../state/ApiKeyContext';
+import { ApiError } from '../api/http';
+import { useToast } from '../components/ToastProvider';
+import type { Plan } from '../api/types';
+
+const TaskDetailPage = (): JSX.Element => {
+  const { apiKey, useEnvKey } = useApiKey();
+  const hasKey = Boolean(apiKey) || useEnvKey;
+  const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+  const taskQuery = useTask(id ?? '', { enabled: hasKey && Boolean(id) });
+  const genMutation = useGenerateTaskPlan(id ?? '');
+  const toast = useToast();
+  const [plan, setPlan] = useState<Plan | undefined>(undefined);
+
+  useEffect(() => {
+    setPlan(taskQuery.data?.plan);
+  }, [taskQuery.data?.plan]);
+
+  const retry = (): void => {
+    queryClient.invalidateQueries({ queryKey: ['task', id] });
+  };
+
+  const generate = async (): Promise<void> => {
+    try {
+      const res = await genMutation.mutateAsync();
+      setPlan(res);
+      if (res.status === 'ready') {
+        toast('Plan généré', 'success');
+      } else if (res.status === 'invalid') {
+        toast('Plan invalide', 'error');
+      }
+    } catch {
+      toast('Erreur de génération', 'error');
+    }
+  };
+
+  if (!hasKey) {
+    return <div>Veuillez saisir une clé API pour continuer.</div>;
+  }
+
+  if (taskQuery.isLoading) {
+    return <div className="skeleton">Chargement...</div>;
+  }
+
+  if (taskQuery.isError) {
+    const err = taskQuery.error as unknown;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+        <button onClick={retry}>Réessayer</button>
+      </div>
+    );
+  }
+
+  const task = taskQuery.data;
+  if (!task) {
+    return <p>Aucune donnée.</p>;
+  }
+
+  return (
+    <div>
+      <h2>{task.title}</h2>
+      <p>Statut: {task.status}</p>
+      {plan && (
+        <div>
+          <p>Plan: {plan.status}</p>
+          {plan.errors && (
+            <ul>
+              {plan.errors.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      <button onClick={generate} disabled={genMutation.isLoading}>
+        Générer le plan
+      </button>
+    </div>
+  );
+};
+
+export default TaskDetailPage;

--- a/dashboard/mini/src/pages/Tasks.tsx
+++ b/dashboard/mini/src/pages/Tasks.tsx
@@ -1,0 +1,55 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useApiKey } from '../state/ApiKeyContext';
+import TasksTable from '../components/TasksTable';
+import TaskFormModal from '../components/TaskFormModal';
+
+const TasksPage = (): JSX.Element => {
+  const { apiKey, useEnvKey } = useApiKey();
+  const hasKey = Boolean(apiKey) || useEnvKey;
+  const navigate = useNavigate();
+
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [orderBy, setOrderBy] = useState<'created_at' | 'title' | 'status'>('created_at');
+  const [orderDir, setOrderDir] = useState<'asc' | 'desc'>('desc');
+  const [showModal, setShowModal] = useState(false);
+
+  const onOpenTask = (id: string): void => {
+    navigate(`/tasks/${id}`);
+  };
+
+  if (!hasKey) {
+    return <div>Veuillez saisir une clé API pour continuer.</div>;
+  }
+
+  return (
+    <div>
+      <button onClick={() => setShowModal(true)}>Nouvelle tâche</button>
+      <TasksTable
+        page={page}
+        pageSize={pageSize}
+        orderBy={orderBy}
+        orderDir={orderDir}
+        onPageChange={setPage}
+        onPageSizeChange={(s) => {
+          setPageSize(s);
+          setPage(1);
+        }}
+        onOrderByChange={(f) => {
+          setOrderBy(f);
+          setPage(1);
+        }}
+        onOrderDirChange={(d) => {
+          setOrderDir(d);
+          setPage(1);
+        }}
+        onOpenTask={onOpenTask}
+      />
+      {showModal && <TaskFormModal onClose={() => setShowModal(false)} />}
+    </div>
+  );
+};
+
+export default TasksPage;


### PR DESCRIPTION
## Résumé
- liste paginée des tâches avec création via formulaire modal
- page de détail avec génération de plan et affichage d'erreurs
- hooks React Query et toasts pour le suivi des actions

## Tests
- `npm test` *(échec: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a3008ff483278e0bbf888052da4b