### PR TITLE
Ajout script de scénario E2E et cibles Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,71 @@ Pour lister les événements d'un run spécifique :
 curl -H "X-API-Key: test-key" "http://localhost:8000/events?run_id=<RUN_ID>"
 ```
 
+## Scénario E2E (API + UI)
+
+### Prérequis
+
+- Python 3.11+
+- Node 18+
+- `make`, `npm`
+
+Variables d'environnement minimales :
+
+```
+API_KEY=test-key
+DATABASE_URL=sqlite+aiosqlite:///./app.db
+API_URL=http://localhost:8000
+```
+
+### Étapes (local)
+
+1. Appliquer les migrations :
+
+   ```bash
+   make api-migrate
+   ```
+
+2. Démarrer l'API (terminal séparé) :
+
+   ```bash
+   make api-run
+   ```
+
+3. Déclencher le flux de démonstration (création → plan → assignation → start) :
+
+   ```bash
+   make task-plan-start
+   ```
+
+### Étapes (prévisualisation UI)
+
+Lance les tests E2E Playwright sur la version buildée du dashboard :
+
+```bash
+make ui-run-e2e
+```
+
+### Exemples cURL
+
+```bash
+# 1) Créer une tâche brouillon
+curl -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"title":"Demo"}' $API_URL/tasks
+
+# 2) Générer un plan
+curl -X POST -H "X-API-Key: $API_KEY" \
+  $API_URL/tasks/<TASK_ID>/plan
+
+# 3) Assigner des nœuds
+curl -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"items":[{"node_id":"n1","role":"writer","agent_id":"a1","llm_backend":"openai","llm_model":"gpt-4o-mini"}]}' \
+  $API_URL/plans/<PLAN_ID>/assignments
+
+# 4) Démarrer (dry run)
+curl -X POST -H "X-API-Key: $API_KEY" \
+  "$API_URL/tasks/<TASK_ID>/start?dry_run=true"
+```
+
 The server always returns timestamps in UTC. Clients may supply `X-Timezone`
 header to ask for conversion to a specific zone.
 

--- a/scripts/task_plan_start.py
+++ b/scripts/task_plan_start.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Script utilitaire pour créer une tâche via l'API, générer son plan,
+assigner deux nœuds puis démarrer le run.
+
+Variables d'environnement utilisées :
+- API_URL (défaut : http://localhost:8000)
+- API_KEY (obligatoire)
+- DRY_RUN (défaut : true)
+"""
+
+import os
+import sys
+import uuid
+import httpx
+
+API_URL = os.getenv("API_URL", "http://localhost:8000")
+API_KEY = os.getenv("API_KEY")
+DRY_RUN = os.getenv("DRY_RUN", "true").lower() in {"1", "true", "yes"}
+
+if not API_KEY:
+    print("API_KEY manquante", file=sys.stderr)
+    sys.exit(1)
+
+request_id = str(uuid.uuid4())
+
+headers = {
+    "X-API-Key": API_KEY,
+    "X-Request-ID": request_id,
+}
+
+with httpx.Client(base_url=API_URL, headers=headers, timeout=10.0) as client:
+    # Création de la tâche brouillon
+    r = client.post("/tasks", json={"title": "Demo"})
+    r.raise_for_status()
+    task_id = r.json()["id"]
+    req_id = r.headers.get("X-Request-ID", request_id)
+    print(f"tâche créée: {task_id} (X-Request-ID={req_id})")
+
+    # Propagation de l'ID de requête
+    client.headers["X-Request-ID"] = req_id
+
+    # Génération du plan
+    r = client.post(f"/tasks/{task_id}/plan")
+    r.raise_for_status()
+    plan_id = r.json()["plan_id"]
+    nodes = [n["id"] for n in r.json()["graph"]["plan"]]
+    if len(nodes) < 2:
+        print("Plan insuffisant pour l'assignation (au moins deux nœuds requis)", file=sys.stderr)
+        sys.exit(1)
+    print(f"plan généré: {plan_id} avec nœuds {nodes[:2]}")
+
+    # Assignation de deux nœuds
+    payload = {
+        "items": [
+            {
+                "node_id": nodes[0],
+                "role": "writer",
+                "agent_id": "agent-1",
+                "llm_backend": "openai",
+                "llm_model": "gpt-4o-mini",
+            },
+            {
+                "node_id": nodes[1],
+                "role": "reviewer",
+                "agent_id": "agent-2",
+                "llm_backend": "openai",
+                "llm_model": "gpt-4o-mini",
+            },
+        ]
+    }
+    r = client.post(f"/plans/{plan_id}/assignments", json=payload)
+    r.raise_for_status()
+    print(f"assignations appliquées: {r.json().get('updated', 0)} mises à jour")
+
+    # Démarrage du run (dry_run param)
+    r = client.post(f"/tasks/{task_id}/start", params={"dry_run": str(DRY_RUN).lower()})
+    r.raise_for_status()
+    run_id = r.json()["run_id"]
+    print(f"run démarré: {run_id} (dry_run={r.json()['dry_run']})")


### PR DESCRIPTION
## Résumé
- documente un scénario E2E API + UI avec prérequis, variables d'environnement et exemples cURL
- ajoute le script `task_plan_start.py` pour enchaîner création de tâche, plan, assignation et démarrage
- expose les cibles `api-migrate`, `task-plan-start` et `ui-run-e2e` dans le Makefile

## Test
- `make test` *(échoue : tests existants `tests_api/test_tasks_write_api.py`)*
- `DATABASE_URL=sqlite:///./app.db make api-migrate` *(échoue : JSONB non supporté par SQLite)*
- `API_KEY=test-key API_URL=http://127.0.0.1:8000 DRY_RUN=true make task-plan-start` *(échoue : table `tasks` absente)*
- `make ui-run-e2e` *(échoue : erreurs TypeScript lors du build)*

------
https://chatgpt.com/codex/tasks/task_e_68b5db246da8832798f8e914e5b1e400