### PR TITLE
Uniformisation des liens de pagination et RBAC lecture

### DIFF
--- a/api/fastapi_app/deps.py
+++ b/api/fastapi_app/deps.py
@@ -153,7 +153,16 @@ async def read_role(
         role = x_role or "viewer"
         request.state.role = role
         return role
-    if x_role not in {"viewer", "editor", "admin"}:
+
+    allowed = {"viewer", "editor", "admin"}
+    if request.method in {"GET", "HEAD", "OPTIONS"}:
+        role = x_role or "viewer"
+        if x_role and x_role not in allowed:
+            raise HTTPException(status_code=403, detail="RBAC: rôle requis")
+        request.state.role = role
+        return role
+
+    if x_role not in allowed:
         raise HTTPException(status_code=403, detail="RBAC: rôle requis")
     request.state.role = x_role
     return x_role

--- a/api/fastapi_app/routes/artifacts.py
+++ b/api/fastapi_app/routes/artifacts.py
@@ -72,7 +72,7 @@ async def list_artifacts(
         )
         for a in rows
     ]
-    set_pagination_headers(
+    links = set_pagination_headers(
         response, request, total, pagination.limit, pagination.offset
     )
     return Page[ArtifactOut](
@@ -80,6 +80,7 @@ async def list_artifacts(
         total=total,
         limit=pagination.limit,
         offset=pagination.offset,
+        links=links or None,
     )
 
 # --- NEW: GET /artifacts/{artifact_id} ---

--- a/api/fastapi_app/routes/events.py
+++ b/api/fastapi_app/routes/events.py
@@ -83,7 +83,7 @@ async def list_events(
         )
         for e in rows
     ]
-    set_pagination_headers(
+    links = set_pagination_headers(
         response, request, total, pagination.limit, pagination.offset
     )
     return Page[EventOut](
@@ -91,4 +91,5 @@ async def list_events(
         total=total,
         limit=pagination.limit,
         offset=pagination.offset,
+        links=links or None,
     )

--- a/api/fastapi_app/routes/nodes.py
+++ b/api/fastapi_app/routes/nodes.py
@@ -84,7 +84,7 @@ async def list_nodes(
         )
         for n in rows
     ]
-    set_pagination_headers(
+    links = set_pagination_headers(
         response, request, total, pagination.limit, pagination.offset
     )
     return Page[NodeOut](
@@ -92,4 +92,5 @@ async def list_nodes(
         total=total,
         limit=pagination.limit,
         offset=pagination.offset,
+        links=links or None,
     )

--- a/api/fastapi_app/routes/runs.py
+++ b/api/fastapi_app/routes/runs.py
@@ -87,7 +87,7 @@ async def list_runs(
         for r in runs
     ]
 
-    set_pagination_headers(
+    links = set_pagination_headers(
         response, request, total, pagination.limit, pagination.offset
     )
     return Page[RunListItemOut](
@@ -95,6 +95,7 @@ async def list_runs(
         total=total,
         limit=pagination.limit,
         offset=pagination.offset,
+        links=links or None,
     )
 
 @router.get("/{run_id}", response_model=RunOut)

--- a/tests/security/test_rbac.py
+++ b/tests/security/test_rbac.py
@@ -33,3 +33,10 @@ async def test_no_rbac_header_required_when_flag_off(client, monkeypatch):
         headers={"X-Request-ID": "r3"},
     )
     assert r.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_without_role_header(client, monkeypatch):
+    monkeypatch.setattr(deps, "FEATURE_RBAC", True)
+    r = await client.get("/agents")
+    assert r.status_code == 200

--- a/tests_api/test_pagination.py
+++ b/tests_api/test_pagination.py
@@ -7,6 +7,7 @@ async def test_runs_pagination(client, seed_sample):
     body = r.json()
     assert body["limit"] == 50
     assert body["offset"] == 0
+    assert "_links" in body
 
     total = body["total"]
 
@@ -40,6 +41,7 @@ async def test_nodes_pagination(client, seed_sample):
     body = r.json()
     assert body["limit"] == 50
     assert body["offset"] == 0
+    assert "_links" in body
 
     r2 = await client.get(f"/runs/{run_id}/nodes?limit=500")
     assert r2.status_code == 200
@@ -64,6 +66,7 @@ async def test_artifacts_pagination(client, seed_sample):
     body = r.json()
     assert body["limit"] == 50
     assert body["offset"] == 0
+    assert "_links" in body
 
     r2 = await client.get(f"/nodes/{node_id}/artifacts?limit=500")
     assert r2.status_code == 200
@@ -96,6 +99,7 @@ async def test_events_pagination(client, seed_sample):
     body = r.json()
     assert body["limit"] == 50
     assert body["offset"] == 0
+    assert "_links" in body
 
     r2 = await client.get("/events", params={"run_id": run_id, "limit": 500})
     assert r2.status_code == 200


### PR DESCRIPTION
## Résumé
- ajoute le champ `_links` à toutes les réponses paginées (runs, nodes, events, artifacts)
- assouplit le RBAC : les requêtes GET ne nécessitent plus d'en-tête X-Role
- couvre ces changements par des tests de pagination et de sécurité

## Tests
- `pre-commit run --files api/fastapi_app/routes/runs.py api/fastapi_app/routes/nodes.py api/fastapi_app/routes/events.py api/fastapi_app/routes/artifacts.py api/fastapi_app/deps.py tests_api/test_pagination.py tests/security/test_rbac.py`
- `pytest tests_api/test_pagination.py tests/security/test_rbac.py`

------
https://chatgpt.com/codex/tasks/task_e_68b679baecc48327ad88a6c33a8f6a8d