### PR TITLE
validation humaine du plan avant exécution

### DIFF
--- a/api/database/models.py
+++ b/api/database/models.py
@@ -5,6 +5,7 @@ from sqlmodel import SQLModel
 from core.storage.db_models import Artifact, Event, Node, Run
 from app.models.task import Task
 from app.models.plan import Plan
+from app.models.plan_review import PlanReview
 from app.models.assignment import Assignment
 
 # Les tests s’attendent à un objet ayant un attribut `metadata`.
@@ -19,4 +20,5 @@ __all__ = [
     "Task",
     "Plan",
     "Assignment",
+    "PlanReview",
 ]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,9 +1,11 @@
 from .task import Task, TaskStatus
 from .plan import Plan, PlanStatus
+from .plan_review import PlanReview
 
 __all__ = [
     "Task",
     "TaskStatus",
     "Plan",
     "PlanStatus",
+    "PlanReview",
 ]

--- a/app/models/plan_review.py
+++ b/app/models/plan_review.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, UTC
+from typing import List
+
+import sqlalchemy as sa
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Boolean, func
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
+from sqlmodel import SQLModel, Field
+
+
+class PlanReview(SQLModel, table=True):
+    __tablename__ = "plan_reviews"
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
+    )
+    plan_id: uuid.UUID = Field(
+        sa_column=Column(
+            PGUUID(as_uuid=True),
+            ForeignKey("plans.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    version: int = Field(sa_column=Column(Integer, nullable=False))
+    validated: bool = Field(sa_column=Column(Boolean, nullable=False))
+    errors: List[str] = Field(
+        default_factory=list,
+        sa_column=Column(
+            sa.JSON().with_variant(JSONB, "postgresql"),
+            nullable=False,
+        ),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
+    )

--- a/app/services/orchestrator_adapter.py
+++ b/app/services/orchestrator_adapter.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException
 
 
 async def start(plan_id: uuid.UUID, dry_run: bool = False) -> uuid.UUID:
-    """Démarre un plan via l'orchestrateur (stub)."""
+    """Démarre un plan via l'orchestrateur (mock)."""
     return uuid.uuid4()
 
 
@@ -18,9 +18,11 @@ _NODE_STATES: Dict[uuid.UUID, Dict[str, Any]] = {}
 async def node_action(
     node_id: uuid.UUID, action: str, payload: Dict[str, Any] | None = None
 ) -> Dict[str, Any]:
-    """Applique une action sur un nœud (FSM en mémoire).
-    - 409 si transition invalide
-    - Retourne status_after et sidecar_updated
+    """Applique une action sur un nœud (mock en mémoire).
+
+    - Valide les transitions et lève HTTP 409 si invalide
+    - Retourne le statut après action
+    - Indique si le sidecar LLM a été mis à jour (override prompt/params)
     """
     payload = payload or {}
 

--- a/app/services/supervisor.py
+++ b/app/services/supervisor.py
@@ -41,5 +41,5 @@ async def generate_plan(task: Task) -> PlanGenerationResult:
             edges.append({"source": dep, "target": n.id})
 
     graph = PlanGraph(nodes=nodes, edges=edges)
-    status = PlanStatus.ready if nodes else PlanStatus.invalid
+    status = PlanStatus.draft if nodes else PlanStatus.invalid
     return PlanGenerationResult(graph=graph, status=status)

--- a/tests_api/test_tasks_plan.py
+++ b/tests_api/test_tasks_plan.py
@@ -5,12 +5,13 @@ from sqlalchemy import insert, select
 
 from app.models.task import Task, TaskStatus
 from app.models.plan import Plan, PlanStatus
+from app.models.plan_review import PlanReview
 from app.schemas.plan import PlanGraph, PlanNode, PlanGenerationResult
 import api.fastapi_app.routes.tasks as tasks_routes
 
 
 @pytest.mark.asyncio
-async def test_generate_plan_ready(client, db_session, monkeypatch):
+async def test_generate_plan_draft(client, db_session, monkeypatch):
     task_id = uuid.uuid4()
     await db_session.execute(
         insert(Task).values({"id": task_id, "title": "Demo", "status": TaskStatus.draft})
@@ -20,14 +21,14 @@ async def test_generate_plan_ready(client, db_session, monkeypatch):
     async def fake_generate(_task: Task) -> PlanGenerationResult:
         node = PlanNode(id="n1", title="T1", deps=[], suggested_agent_role="role")
         graph = PlanGraph(nodes=[node], edges=[])
-        return PlanGenerationResult(graph=graph, status=PlanStatus.ready)
+        return PlanGenerationResult(graph=graph, status=PlanStatus.draft)
 
     monkeypatch.setattr(tasks_routes, "generate_plan", fake_generate)
 
     r = await client.post(f"/tasks/{task_id}/plan", headers={"X-API-Key": "test-key"})
     assert r.status_code == 201
     body = r.json()
-    assert body["status"] == "ready"
+    assert body["status"] == "draft"
     assert body["graph"]["version"] == "1.0"
     plan_id = uuid.UUID(body["plan_id"])
 
@@ -36,7 +37,7 @@ async def test_generate_plan_ready(client, db_session, monkeypatch):
     ).scalar_one()
     task = await db_session.get(Task, task_id)
     assert task.plan_id == plan.id
-    assert plan.status == PlanStatus.ready
+    assert plan.status == PlanStatus.draft
 
 
 @pytest.mark.asyncio
@@ -65,6 +66,82 @@ async def test_generate_plan_invalid(client, db_session, monkeypatch):
     task = await db_session.get(Task, task_id)
     assert task.plan_id is None
     assert plan.status == PlanStatus.invalid
+
+
+@pytest.mark.asyncio
+async def test_submit_plan_validation(client, db_session, monkeypatch):
+    task_id = uuid.uuid4()
+    await db_session.execute(
+        insert(Task).values({"id": task_id, "title": "Demo", "status": TaskStatus.draft})
+    )
+    await db_session.commit()
+
+    async def fake_generate(_task: Task) -> PlanGenerationResult:
+        node = PlanNode(id="n1", title="T1", deps=[], suggested_agent_role="role")
+        graph = PlanGraph(nodes=[node], edges=[])
+        return PlanGenerationResult(graph=graph, status=PlanStatus.draft)
+
+    monkeypatch.setattr(tasks_routes, "generate_plan", fake_generate)
+
+    r = await client.post(f"/tasks/{task_id}/plan", headers={"X-API-Key": "test-key"})
+    plan_id = uuid.UUID(r.json()["plan_id"])
+
+    r2 = await client.post(
+        f"/plans/{plan_id}/submit_for_validation",
+        json={"validated": True},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["validated"] is True
+
+    plan = await db_session.get(Plan, plan_id)
+    assert plan.status == PlanStatus.ready
+
+    reviews = (
+        await db_session.execute(select(PlanReview).where(PlanReview.plan_id == plan_id))
+    ).scalars().all()
+    assert len(reviews) == 1
+    assert reviews[0].validated is True
+    assert reviews[0].version == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_regeneration_after_review(client, db_session, monkeypatch):
+    task_id = uuid.uuid4()
+    await db_session.execute(
+        insert(Task).values({"id": task_id, "title": "Demo", "status": TaskStatus.draft})
+    )
+    await db_session.commit()
+
+    async def fake_generate(_task: Task) -> PlanGenerationResult:
+        node = PlanNode(id="n1", title="T1", deps=[], suggested_agent_role="role")
+        graph = PlanGraph(nodes=[node], edges=[])
+        return PlanGenerationResult(graph=graph, status=PlanStatus.draft)
+
+    monkeypatch.setattr(tasks_routes, "generate_plan", fake_generate)
+
+    r = await client.post(f"/tasks/{task_id}/plan", headers={"X-API-Key": "test-key"})
+    plan_id = uuid.UUID(r.json()["plan_id"])
+
+    await client.post(
+        f"/plans/{plan_id}/submit_for_validation",
+        json={"validated": False, "errors": ["oops"]},
+        headers={"X-API-Key": "test-key"},
+    )
+
+    # Regenerate plan -> version should increment
+    r2 = await client.post(f"/tasks/{task_id}/plan", headers={"X-API-Key": "test-key"})
+    assert r2.status_code == 201
+
+    plan = await db_session.get(Plan, plan_id)
+    assert plan.version == 2
+    assert plan.status == PlanStatus.draft
+
+    reviews = (
+        await db_session.execute(select(PlanReview).where(PlanReview.plan_id == plan_id))
+    ).scalars().all()
+    assert len(reviews) == 1
+    assert reviews[0].validated is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Résumé
- plan généré en mode brouillon avec version incrémentale
- endpoint de validation humaine avec historique des revues
- interdiction de démarrer une tâche sans plan prêt
- séparation de la logique `node_action` et de la configuration de logging

## Tests
- `make api-test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f5b459088327b34987a4d3f415b0