### PR TITLE
feat: logger structuré et propagation X-Request-ID

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+
+# Configuration du logger structuré dès le démarrage de l'application
+import core.log  # noqa: F401
 from fastapi.responses import RedirectResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware

--- a/api/fastapi_app/middleware/request_id.py
+++ b/api/fastapi_app/middleware/request_id.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import json
 import logging
 import time
 import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
+
+from core.log import request_id_var
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """Attach a request ID and log access in JSON format."""
@@ -19,19 +20,19 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         rid = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = rid
+        token = request_id_var.set(rid)
         start = time.perf_counter()
         response = await call_next(request)
         duration_ms = int((time.perf_counter() - start) * 1000)
         response.headers["X-Request-ID"] = rid
         self.logger.info(
-            json.dumps(
-                {
-                    "request_id": rid,
-                    "method": request.method,
-                    "path": request.url.path,
-                    "status_code": response.status_code,
-                    "duration_ms": duration_ms,
-                }
-            )
+            "access",
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration_ms": duration_ms,
+            },
         )
+        request_id_var.reset(token)
         return response

--- a/core/log.py
+++ b/core/log.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import contextvars
+import datetime as dt
+import json
+import logging
+from typing import Any
+
+# Context variables
+request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_id", default=None)
+run_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("run_id", default=None)
+node_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("node_id", default=None)
+status_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("status", default=None)
+llm_backend_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("llm_backend", default=None)
+llm_model_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("llm_model", default=None)
+
+class ContextFilter(logging.Filter):
+    """Injecte les contextvars dans chaque LogRecord."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        record.request_id = request_id_var.get()
+        record.run_id = run_id_var.get()
+        record.node_id = node_id_var.get()
+        record.status = status_var.get()
+        record.llm_backend = llm_backend_var.get()
+        record.llm_model = llm_model_var.get()
+        return True
+
+class JsonFormatter(logging.Formatter):
+    """Formateur JSON simple pour les logs structurés."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        payload: dict[str, Any] = {
+            "timestamp": dt.datetime.utcnow().isoformat() + "Z",
+            "level": record.levelname.lower(),
+            "run_id": getattr(record, "run_id", None),
+            "node_id": getattr(record, "node_id", None),
+            "request_id": getattr(record, "request_id", None),
+            "status": getattr(record, "status", None),
+            "llm_backend": getattr(record, "llm_backend", None),
+            "llm_model": getattr(record, "llm_model", None),
+            "message": record.getMessage(),
+        }
+        # Ajout de champs supplémentaires éventuels
+        for key in ("method", "path", "status_code", "duration_ms"):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
+        return json.dumps(payload, ensure_ascii=False)
+
+def configure_logging() -> None:
+    """Configure le root logger pour utiliser le formateur JSON."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    handler.addFilter(ContextFilter())
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.handlers = [handler]
+
+# Configure les logs dès l'import
+configure_logging()

--- a/tests_api/test_request_id_header.py
+++ b/tests_api/test_request_id_header.py
@@ -11,5 +11,5 @@ async def test_request_id_header_and_log(client, caplog):
     assert resp.status_code == 200
     rid = resp.headers.get("X-Request-ID")
     assert rid
-    logged = [json.loads(r.message)["request_id"] for r in caplog.records]
+    logged = [getattr(r, "request_id", None) for r in caplog.records]
     assert rid in logged


### PR DESCRIPTION
## Résumé
- ajoute un logger JSON global avec contextvars pour les identifiants de requêtes et d'exécution
- propage `X-Request-ID` via un middleware FastAPI utilisant les contextvars
- adapte les tests pour valider la présence de l'identifiant dans les logs

## Tests
- `pytest tests_api/test_request_id_header.py tests_api/test_request_id_event.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e83bf1948327a23673816f44cecd