### PR TITLE
feat(fil8): modèles agents, seeds et schémas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,14 @@ api-run-prod: ensure-venv
 api-migrate: ensure-venv
 	@$(ACTIVATE) && alembic upgrade head
 
+.PHONY: migrate-fil8
+migrate-fil8:
+	poetry run alembic upgrade head
+
+.PHONY: seed-agents
+seed-agents:
+	poetry run python scripts/seed_agents.py
+
 .PHONY: api-test
 api-test: ensure-venv
 	@if [ -d api/tests ]; then \

--- a/alembic/versions/20250901_01_init_agents.py
+++ b/alembic/versions/20250901_01_init_agents.py
@@ -1,0 +1,129 @@
+"""init agents tables
+
+Revision ID: 20250901_01_init_agents
+Revises: 20250818_indexes_readonly
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20250901_01_init_agents"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250818_indexes_readonly",
+    "7eb39369039a",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_templates",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=False),
+        sa.Column("prompt_system", sa.Text(), nullable=True),
+        sa.Column("prompt_user", sa.Text(), nullable=True),
+        sa.Column("default_model", sa.Text(), nullable=True),
+        sa.Column(
+            "config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_agent_templates_name"),
+    )
+
+    op.create_table(
+        "agent_models_matrix",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=False),
+        sa.Column(
+            "models",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("role", "domain", name="uq_agent_models_matrix_role_domain"),
+    )
+
+    op.create_table(
+        "agents",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=False),
+        sa.Column("prompt_system", sa.Text(), nullable=True),
+        sa.Column("prompt_user", sa.Text(), nullable=True),
+        sa.Column("default_model", sa.Text(), nullable=True),
+        sa.Column(
+            "config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_agents_name"),
+    )
+    op.create_index(
+        "ix_agents_role_domain", "agents", ["role", "domain"], unique=False
+    )
+    op.create_index("ix_agents_is_active", "agents", ["is_active"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agents_is_active", table_name="agents")
+    op.drop_index("ix_agents_role_domain", table_name="agents")
+    op.drop_table("agents")
+    op.drop_table("agent_models_matrix")
+    op.drop_table("agent_templates")

--- a/api/database/models.py
+++ b/api/database/models.py
@@ -7,6 +7,7 @@ from app.models.task import Task
 from app.models.plan import Plan
 from app.models.plan_review import PlanReview
 from app.models.assignment import Assignment
+from api.fastapi_app.models.agent import Agent, AgentTemplate, AgentModelsMatrix
 
 # Les tests s’attendent à un objet ayant un attribut `metadata`.
 Base = SQLModel
@@ -21,4 +22,7 @@ __all__ = [
     "Plan",
     "Assignment",
     "PlanReview",
+    "Agent",
+    "AgentTemplate",
+    "AgentModelsMatrix",
 ]

--- a/api/fastapi_app/models/agent.py
+++ b/api/fastapi_app/models/agent.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, UTC
+from typing import Dict, Any
+
+import sqlalchemy as sa
+from sqlalchemy import Column, DateTime, Text, Boolean, Integer, Index, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
+from sqlmodel import SQLModel, Field
+
+
+class Agent(SQLModel, table=True):
+    __tablename__ = "agents"
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
+    )
+    name: str = Field(sa_column=Column(Text, nullable=False, unique=True))
+    role: str = Field(sa_column=Column(Text, nullable=False))
+    domain: str = Field(sa_column=Column(Text, nullable=False))
+    prompt_system: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    prompt_user: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    default_model: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    config: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(
+            sa.JSON().with_variant(JSONB, "postgresql"),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+    )
+    version: int = Field(default=1, sa_column=Column(Integer, nullable=False, default=1))
+    is_active: bool = Field(default=True, sa_column=Column(Boolean, nullable=False, default=True))
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+
+    __table_args__ = (
+        Index("ix_agents_role_domain", "role", "domain"),
+        Index("ix_agents_is_active", "is_active"),
+        UniqueConstraint("name", name="uq_agents_name"),
+    )
+
+
+class AgentTemplate(SQLModel, table=True):
+    __tablename__ = "agent_templates"
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
+    )
+    name: str = Field(sa_column=Column(Text, nullable=False, unique=True))
+    role: str = Field(sa_column=Column(Text, nullable=False))
+    domain: str = Field(sa_column=Column(Text, nullable=False))
+    prompt_system: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    prompt_user: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    default_model: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    config: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(
+            sa.JSON().with_variant(JSONB, "postgresql"),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+    )
+    version: int = Field(default=1, sa_column=Column(Integer, nullable=False, default=1))
+    is_active: bool = Field(default=True, sa_column=Column(Boolean, nullable=False, default=True))
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("name", name="uq_agent_templates_name"),
+    )
+
+
+class AgentModelsMatrix(SQLModel, table=True):
+    __tablename__ = "agent_models_matrix"
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
+    )
+    role: str = Field(sa_column=Column(Text, nullable=False))
+    domain: str = Field(sa_column=Column(Text, nullable=False))
+    models: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(
+            sa.JSON().with_variant(JSONB, "postgresql"),
+            server_default=sa.text("'{}'"),
+            nullable=False,
+        ),
+    )
+    version: int = Field(default=1, sa_column=Column(Integer, nullable=False, default=1))
+    is_active: bool = Field(default=True, sa_column=Column(Boolean, nullable=False, default=True))
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("role", "domain", name="uq_agent_models_matrix_role_domain"),
+    )

--- a/api/fastapi_app/schemas/prompting.py
+++ b/api/fastapi_app/schemas/prompting.py
@@ -1,0 +1,100 @@
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+
+class SafetyPolicies(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    allow_tools: List[str] = Field(default_factory=list)
+    forbidden_content: List[str] = Field(default_factory=list)
+    pii_redaction: bool = True
+
+
+class Capabilities(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    tools: List[str] = Field(default_factory=list)
+    permissions: List[str] = Field(default_factory=list)
+
+
+class PromptGuidelines(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    style: Dict[str, Any] = Field(default_factory=lambda: {"tone": "professionnel", "no_purple_prose": True})
+    io_format: Dict[str, Any] = Field(default_factory=lambda: {"input": "json", "output": "json"})
+    acceptance: List[str] = Field(default_factory=list)
+    tracing: Dict[str, Any] = Field(default_factory=lambda: {"summarize_key_decisions": True})
+
+
+class ProviderStrategy(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    preferences: List[Dict[str, Any]] = Field(default_factory=list)
+    fallbacks: List[Dict[str, Any]] = Field(default_factory=list)
+    budget: Dict[str, Any] = Field(default_factory=lambda: {"max_total_cost_per_run": 5.0})
+
+
+class CostLimits(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    max_tokens_per_call: int = 8192
+    max_total_cost_per_run: float = 5.0
+
+
+class AgentConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    prompt_guidelines: PromptGuidelines = Field(default_factory=PromptGuidelines)
+    capabilities: Capabilities = Field(default_factory=Capabilities)
+    provider_strategy: ProviderStrategy = Field(default_factory=ProviderStrategy)
+    cost_limits: CostLimits = Field(default_factory=CostLimits)
+    safety_policies: SafetyPolicies = Field(default_factory=SafetyPolicies)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentCreate(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    name: str
+    role: str
+    domain: str
+    prompt_system: Optional[str] = None
+    prompt_user: Optional[str] = None
+    default_model: Optional[str] = None
+    config: AgentConfig = Field(default_factory=AgentConfig)
+
+    @field_validator('role')
+    @classmethod
+    def role_allowed(cls, v: str) -> str:
+        allowed = {"supervisor", "manager", "executor", "reviewer", "other"}
+        if v not in allowed:
+            raise ValueError(f"role must be one of {allowed}")
+        return v
+
+
+class AgentUpdate(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    name: Optional[str] = None
+    domain: Optional[str] = None
+    prompt_system: Optional[str] = None
+    prompt_user: Optional[str] = None
+    default_model: Optional[str] = None
+    is_active: Optional[bool] = None
+    config: Optional[AgentConfig] = None
+
+
+class RecruitRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    role_description: str
+    role: Optional[str] = None
+    domain: Optional[str] = None
+    language: Optional[str] = Field(default="fr")
+    tone: Optional[str] = Field(default="professionnel")
+    tools_required: List[str] = Field(default_factory=list)
+    budget: Dict[str, Any] = Field(default_factory=lambda: {"max_total_cost_per_run": 5.0})
+    latency_target_ms: Optional[int] = None
+    safety_level: Optional[str] = Field(default="standard")
+
+
+class RecruitResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    agent_id: str
+    name: str
+    role: str
+    domain: Optional[str]
+    default_model: Optional[str]
+    sidecar: Dict[str, Any]
+    template_used: Optional[str] = None

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -4,5 +4,6 @@ from sqlmodel import SQLModel
 # Import minimal models so SQLModel.metadata is populated
 from app.models.plan import Plan  # noqa: F401
 from app.models.task import Task  # noqa: F401
+from api.fastapi_app.models.agent import Agent, AgentTemplate, AgentModelsMatrix  # noqa: F401
 
 Base = SQLModel

--- a/scripts/seed_agents.py
+++ b/scripts/seed_agents.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+from sqlalchemy import select
+
+from api.fastapi_app.models.agent import AgentTemplate, AgentModelsMatrix
+from api.fastapi_app.deps import get_sessionmaker
+
+
+async def seed_templates(path: str = "seeds/agent_templates.json") -> None:
+    SessionLocal = get_sessionmaker()
+    async with SessionLocal() as s:
+        data = json.load(open(path, "r", encoding="utf-8"))
+        for row in data:
+            exists = (
+                await s.execute(
+                    select(AgentTemplate).where(AgentTemplate.name == row["name"])
+                )
+            ).scalar_one_or_none()
+            if not exists:
+                s.add(AgentTemplate(**row))
+        await s.commit()
+
+
+async def seed_matrix(path: str = "seeds/agent_models_matrix.json") -> None:
+    SessionLocal = get_sessionmaker()
+    async with SessionLocal() as s:
+        data = json.load(open(path, "r", encoding="utf-8"))
+        for row in data:
+            exists = (
+                await s.execute(
+                    select(AgentModelsMatrix).where(
+                        AgentModelsMatrix.role == row["role"],
+                        AgentModelsMatrix.domain == row["domain"],
+                    )
+                )
+            ).scalar_one_or_none()
+            if not exists:
+                s.add(AgentModelsMatrix(**row))
+        await s.commit()
+
+
+async def main() -> None:
+    await seed_matrix()
+    await seed_templates()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/seeds/agent_models_matrix.json
+++ b/seeds/agent_models_matrix.json
@@ -1,0 +1,61 @@
+[
+  {
+    "role": "manager",
+    "domain": "frontend",
+    "models": {
+      "preferred": [
+        {"provider":"openai","model":"gpt-4o-mini","weight_quality":1.0,"weight_latency":1.0,"weight_cost":0.8},
+        {"provider":"anthropic","model":"claude-haiku","weight_quality":0.9,"weight_latency":1.0,"weight_cost":0.8}
+      ],
+      "fallbacks": [
+        {"provider":"mistral","model":"mistral-small","weight_quality":0.75,"weight_latency":0.9,"weight_cost":1.0},
+        {"provider":"ollama","model":"llama3","weight_quality":0.6,"weight_latency":0.7,"weight_cost":1.0}
+      ],
+      "notes_performance": {},
+      "notes_cost": {}
+    }
+  },
+  {
+    "role": "manager",
+    "domain": "backend",
+    "models": {
+      "preferred": [
+        {"provider":"openai","model":"gpt-4o-mini","weight_quality":1.0,"weight_latency":1.0,"weight_cost":0.8}
+      ],
+      "fallbacks": [
+        {"provider":"mistral","model":"mistral-small","weight_quality":0.8,"weight_latency":0.9,"weight_cost":1.0},
+        {"provider":"ollama","model":"llama3","weight_quality":0.6,"weight_latency":0.6,"weight_cost":1.0}
+      ],
+      "notes_performance": {},
+      "notes_cost": {}
+    }
+  },
+  {
+    "role": "executor",
+    "domain": "writer-translator",
+    "models": {
+      "preferred": [
+        {"provider":"openai","model":"gpt-4o-mini","weight_quality":1.0,"weight_latency":1.0,"weight_cost":0.9}
+      ],
+      "fallbacks": [
+        {"provider":"mistral","model":"mistral-small","weight_quality":0.8,"weight_latency":0.9,"weight_cost":1.0}
+      ],
+      "notes_performance": {},
+      "notes_cost": {}
+    }
+  },
+  {
+    "role": "reviewer",
+    "domain": "general",
+    "models": {
+      "preferred": [
+        {"provider":"openai","model":"gpt-4o-mini","weight_quality":1.0,"weight_latency":1.0,"weight_cost":0.85}
+      ],
+      "fallbacks": [
+        {"provider":"ollama","model":"llama3","weight_quality":0.6,"weight_latency":0.7,"weight_cost":1.0}
+      ],
+      "notes_performance": {},
+      "notes_cost": {}
+    }
+  }
+]

--- a/seeds/agent_templates.json
+++ b/seeds/agent_templates.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "manager-frontend",
+    "role": "manager",
+    "domain": "frontend",
+    "prompt_system": "Tu es un Manager Frontend. Langue:{language} Ton:{tone}. Responsabilités: planifier, coacher, valider. Limites: outils déclaratifs uniquement.",
+    "default_model": "openai:gpt-4o-mini",
+    "config": {
+      "prompt_guidelines": {"style":{"tone":"professionnel","no_purple_prose":true},"io_format":{"input":"json","output":"json"},"acceptance":["structure claire","pas de cycles infinis"],"tracing":{"summarize_key_decisions":true}},
+      "capabilities": {"tools":["search","notion.write"],"permissions":["assign","review"]},
+      "provider_strategy": {"preferences":[{"provider":"openai","model":"gpt-4o-mini"}],"fallbacks":[{"provider":"mistral","model":"mistral-small"}],"budget":{"max_total_cost_per_run":5.0}},
+      "cost_limits": {"max_tokens_per_call":8192,"max_total_cost_per_run":5.0},
+      "safety_policies": {"allow_tools":["search","notion.write"],"forbidden_content":[],"pii_redaction":true},
+      "metadata": {"category":"manager","name_pattern":"manager-frontend-{domain}"}
+    }
+  },
+  {
+    "name": "manager-backend",
+    "role": "manager",
+    "domain": "backend",
+    "prompt_system": "Tu es un Manager Backend. Langue:{language} Ton:{tone}.",
+    "default_model": "openai:gpt-4o-mini",
+    "config": { "prompt_guidelines": {"style":{"tone":"professionnel","no_purple_prose":true}}, "capabilities": {"tools":["search"],"permissions":["assign","review"]}, "provider_strategy": {"preferences":[{"provider":"openai","model":"gpt-4o-mini"}],"fallbacks":[{"provider":"mistral","model":"mistral-small"}]}, "cost_limits": {"max_tokens_per_call":8192,"max_total_cost_per_run":5.0}, "safety_policies": {}, "metadata":{"category":"manager","name_pattern":"manager-backend-{domain}"} }
+  },
+  {
+    "name": "executor-writer-translator",
+    "role": "executor",
+    "domain": "writer-translator",
+    "prompt_system": "Tu es un traducteur technique EN↔FR. Langue:{language} Ton:{tone}.",
+    "default_model": "openai:gpt-4o-mini",
+    "config": { "prompt_guidelines": {"style":{"tone":"professionnel","no_purple_prose":true},"io_format":{"input":"text","output":"text"},"acceptance":["fidélité","terminologie"],"tracing":{"summarize_key_decisions":true}}, "capabilities": {"tools":[],"permissions":[]}, "provider_strategy": {"preferences":[{"provider":"openai","model":"gpt-4o-mini"}],"fallbacks":[{"provider":"mistral","model":"mistral-small"}],"budget":{"max_total_cost_per_run":1.0}}, "cost_limits": {"max_tokens_per_call":8192,"max_total_cost_per_run":1.0}, "safety_policies": {}, "metadata":{"category":"executor","name_pattern":"translator-{domain}"} }
+  },
+  {
+    "name": "executor-researcher",
+    "role": "executor",
+    "domain": "research",
+    "prompt_system": "Tu es un chercheur. Langue:{language} Ton:{tone}.",
+    "default_model": "openai:gpt-4o-mini",
+    "config": { "prompt_guidelines": {"style":{"tone":"professionnel","no_purple_prose":true}}, "capabilities": {"tools":["search"],"permissions":[]}, "provider_strategy": {"preferences":[{"provider":"openai","model":"gpt-4o-mini"}],"fallbacks":[{"provider":"mistral","model":"mistral-small"}]}, "cost_limits": {"max_tokens_per_call":8192,"max_total_cost_per_run":3.0}, "safety_policies": {}, "metadata":{"category":"executor","name_pattern":"researcher-{domain}"} }
+  },
+  {
+    "name": "reviewer-general",
+    "role": "reviewer",
+    "domain": "general",
+    "prompt_system": "Tu es un reviewer. Langue:{language} Ton:{tone}.",
+    "default_model": "openai:gpt-4o-mini",
+    "config": { "prompt_guidelines": {"style":{"tone":"professionnel","no_purple_prose":true}}, "capabilities": {"tools":[],"permissions":["review"]}, "provider_strategy": {"preferences":[{"provider":"openai","model":"gpt-4o-mini"}],"fallbacks":[{"provider":"ollama","model":"llama3"}]}, "cost_limits": {"max_tokens_per_call":4096,"max_total_cost_per_run":2.0}, "safety_policies": {}, "metadata":{"category":"reviewer","name_pattern":"reviewer-{domain}"} }
+  }
+]

--- a/tests/test_agents_model.py
+++ b/tests/test_agents_model.py
@@ -1,0 +1,37 @@
+import uuid
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from api.fastapi_app.models.agent import Agent
+
+
+@pytest.mark.asyncio
+async def test_create_read_agent(db_session):
+    agent = Agent(
+        name="manager-frontend-general",
+        role="manager",
+        domain="frontend",
+        default_model="openai:gpt-4o-mini",
+    )
+    db_session.add(agent)
+    await db_session.commit()
+    await db_session.refresh(agent)
+
+    stmt = select(Agent).where(Agent.id == agent.id)
+    res = await db_session.execute(stmt)
+    fetched = res.scalar_one()
+    assert fetched.name == "manager-frontend-general"
+    assert fetched.role == "manager"
+    assert fetched.domain == "frontend"
+
+
+@pytest.mark.asyncio
+async def test_unique_agent_name(db_session):
+    a1 = Agent(name="dup", role="manager", domain="frontend")
+    a2 = Agent(name="dup", role="manager", domain="backend")
+    db_session.add(a1)
+    await db_session.commit()
+    db_session.add(a2)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()


### PR DESCRIPTION
## Résumé
- normalise la configuration des agents via des schémas Pydantic
- ajoute les seeds pour la matrice de modèles et les templates d'agents
- introduit un script idempotent de semis et la cible `seed-agents`

## Tests
- `make migrate-fil8` *(échoue : Command not found: alembic)*
- `make seed-agents` *(échoue : ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest -q tests/test_agents_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68b60224163483279c84083c7c932faa