### PR TITLE
feat: add human validation to task plan script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,13 @@ help:
 	@echo "  env-check           -> imprime quelques variables utiles"
 	@echo "  api-run             -> lance FastAPI en dev (reload)"
 	@echo "  api-run-prod        -> lance FastAPI en prod"
+	@echo "  api-migrate         -> applique les migrations Alembic"
 	@echo "  api-test            -> teste l’API (si tests présents)"
 	@echo "  db-up / db-down     -> docker compose (postgres/pgadmin) si docker-compose.yml existe"
 	@echo "  db-logs / db-reset  -> idem"
 	@echo "  validate            -> valide les sidecars .llm.json"
 	@echo "  validate-strict     -> validation stricte des sidecars"
+	@echo "  ui-run-e2e          -> build + preview + tests e2e UI"
 .PHONY: init-env
 init-env:
 	@if [ -f $(ENV_FILE) ]; then \


### PR DESCRIPTION
## Summary
- document api-migrate and ui-run-e2e in Makefile help
- extend task_plan_start script with simulated human validation and X-Request-ID logging
- log plan status and expose Location header when starting a run

## Testing
- `make test` *(échoue : KeyError 'prompt' et connexion Sentry refusée)*
- `make api-test`
- `make api-run` *(impossible de se connecter à PostgreSQL)*
- `scripts/task_plan_start.py` *(HTTP 500 depuis /tasks)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f5d5e6608327a19272989ee7c068