### PR TITLE
feat: ajout de l’éditeur de plan avec assignation

### DIFF
--- a/dashboard/mini/src/App.tsx
+++ b/dashboard/mini/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AppLayout from './layouts/AppLayout';
 import RunsPage from './pages/RunsPage';
 import RunDetailPage from './pages/RunDetailPage';
+import PlanEditor from './pages/PlanEditor';
 import { ApiKeyProvider } from './state/ApiKeyContext';
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ export const App = (): JSX.Element => (
           <Routes>
             <Route path="/runs" element={<RunsPage />} />
             <Route path="/runs/:id" element={<RunDetailPage />} />
+            <Route path="/plans/:id" element={<PlanEditor />} />
             <Route path="*" element={<Navigate to="/runs" replace />} />
           </Routes>
         </AppLayout>

--- a/dashboard/mini/src/__tests__/PlanEditor.assign.test.tsx
+++ b/dashboard/mini/src/__tests__/PlanEditor.assign.test.tsx
@@ -1,0 +1,159 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PlanEditor from '../pages/PlanEditor';
+
+const renderEditor = () => {
+  render(
+    <MemoryRouter initialEntries={['/plans/p1']}>
+      <Routes>
+        <Route path="/plans/:id" element={<PlanEditor />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe('PlanEditor assignments', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('upsert assign', async () => {
+    const plan = {
+      id: 'p1',
+      status: 'draft',
+      graph: { nodes: [{ id: 'n1' }], edges: [] },
+      assignments: [],
+    };
+    const fetchMock = vi
+      .fn<[
+        RequestInfo,
+        RequestInit | undefined
+      ], Promise<Response>>((url, opts) => {
+        if (url.toString().endsWith('/plans/p1')) {
+          return Promise.resolve(
+            new Response(JSON.stringify(plan), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+        }
+        if (url.toString().endsWith('/plans/p1/assignments')) {
+          return Promise.resolve(
+            new Response('{}', {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+        }
+        if (url.toString().endsWith('/plans/p1/status')) {
+          return Promise.resolve(
+            new Response('{}', {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+        }
+        return Promise.reject(new Error('unknown url'));
+      });
+    (global as any).fetch = fetchMock;
+
+    renderEditor();
+
+    const nodeBtn = await screen.findByTestId('plan-node-n1');
+    fireEvent.click(nodeBtn);
+    fireEvent.change(screen.getByLabelText('role'), { target: { value: 'r1' } });
+    fireEvent.change(screen.getByLabelText('agent'), { target: { value: 'a1' } });
+    fireEvent.change(screen.getByLabelText('backend'), { target: { value: 'b1' } });
+    fireEvent.change(screen.getByLabelText('model'), { target: { value: 'm1' } });
+    fireEvent.change(screen.getByLabelText('params'), { target: { value: '{"x":1}' } });
+    fireEvent.click(screen.getByText('Save Assignments'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    fireEvent.change(screen.getByLabelText('backend'), {
+      target: { value: 'b2' },
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText('backend')).toHaveValue('b2'),
+    );
+    fireEvent.click(screen.getByText('Save Assignments'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+
+    const calls = fetchMock.mock.calls.filter((c) =>
+      c[0].toString().endsWith('/plans/p1/assignments'),
+    );
+    expect(JSON.parse(calls[0][1]?.body as string)).toEqual({
+      assignments: [
+        {
+          node_id: 'n1',
+          role: 'r1',
+          agent_id: 'a1',
+          llm_backend: 'b1',
+          llm_model: 'm1',
+          params: { x: 1 },
+        },
+      ],
+    });
+    expect(JSON.parse(calls[1][1]?.body as string)).toEqual({
+      assignments: [
+        {
+          node_id: 'n1',
+          role: 'r1',
+          agent_id: 'a1',
+          llm_backend: 'b2',
+          llm_model: 'm1',
+          params: { x: 1 },
+        },
+      ],
+    });
+  });
+
+  it('node unknown -> erreur affichée', async () => {
+    const plan = {
+      id: 'p1',
+      status: 'draft',
+      graph: { nodes: [{ id: 'n1' }], edges: [] },
+      assignments: [],
+    };
+    const fetchMock = vi
+      .fn<[
+        RequestInfo,
+        RequestInit | undefined
+      ], Promise<Response>>((url, opts) => {
+        if (url.toString().endsWith('/plans/p1')) {
+          return Promise.resolve(
+            new Response(JSON.stringify(plan), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+        }
+        if (url.toString().endsWith('/plans/p1/assignments')) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: 'unknown node' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+        }
+        return Promise.reject(new Error('unknown url'));
+      });
+    (global as any).fetch = fetchMock;
+
+    renderEditor();
+
+    const nodeBtn = await screen.findByTestId('plan-node-n1');
+    fireEvent.click(nodeBtn);
+    fireEvent.change(screen.getByLabelText('role'), { target: { value: 'r1' } });
+    fireEvent.change(screen.getByLabelText('agent'), { target: { value: 'a1' } });
+    fireEvent.change(screen.getByLabelText('backend'), { target: { value: 'b1' } });
+    fireEvent.change(screen.getByLabelText('model'), { target: { value: 'm1' } });
+    fireEvent.click(screen.getByText('Save Assignments'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('unknown node');
+  });
+});

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -1,4 +1,4 @@
-import { fetchJson, FetchOpts } from './http';
+import { fetchJson, FetchOpts, postJson } from './http';
 import {
   ApiStatus,
   ArtifactItem,
@@ -10,6 +10,8 @@ import {
   RunSummary,
   Status,
   BackendRun,
+  Plan,
+  Assignment,
 } from './types';
 import { parseLinkHeader } from './links';
 
@@ -237,4 +239,36 @@ export const listNodeArtifacts = async (
       prev: links.prev?.href,
     },
   };
+};
+
+export const getPlan = async (
+  id: string,
+  opts: FetchOpts = {},
+): Promise<Plan> => {
+  const { data } = await fetchJson<Plan>(`/plans/${id}`, opts);
+  return data;
+};
+
+export const saveAssignments = async (
+  planId: string,
+  assignments: Assignment[],
+  opts: FetchOpts = {},
+): Promise<void> => {
+  await postJson<unknown, { assignments: Assignment[] }>(
+    `/plans/${planId}/assignments`,
+    { assignments },
+    opts,
+  );
+};
+
+export const setPlanStatus = async (
+  planId: string,
+  status: 'draft' | 'ready' | 'invalid',
+  opts: FetchOpts = {},
+): Promise<void> => {
+  await postJson<unknown, { status: 'draft' | 'ready' | 'invalid' }>(
+    `/plans/${planId}/status`,
+    { status },
+    opts,
+  );
 };

--- a/dashboard/mini/src/api/types.ts
+++ b/dashboard/mini/src/api/types.ts
@@ -84,3 +84,21 @@ export interface BackendRunsList {
   limit: number;
   offset: number;
 }
+export interface Assignment {
+  node_id: string;
+  role: string;
+  agent_id: string;
+  llm_backend: string;
+  llm_model: string;
+  params?: Record<string, any>;
+}
+
+export interface Plan {
+  id: string;
+  status: 'draft' | 'ready' | 'invalid';
+  graph: {
+    nodes: Array<{ id: string; role?: string }>;
+    edges: Array<{ from: string; to: string }>;
+  };
+  assignments?: Assignment[];
+}

--- a/dashboard/mini/src/components/AssignPanel.tsx
+++ b/dashboard/mini/src/components/AssignPanel.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import type { Assignment } from '../api/types';
+
+interface AssignPanelProps {
+  nodeId?: string | null;
+  assignment?: Assignment;
+  onSave: (a: Assignment) => void | Promise<void>;
+  saving?: boolean;
+  error?: string | null;
+  success?: string | null;
+}
+
+const AssignPanel = ({
+  nodeId,
+  assignment,
+  onSave,
+  saving,
+  error,
+  success,
+}: AssignPanelProps) => {
+  const [role, setRole] = useState('');
+  const [agent, setAgent] = useState('');
+  const [backend, setBackend] = useState('');
+  const [model, setModel] = useState('');
+  const [paramsText, setParamsText] = useState('');
+
+  useEffect(() => {
+    if (assignment) {
+      setRole(assignment.role);
+      setAgent(assignment.agent_id);
+      setBackend(assignment.llm_backend);
+      setModel(assignment.llm_model);
+      setParamsText(
+        assignment.params ? JSON.stringify(assignment.params, null, 2) : '',
+      );
+    } else {
+      setRole('');
+      setAgent('');
+      setBackend('');
+      setModel('');
+      setParamsText('');
+    }
+  }, [assignment, nodeId]);
+
+  if (!nodeId) {
+    return <div data-testid="assign-empty">Sélectionnez un nœud</div>;
+  }
+
+  const handleSave = () => {
+    let parsed: Record<string, unknown> | undefined;
+    try {
+      parsed = paramsText ? JSON.parse(paramsText) : undefined;
+    } catch {
+      parsed = undefined;
+    }
+    onSave({
+      node_id: nodeId,
+      role,
+      agent_id: agent,
+      llm_backend: backend,
+      llm_model: model,
+      params: parsed,
+    });
+  };
+
+  return (
+    <div>
+      <h3>Assignation {nodeId}</h3>
+      <label>
+        Rôle
+        <input
+          aria-label="role"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        />
+      </label>
+      <label>
+        Agent
+        <input
+          aria-label="agent"
+          value={agent}
+          onChange={(e) => setAgent(e.target.value)}
+        />
+      </label>
+      <label>
+        Backend
+        <input
+          aria-label="backend"
+          value={backend}
+          onChange={(e) => setBackend(e.target.value)}
+        />
+      </label>
+      <label>
+        Modèle
+        <input
+          aria-label="model"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        />
+      </label>
+      <label>
+        Params JSON
+        <textarea
+          aria-label="params"
+          value={paramsText}
+          onChange={(e) => setParamsText(e.target.value)}
+        />
+      </label>
+      <button onClick={handleSave} disabled={saving}>
+        Save Assignments
+      </button>
+      {success && <div role="status">{success}</div>}
+      {error && <div role="alert">{error}</div>}
+    </div>
+  );
+};
+
+export default AssignPanel;

--- a/dashboard/mini/src/components/PlanGraph.tsx
+++ b/dashboard/mini/src/components/PlanGraph.tsx
@@ -1,0 +1,64 @@
+import type { ComponentType } from 'react';
+import { useEffect, useState } from 'react';
+
+interface PlanGraphProps {
+  graph?: {
+    nodes: Array<{ id: string; role?: string }>;
+    edges: Array<{ from: string; to: string }>;
+  };
+  selected?: string | null;
+  onSelect?: (id: string) => void;
+}
+
+interface ReactFlowModule {
+  default: ComponentType<unknown>;
+}
+
+const PlanGraph = ({ graph, selected, onSelect }: PlanGraphProps) => {
+  const [rf, setRf] = useState<ReactFlowModule | null>(null);
+
+  useEffect(() => {
+    const pkg = 'reactflow';
+    import(/* @vite-ignore */ pkg)
+      .then((mod: ReactFlowModule) => setRf(mod))
+      .catch(() => {
+        /* ignore, fallback */
+      });
+  }, []);
+
+  if (!graph) return null;
+
+  if (rf) {
+    const ReactFlow = rf.default as ComponentType<Record<string, unknown>>;
+    const nodes = graph.nodes.map((n, idx) => ({
+      id: n.id,
+      position: { x: idx * 200, y: 0 },
+      data: { label: n.role ?? n.id },
+      style: selected === n.id ? { border: '2px solid blue' } : undefined,
+    }));
+    const edges = graph.edges.map((e) => ({
+      id: `${e.from}-${e.to}`,
+      source: e.from,
+      target: e.to,
+    }));
+    return (
+      <div style={{ width: '100%', height: 200 }} data-testid="plan-reactflow">
+        <ReactFlow nodes={nodes} edges={edges} onNodeClick={(_, node) => onSelect?.(node.id)} />
+      </div>
+    );
+  }
+
+  return (
+    <ul data-testid="plan-fallback">
+      {graph.nodes.map((n) => (
+        <li key={n.id}>
+          <button data-testid={`plan-node-${n.id}`} onClick={() => onSelect?.(n.id)}>
+            {n.role ?? n.id}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default PlanGraph;

--- a/dashboard/mini/src/pages/PlanEditor.tsx
+++ b/dashboard/mini/src/pages/PlanEditor.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import PlanGraph from '../components/PlanGraph';
+import AssignPanel from '../components/AssignPanel';
+import { getPlan, saveAssignments, setPlanStatus } from '../api/client';
+import type { Assignment, Plan } from '../api/types';
+import { ApiError } from '../api/http';
+
+const PlanEditor = () => {
+  const { id } = useParams<{ id: string }>();
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [assignments, setAssignments] = useState<Record<string, Assignment>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (id) {
+      getPlan(id)
+        .then((p) => {
+          setPlan(p);
+          const map: Record<string, Assignment> = {};
+          p.assignments?.forEach((a) => {
+            map[a.node_id] = a;
+          });
+          setAssignments(map);
+        })
+        .catch(() => {
+          /* ignore */
+        });
+    }
+  }, [id]);
+
+  const handleSave = async (a: Assignment) => {
+    if (!id) return;
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await saveAssignments(id, [a]);
+      const newMap = { ...assignments, [a.node_id]: a };
+      setAssignments(newMap);
+      setSuccess('Assignation sauvegardée');
+      if (plan && plan.graph.nodes.every((n) => newMap[n.id])) {
+        await setPlanStatus(id, 'ready');
+        setPlan({ ...plan, status: 'ready' });
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { detail?: string; error?: string } | undefined;
+        setError(body?.detail || body?.error || err.message);
+      } else {
+        setError((err as Error).message);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <PlanGraph graph={plan?.graph} selected={selected} onSelect={setSelected} />
+      <AssignPanel
+        nodeId={selected}
+        assignment={selected ? assignments[selected] : undefined}
+        onSave={handleSave}
+        saving={saving}
+        error={error}
+        success={success}
+      />
+    </div>
+  );
+};
+
+export default PlanEditor;


### PR DESCRIPTION
## Résumé
- ajouter une page PlanEditor avec graph React Flow et panneau d’assignation
- persister les assignations et valider le plan
- couvrir les assignations avec des tests RTL

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a3088b608327869dbc16f1697fb8