### PR TITLE
feat(frontend): add node actions on run detail

### DIFF
--- a/dashboard/mini/src/App.tsx
+++ b/dashboard/mini/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AppLayout from './layouts/AppLayout';
 import RunsPage from './pages/RunsPage';
-import RunDetailPage from './pages/RunDetailPage';
+import RunDetail from './pages/RunDetail';
 import { ApiKeyProvider } from './state/ApiKeyContext';
 
 const queryClient = new QueryClient();
@@ -15,7 +15,7 @@ export const App = (): JSX.Element => (
         <AppLayout>
           <Routes>
             <Route path="/runs" element={<RunsPage />} />
-            <Route path="/runs/:id" element={<RunDetailPage />} />
+            <Route path="/runs/:id" element={<RunDetail />} />
             <Route path="*" element={<Navigate to="/runs" replace />} />
           </Routes>
         </AppLayout>

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -238,3 +238,16 @@ export const listNodeArtifacts = async (
     },
   };
 };
+
+export const patchNode = async (
+  nodeId: string,
+  body: Record<string, unknown>,
+  opts: FetchOpts = {},
+) => {
+  const { requestId } = await fetchJson<unknown>(`/nodes/${nodeId}`, {
+    ...opts,
+    method: 'PATCH',
+    body,
+  });
+  return { requestId };
+};

