### PR TITLE
Fix node override payload and recovery test

### DIFF
--- a/app/routers/nodes.py
+++ b/app/routers/nodes.py
@@ -23,7 +23,7 @@ log = logging.getLogger("api.node_actions")
 async def node_action_route(
     node_id: UUID, action: NodeActionRequest, request: Request
 ) -> NodeActionResponse:
-    payload = action.model_dump(exclude={"action"}, exclude_none=True)
+    payload = action.model_dump(exclude={"action"}, exclude_none=True, by_alias=True)
     result = await orchestrator_adapter.node_action(node_id, action.action, payload)
 
     req_id = getattr(request.state, "request_id", None)

--- a/app/schemas/node_actions.py
+++ b/app/schemas/node_actions.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from typing import Any, Dict, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class NodeActionRequest(BaseModel):
     """Requête pour une action sur un nœud."""
 
     action: Literal["pause", "resume", "override", "skip"]
-    override_prompt: Optional[str] = None
+    override_prompt: Optional[str] = Field(None, alias="prompt")
     params: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
 
 class NodeActionResponse(BaseModel):

--- a/tests/test_recovery_e2e.py
+++ b/tests/test_recovery_e2e.py
@@ -20,7 +20,11 @@ class Node:
 
 class DummyDag:
     def __init__(self):
-        self.nodes = {k: Node(k) for k in ["A", "B", "C"]}
+        self.nodes = {
+            "A": Node("A"),
+            "B": Node("B", role="Worker_alt"),
+            "C": Node("C"),
+        }
         self.nodes["B"].deps = ["A"]
         self.nodes["C"].deps = ["B"]
         self.nodes["A"].succ = [self.nodes["B"]]


### PR DESCRIPTION
## Summary
- ensure `override` patch forwards `prompt` to orchestrator
- avoid automatic reallocation in recovery test by using alt worker role

## Testing
- `PYTHONPATH=. make test-all`

------
https://chatgpt.com/codex/tasks/task_e_68b5fe1a78cc832787a8a1f19decbe52