### PR TITLE
UI: plan validation et améliorations run detail

### DIFF
--- a/app/routers/plans.py
+++ b/app/routers/plans.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from uuid import UUID
+from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -57,3 +58,11 @@ async def upsert_assignments(
         out_items.append(item)
     await db.commit()
     return AssignmentsResponse(updated=updated, items=out_items)
+
+
+@router.post("/{plan_id}/submit_for_validation")
+async def submit_for_validation(plan_id: UUID, body: dict, _: Any = Depends(strict_api_key_auth)) -> dict:
+    validated = body.get("validated")
+    errors = body.get("errors") or []
+    # TODO: persister l'événement / statut
+    return {"plan_id": str(plan_id), "validated": bool(validated), "errors": errors}

--- a/app/services/orchestrator_adapter.py
+++ b/app/services/orchestrator_adapter.py
@@ -25,6 +25,10 @@ async def node_action(
     """
 
     sidecar_updated = bool(payload) and bool(
-        (payload.get("override_prompt") or payload.get("params"))
+        (
+            payload.get("override_prompt")
+            or payload.get("prompt")
+            or payload.get("params")
+        )
     )
     return {"status_after": action, "sidecar_updated": sidecar_updated}

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -149,12 +149,32 @@ export const getPlan = async (id: string, opts: FetchOpts = {}): Promise<Plan> =
   return data;
 };
 
-export const saveAssignments = async (planId: string, assignments: Assignment[], opts: FetchOpts = {}): Promise<void> => {
-  await postJson<unknown, { assignments: Assignment[] }>(`/plans/${planId}/assignments`, { assignments }, opts);
+export const saveAssignments = async (
+  planId: string,
+  assignments: Assignment[],
+  opts: FetchOpts = {},
+): Promise<void> => {
+  await postJson<unknown, { items: Assignment[] }>(
+    `/plans/${planId}/assignments`,
+    { items: assignments },
+    opts,
+  );
 };
 
 export const setPlanStatus = async (planId: string, status: 'draft'|'ready'|'invalid', opts: FetchOpts = {}): Promise<void> => {
   await postJson<unknown, { status: 'draft'|'ready'|'invalid' }>(`/plans/${planId}/status`, { status }, opts);
+};
+
+export const submitPlanForValidation = async (
+  planId: string,
+  payload: { validated: boolean; errors?: string[] },
+  opts: FetchOpts = {},
+): Promise<void> => {
+  await postJson<unknown, { validated: boolean; errors?: string[] }>(
+    `/plans/${planId}/submit_for_validation`,
+    payload,
+    opts,
+  );
 };
 
 // -------- Tasks


### PR DESCRIPTION
## Résumé
- prise en compte de `prompt` pour détecter les overrides côté orchestrateur
- ajout de l'endpoint `POST /plans/{id}/submit_for_validation`
- alignement du payload d'affectation (`items`) côté client

## Tests
- `make api-migrate` *(échec : connexion à la base Postgres refusée)*
- `make api-test`
- `make api-e2e-happy`
- `make dash-mini-ci-local` *(échec : option `--run` du script de test invalide)*
- `make ui-run-e2e` *(échec : erreurs de compilation TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e849934083279a5d0d2fa6c701f3