--- a/dashboard/mini/src/api/http.ts
+++ b/dashboard/mini/src/api/http.ts
@@ -23,6 +23,8 @@ export class ApiError extends Error {
 export interface FetchOpts {
   query?: Record<string, string | number | boolean | undefined>;
   signal?: AbortSignal;
+  method?: string;
+  body?: unknown;
 }
 
 export async function fetchJson<T>(
@@ -57,11 +59,17 @@ export async function fetchJson<T>(
     }
   }
 
-  const fetchOnce = () =>
-    fetch(url.toString(), {
-      headers,
-      signal: timeoutCtrl.signal,
-    });
+  const init: RequestInit = {
+    method: opts.method ?? 'GET',
+    headers,
+    signal: timeoutCtrl.signal,
+  };
+  if (opts.body !== undefined) {
+    headers['content-type'] = 'application/json';
+    init.body = JSON.stringify(opts.body);
+  }
+
+  const fetchOnce = () => fetch(url.toString(), init);
 
   const maxRetries = 2;
   const backoff = [200, 500];

--- a/dashboard/mini/src/components/DagView.tsx
+++ b/dashboard/mini/src/components/DagView.tsx
@@ -4,13 +4,15 @@ import type { RunDetail } from '../api/types';
 
 interface DagViewProps {
   dag?: RunDetail['dag'];
+  onSelectNode?: (id: string) => void;
+  selectedNodeId?: string;
 }
 
 interface ReactFlowModule {
   default: ComponentType<unknown>;
 }
 
-const DagView = ({ dag }: DagViewProps): JSX.Element | null => {
+const DagView = ({ dag, onSelectNode, selectedNodeId }: DagViewProps): JSX.Element | null => {
   const [rf, setRf] = useState<ReactFlowModule | null>(null);
 
   useEffect(() => {
@@ -47,6 +49,7 @@ const DagView = ({ dag }: DagViewProps): JSX.Element | null => {
           panOnDrag
           zoomOnScroll
           fitView
+          onNodeClick={(_: unknown, n: { id: string }) => onSelectNode?.(n.id)}
         />
       </div>
     );
@@ -96,8 +99,15 @@ const DagView = ({ dag }: DagViewProps): JSX.Element | null => {
           key={n.id}
           transform={`translate(${40 + idx * 120},40)`}
           data-testid={`dag-node-${n.id}`}
+          onClick={() => onSelectNode?.(n.id)}
         >
-          <rect width="80" height="40" fill="#eee" stroke="#333" rx="4" />
+          <rect
+            width="80"
+            height="40"
+            fill="#eee"
+            stroke={selectedNodeId === n.id ? 'blue' : '#333'}
+            rx="4"
+          />
           <text
             x="40"
             y="18"

--- a/dashboard/mini/src/components/NodeSidePanel.tsx
+++ b/dashboard/mini/src/components/NodeSidePanel.tsx
@@ -1,0 +1,130 @@
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { useNodeArtifacts } from '../api/hooks';
+import { patchNode } from '../api/client';
+
+interface NodeSidePanelProps {
+  node: { id: string; status: string; role?: string };
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+const NodeSidePanel = ({ node, onClose, onUpdated }: NodeSidePanelProps): JSX.Element => {
+  const [requestId, setRequestId] = useState<string | undefined>();
+  const [overridePrompt, setOverridePrompt] = useState('');
+  const [overrideParams, setOverrideParams] = useState('');
+  const [logText, setLogText] = useState('');
+  const [sidecar, setSidecar] = useState('');
+
+  const artifactsQuery = useNodeArtifacts(
+    node.id,
+    { page: 1, pageSize: 50 },
+    { enabled: Boolean(node.id) },
+  );
+
+  useEffect(() => {
+    setRequestId(undefined);
+    setOverridePrompt('');
+    setOverrideParams('');
+    setLogText('');
+    setSidecar('');
+  }, [node.id]);
+
+  useEffect(() => {
+    const fetchArtifacts = async () => {
+      if (!artifactsQuery.data) return;
+      const log = artifactsQuery.data.items.find((a) => a.kind === 'log');
+      if (log) {
+        try {
+          const res = await fetch(log.url);
+          setLogText(await res.text());
+        } catch {
+          setLogText('');
+        }
+      }
+      const sc = artifactsQuery.data.items.find((a) => a.kind === 'llm_sidecar');
+      if (sc) {
+        try {
+          const res = await fetch(sc.url);
+          setSidecar(await res.text());
+        } catch {
+          setSidecar('');
+        }
+      }
+    };
+    fetchArtifacts();
+  }, [artifactsQuery.data]);
+
+  const doAction = async (body: Record<string, unknown>) => {
+    if (!window.confirm('Confirmer ?')) return;
+    const { requestId } = await patchNode(node.id, body);
+    setRequestId(requestId);
+    await artifactsQuery.refetch();
+    onUpdated();
+  };
+
+  const onOverride = () => {
+    let params: unknown;
+    if (overrideParams) {
+      try {
+        params = JSON.parse(overrideParams);
+      } catch {
+        alert('Paramètres JSON invalides');
+        return;
+      }
+    }
+    void doAction({ action: 'override', prompt: overridePrompt || undefined, params });
+  };
+
+  return (
+    <aside style={{ borderLeft: '1px solid #ccc', padding: 16, width: 320 }} data-testid="node-sidepanel">
+      <button onClick={onClose}>Fermer</button>
+      <h3>{node.role ?? node.id}</h3>
+      <p>Statut: {node.status}</p>
+      <div>
+        <button onClick={() => void doAction({ action: 'pause' })}>Pause</button>
+        <button onClick={() => void doAction({ action: 'resume' })}>Resume</button>
+        <button onClick={() => void doAction({ action: 'skip' })}>Skip</button>
+      </div>
+      <div>
+        <h4>Override</h4>
+        <input
+          placeholder="prompt"
+          value={overridePrompt}
+          onChange={(e) => setOverridePrompt(e.target.value)}
+        />
+        <textarea
+          placeholder="params JSON"
+          value={overrideParams}
+          onChange={(e) => setOverrideParams(e.target.value)}
+        />
+        <button onClick={onOverride}>Envoyer</button>
+      </div>
+      {requestId && <p>Request ID: {requestId}</p>}
+      <div>
+        <h4>Logs</h4>
+        <pre style={{ whiteSpace: 'pre-wrap' }}>{logText}</pre>
+      </div>
+      <div>
+        <h4>Artifacts</h4>
+        <ul>
+          {artifactsQuery.data?.items.map((a) => (
+            <li key={a.id}>
+              <a href={a.url} target="_blank" rel="noreferrer">
+                {a.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      {sidecar && (
+        <div>
+          <h4>Sidecar</h4>
+          <pre style={{ whiteSpace: 'pre-wrap' }}>{sidecar}</pre>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default NodeSidePanel;

--- a/dashboard/mini/src/pages/RunDetail.tsx
+++ b/dashboard/mini/src/pages/RunDetail.tsx
@@ -1,0 +1,92 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import DagView from '../components/DagView';
+import NodeSidePanel from '../components/NodeSidePanel';
+import type { RunDetail as RunType, Status } from '../api/types';
+import { fetchJson, ApiError } from '../api/http';
+import { useApiKey } from '../state/ApiKeyContext';
+
+const apiToUiStatus = (status: string): Status => {
+  switch (status) {
+    case 'pending':
+      return 'queued';
+    case 'completed':
+      return 'succeeded';
+    default:
+      return status as Status;
+  }
+};
+
+const fetchRun = async (id: string, signal: AbortSignal) => {
+  const { data, requestId } = await fetchJson<any>(`/runs/${id}`, { signal });
+  const run: RunType = { ...data, status: apiToUiStatus(data.status) };
+  if (run.dag) {
+    run.dag = {
+      nodes: (run.dag.nodes as any).map((n: any) => ({
+        ...n,
+        status: apiToUiStatus(n.status),
+      })),
+      edges: run.dag.edges,
+    };
+  }
+  return { run, requestId };
+};
+
+const RunDetail = (): JSX.Element => {
+  const { id } = useParams<{ id: string }>();
+  const { apiKey, useEnvKey } = useApiKey();
+  const hasKey = Boolean(apiKey) || useEnvKey;
+  const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>();
+  const runQuery = useQuery({
+    queryKey: ['run', id],
+    queryFn: ({ signal }) => fetchRun(id!, signal),
+    enabled: hasKey && Boolean(id),
+    refetchInterval: (query) => {
+      const status = query.state.data?.run.status;
+      return status === 'running' || status === 'queued' ? 2000 : false;
+    },
+  });
+
+  if (!hasKey) {
+    return <div>Veuillez saisir une clé API pour continuer.</div>;
+  }
+  if (runQuery.isLoading) {
+    return <div className="skeleton">Chargement...</div>;
+  }
+  if (runQuery.isError) {
+    const err = runQuery.error as unknown;
+    return (
+      <div>
+        <p>Une erreur est survenue.</p>
+        {err instanceof ApiError && <p>Request ID: {err.requestId}</p>}
+      </div>
+    );
+  }
+  const run = runQuery.data?.run;
+  if (!run) return <p>Aucune donnée.</p>;
+  const selectedNode = run.dag?.nodes.find((n) => n.id === selectedNodeId);
+  return (
+    <div>
+      <h2>{run.title ?? run.id}</h2>
+      <p>Request ID: {runQuery.data?.requestId}</p>
+      {run.dag && (
+        <DagView
+          dag={run.dag}
+          onSelectNode={(nid) => setSelectedNodeId(nid)}
+          selectedNodeId={selectedNodeId}
+        />
+      )}
+      {selectedNode && (
+        <NodeSidePanel
+          node={selectedNode}
+          onClose={() => setSelectedNodeId(undefined)}
+          onUpdated={() => runQuery.refetch()}
+        />
+      )}
+    </div>
+  );
+};
+
+export default RunDetail;

--- a/dashboard/mini/tests-e2e/run-detail.spec.ts
+++ b/dashboard/mini/tests-e2e/run-detail.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+const PREVIEW_URL = process.env.PREVIEW_URL;
+
+test('actions sur un noeud', async ({ page }) => {
+  test.skip(!PREVIEW_URL, 'PREVIEW_URL non défini');
+
+  const apiBase = 'https://mock.api';
+  const apiKey = 'test-key';
+  let sidecarContent = '{"a":1}';
+
+  await page.route(`${apiBase}/**`, async (route) => {
+    const req = route.request();
+    const url = req.url();
+    if (url.endsWith('/runs/run-1')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'run-1',
+          status: 'running',
+          dag: {
+            nodes: [{ id: 'node-1', status: 'running', role: 'agent' }],
+            edges: [],
+          },
+        }),
+      });
+    } else if (url.endsWith('/nodes/node-1/artifacts')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            { id: 'a1', node_id: 'node-1', name: 'log', kind: 'log', url: apiBase + '/log1' },
+            {
+              id: 'a2',
+              node_id: 'node-1',
+              name: 'sidecar',
+              kind: 'llm_sidecar',
+              url: apiBase + '/sc1',
+            },
+          ],
+        }),
+      });
+    } else if (url.endsWith('/log1')) {
+      await route.fulfill({ status: 200, body: 'log content' });
+    } else if (url.endsWith('/sc1')) {
+      await route.fulfill({ status: 200, body: sidecarContent });
+    } else if (url.includes('/nodes/node-1') && req.method() === 'PATCH') {
+      const body = JSON.parse(req.postData() || '{}');
+      if (body.action === 'override') {
+        sidecarContent = '{"override":true}';
+      }
+      await route.fulfill({ status: 200, body: '{}' });
+    } else {
+      await route.fulfill({ status: 200, body: '{}' });
+    }
+  });
+
+  await page.goto(PREVIEW_URL!);
+  await page.getByTestId('apiUrlInput').fill(apiBase);
+  await page.getByRole('button', { name: 'Enregistrer' }).last().click();
+  await page.getByLabel('api-key').fill(apiKey);
+  await page.getByRole('button', { name: 'Enregistrer' }).first().click();
+
+  await page.goto(`${PREVIEW_URL}/runs/run-1`);
+  await page.getByTestId('dag-node-node-1').click();
+  await expect(page.getByTestId('node-sidepanel')).toBeVisible();
+  await expect(page.getByText('log content')).toBeVisible();
+  await expect(page.getByText('{"a":1}')).toBeVisible();
+
+  page.on('dialog', (d) => d.accept());
+  await page.getByRole('button', { name: 'Pause' }).click();
+  await expect(page.getByText(/Request ID:/)).toBeVisible();
+
+  page.on('dialog', (d) => d.accept());
+  await page.getByRole('button', { name: 'Resume' }).click();
+
+  page.on('dialog', (d) => d.accept());
+  await page.getByPlaceholder('prompt').fill('new prompt');
+  await page.getByPlaceholder('params JSON').fill('{"x":1}');
+  await page.getByRole('button', { name: 'Envoyer' }).click();
+  await expect(page.getByText('{"override":true}')).toBeVisible();
+
+  page.on('dialog', (d) => d.accept());
+  await page.getByRole('button', { name: 'Skip' }).click();
+});


### PR DESCRIPTION
## Summary
- add RunDetail page with live DAG and request id display
- add NodeSidePanel with node actions and artifact preview
- support node PATCH actions and enable node selection in DagView

## Testing
- `npm test`
- `npm run lint` *(fails: prettier formatting in repo)*
- `npm run typecheck`
- `npm run e2e` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a30f5b3c8327ade19adc3c122357