### PR TITLE
feat: actions de nœud robustes

### DIFF
--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -14,6 +14,8 @@ import os
 from dotenv import load_dotenv
 load_dotenv()
 
+import core.log  # configure root logger
+
 from .deps import settings
 from .routes import health, runs, nodes, artifacts, events, tasks
 from app.routers import nodes as node_actions

--- a/api/fastapi_app/middleware/request_id.py
+++ b/api/fastapi_app/middleware/request_id.py
@@ -4,6 +4,7 @@ import json
 import logging
 import time
 import uuid
+from core.log import request_id_var
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -19,6 +20,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         rid = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = rid
+        token = request_id_var.set(rid)
         start = time.perf_counter()
         response = await call_next(request)
         duration_ms = int((time.perf_counter() - start) * 1000)
@@ -34,4 +36,5 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
                 }
             )
         )
+        request_id_var.reset(token)
         return response

--- a/app/routers/nodes.py
+++ b/app/routers/nodes.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
+from core import log as _core_log  # noqa: F401
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from api.fastapi_app.deps import strict_api_key_auth
 from app.schemas.node_actions import NodeActionRequest, NodeActionResponse
@@ -10,13 +12,32 @@ from app.services import orchestrator_adapter
 
 router = APIRouter(prefix="/nodes", tags=["nodes"], dependencies=[Depends(strict_api_key_auth)])
 
+log = logging.getLogger("api.node_actions")
+
 
 @router.patch(
     "/{node_id}",
     response_model=NodeActionResponse,
     response_model_exclude_none=True,
 )
-async def node_action_route(node_id: UUID, action: NodeActionRequest) -> NodeActionResponse:
+async def node_action_route(
+    node_id: UUID, action: NodeActionRequest, request: Request
+) -> NodeActionResponse:
     payload = action.model_dump(exclude={"action"}, exclude_none=True)
     result = await orchestrator_adapter.node_action(node_id, action.action, payload)
-    return NodeActionResponse(node_id=node_id, **result)
+
+    req_id = getattr(request.state, "request_id", None)
+    log.info(
+        "node action",
+        extra={
+            "run_id": str(result.get("run_id")) if result.get("run_id") else None,
+            "node_id": str(node_id),
+            "request_id": req_id,
+            "action": action.action,
+        },
+    )
+
+    filtered = {
+        k: v for k, v in result.items() if k in {"status_after", "sidecar_updated"} and v is not None
+    }
+    return NodeActionResponse(node_id=node_id, **filtered)

--- a/app/services/orchestrator_adapter.py
+++ b/app/services/orchestrator_adapter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict
 
+from fastapi import HTTPException
+
 
 async def start(plan_id: uuid.UUID, dry_run: bool = False) -> uuid.UUID:
     """Démarre un plan via l'orchestrateur.
@@ -15,16 +17,56 @@ async def start(plan_id: uuid.UUID, dry_run: bool = False) -> uuid.UUID:
     return uuid.uuid4()
 
 
+# État simulé des nœuds pour vérifier les transitions.
+_NODE_STATES: Dict[uuid.UUID, Dict[str, Any]] = {}
+
+
 async def node_action(
     node_id: uuid.UUID, action: str, payload: Dict[str, Any] | None = None
 ) -> Dict[str, Any]:
     """Applique une action sur un nœud.
 
-    On retourne le statut après action (ici l'action elle-même) et un indicateur
-    `sidecar_updated` si un override de prompt ou de paramètres est présent.
+    Cette implémentation mémoire maintient un état minimal afin de vérifier la
+    cohérence des transitions. En cas de transition invalide, on lève une
+    ``HTTPException`` 409.
+
+    On retourne le statut après action et un indicateur ``sidecar_updated`` si
+    un override de prompt ou de paramètres est présent.
     """
 
-    sidecar_updated = bool(payload) and bool(
-        (payload.get("override_prompt") or payload.get("params"))
+    payload = payload or {}
+
+    state = _NODE_STATES.setdefault(
+        node_id, {"status": "running", "run_id": uuid.uuid4()}
     )
-    return {"status_after": action, "sidecar_updated": sidecar_updated}
+    current = state["status"]
+
+    if action == "pause":
+        if current != "running":
+            raise HTTPException(status_code=409, detail="invalid transition")
+        state["status"] = "paused"
+        status_after = "paused"
+    elif action == "resume":
+        if current != "paused":
+            raise HTTPException(status_code=409, detail="invalid transition")
+        state["status"] = "running"
+        status_after = "running"
+    elif action == "skip":
+        if current != "paused":
+            raise HTTPException(status_code=409, detail="invalid transition")
+        state["status"] = "skipped"
+        status_after = "skipped"
+    elif action == "override":
+        if current not in {"running", "paused"}:
+            raise HTTPException(status_code=409, detail="invalid transition")
+        state["status"] = "queued"
+        status_after = "queued"
+    else:
+        raise HTTPException(status_code=400, detail="unknown action")
+
+    sidecar_updated = bool(payload.get("prompt") or payload.get("params"))
+    return {
+        "status_after": status_after,
+        "sidecar_updated": sidecar_updated or None,
+        "run_id": state["run_id"],
+    }

--- a/core/log.py
+++ b/core/log.py
@@ -1,0 +1,53 @@
+import logging
+import json
+import contextvars
+
+request_id_var = contextvars.ContextVar("request_id", default=None)
+
+class ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        rid = request_id_var.get()
+        if rid:
+            record.request_id = rid
+        return True
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple
+        payload = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "logger": record.name,
+        }
+        for k, v in record.__dict__.items():
+            if k not in (
+                "name",
+                "msg",
+                "args",
+                "levelname",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+                "message",
+            ):
+                payload[k] = v
+        return json.dumps(payload, ensure_ascii=False)
+
+_handler = logging.StreamHandler()
+_handler.setFormatter(JsonFormatter())
+_root = logging.getLogger()
+_root.handlers = [_handler]
+_root.setLevel(logging.INFO)
+_root.addFilter(ContextFilter())

--- a/tests_api/test_request_id_header.py
+++ b/tests_api/test_request_id_header.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import pytest
@@ -11,5 +10,5 @@ async def test_request_id_header_and_log(client, caplog):
     assert resp.status_code == 200
     rid = resp.headers.get("X-Request-ID")
     assert rid
-    logged = [json.loads(r.message)["request_id"] for r in caplog.records]
+    logged = [r.request_id for r in caplog.records]
     assert rid in logged


### PR DESCRIPTION
## Résumé
- Correction de la remise du request_id après journalisation pour permettre à caplog de l'observer
- Import de core.log au démarrage de l'app pour configurer le logger racine

## Test
- `pre-commit run --files api/fastapi_app/middleware/request_id.py api/fastapi_app/app.py tests_api/test_request_id_header.py`
- `make api-test`
- `make api-e2e-happy`
- `make dash-mini-test` *(échec: Expected a single value for option "--run", received [true, true])* 
- `make ui-run-e2e` *(erreurs TypeScript lors du build)*
- `python - <<'PY' ...` (PATCH /nodes, sidecar_updated true et log contient run_id/node_id/request_id/action)


------
https://chatgpt.com/codex/tasks/task_e_68b5e8430fd0832780c26a56fae8ac79