### PR TITLE
Gestion dynamique des échecs de nœuds

### DIFF
--- a/tests/test_executor_reallocation.py
+++ b/tests/test_executor_reallocation.py
@@ -1,0 +1,46 @@
+import uuid
+import pytest
+
+from core.planning.task_graph import PlanNode, TaskGraph
+from apps.orchestrator import executor as exec_mod
+
+class DummyStorage:
+    async def save_run(self, *a, **kw):
+        pass
+    async def save_node(self, *a, **kw):
+        pass
+    async def save_artifact(self, *a, **kw):
+        pass
+
+@pytest.mark.asyncio
+async def test_reallocation_success(monkeypatch):
+    calls = []
+    async def fake_exec(node, *args, **kwargs):
+        calls.append(node.suggested_agent_role)
+        if node.suggested_agent_role.endswith('_alt'):
+            return {}
+        raise RuntimeError('boom')
+    monkeypatch.setattr(exec_mod, '_execute_node', fake_exec)
+    monkeypatch.setenv('NODE_MAX_RETRIES', '0')
+    node = PlanNode(id='n1', title='N', type='execute', suggested_agent_role='Writer_FR')
+    dag = TaskGraph([node])
+    storage = DummyStorage()
+    res = await exec_mod.run_graph(dag, storage, str(uuid.uuid4()))
+    assert calls == ['Writer_FR', 'Writer_FR_alt']
+    assert res['status'] == 'succeeded'
+
+@pytest.mark.asyncio
+async def test_reallocation_failure_signal(monkeypatch):
+    async def fake_exec(node, *args, **kwargs):
+        raise RuntimeError('boom')
+    monkeypatch.setattr(exec_mod, '_execute_node', fake_exec)
+    monkeypatch.setenv('NODE_MAX_RETRIES', '0')
+    node = PlanNode(id='n1', title='N', type='execute', suggested_agent_role='Writer_FR')
+    dag = TaskGraph([node])
+    storage = DummyStorage()
+    res = await exec_mod.run_graph(dag, storage, str(uuid.uuid4()))
+    assert res['failed'] == ['n1']
+    assert res['signals']
+    sig = res['signals'][0]
+    assert sig['plan_status'] == 'draft'
+    assert sig['report']['attempts'] == 1


### PR DESCRIPTION
## Résumé
- Ajout d'un rapport d'échec avec tentative de réallocation automatique vers un autre profil d'agent
- Signalisation au superviseur pour replanification lorsque la réallocation échoue
- Couverture de ces scénarios par des tests dédiés

## Tests
- `pytest tests/test_executor_reallocation.py tests/test_manager_assignments.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5f5c708788327a2a5fecfb39d6268