### PR TITLE
feat: auto review hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ curl -X POST "http://localhost:8000/feedbacks" \
  }'
 ```
 
+Un feedback automatique est généré après chaque nœud. Si le score est
+inférieur au seuil configuré (`FEEDBACK_CRITICAL_THRESHOLD`, 60 par
+défaut) :
+
+1. Le nœud est marqué en pause et un événement `feedback.critical` est
+émis.
+2. Depuis l'interface, un re-run guidé peut être déclenché après avoir
+corrigé le prompt ou relancé le nœud.
+
+### Scénario E2E feedback auto + re-run
+
+1. Lancer l'API (`make api-run`).
+2. Exécuter un DAG : un feedback auto est créé et visible dans le
+   panneau Feedback du dashboard.
+3. En cas de score critique, utiliser le bouton « Re-run guidé » pour
+   relancer le nœud après correction.
+
 ## Scénario E2E (API + UI)
 
 ### Prérequis

--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -44,6 +44,7 @@ TAGS_METADATA = [
     {"name": "events", "description": "Lecture des événements/logs d'un run."},
     {"name": "tasks", "description": "Déclenchement d’un run ad-hoc et suivi de statut."},
     {"name": "agents", "description": "Gestion des agents, recrutement et matrice modèles."},
+    {"name": "feedbacks", "description": "Feedbacks auto-générés ou humains."},
 ]
 
 def _build_storage():

--- a/api/fastapi_app/schemas/feedbacks.py
+++ b/api/fastapi_app/schemas/feedbacks.py
@@ -8,13 +8,17 @@ from pydantic import BaseModel, Field, ConfigDict
 
 
 class FeedbackCreate(BaseModel):
-    run_id: UUID
-    node_id: UUID
-    source: str
-    reviewer: Optional[str] = None
-    score: int = Field(ge=0, le=100)
-    comment: str
-    metadata: Optional[Dict[str, Any]] = None
+    """Payload pour créer un feedback."""
+
+    run_id: UUID = Field(..., examples=["11111111-1111-1111-1111-111111111111"])
+    node_id: UUID = Field(..., examples=["22222222-2222-2222-2222-222222222222"])
+    source: str = Field(..., examples=["auto", "human"])
+    reviewer: Optional[str] = Field(
+        default=None, examples=["reviewer-general"], description="Identité du reviewer"
+    )
+    score: int = Field(ge=0, le=100, examples=[75])
+    comment: str = Field(..., examples=["Sortie invalide"])
+    metadata: Optional[Dict[str, Any]] = Field(default=None, examples=[{"foo": "bar"}])
 
 
 class FeedbackOut(FeedbackCreate):

--- a/core/storage/composite_adapter.py
+++ b/core/storage/composite_adapter.py
@@ -86,7 +86,7 @@ class CompositeAdapter:
 
     async def _call(self, name: str, *args, **kwargs):
         result = None
-        needs_norm = name in {"save_artifact", "save_event"}
+        needs_norm = name in {"save_artifact", "save_event", "save_feedback"}
         for a in self.adapters:
             if not hasattr(a, name):
                 continue
@@ -117,6 +117,9 @@ class CompositeAdapter:
 
     async def save_event(self, *args, **kwargs):
         return await self._call("save_event", *args, **kwargs)
+
+    async def save_feedback(self, *args, **kwargs):
+        return await self._call("save_feedback", *args, **kwargs)
 
     async def get_run(self, *args, **kwargs):
         # premier qui répond (tolérant aux erreurs backend)

--- a/tests/test_orchestrator_autoreview.py
+++ b/tests/test_orchestrator_autoreview.py
@@ -1,0 +1,65 @@
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from core.planning.task_graph import PlanNode, TaskGraph
+import apps.orchestrator.executor as exec_mod
+
+
+class DummyStorage:
+    def __init__(self):
+        self.feedbacks = []
+        self.events = []
+
+    async def save_run(self, *a, **k):
+        pass
+
+    async def save_node(self, *a, **k):
+        pass
+
+    async def save_artifact(self, *a, **k):
+        pass
+
+    async def save_feedback(self, **k):
+        self.feedbacks.append(k)
+
+    async def save_event(self, **k):
+        self.events.append(k)
+
+
+@pytest.mark.asyncio
+async def test_autoreview_creates_feedback_and_event(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    async def fake_execute(node, *a, **k):
+        return {"markdown": "ok", "llm": {}}
+
+    async def fake_review(content):
+        return {"score": 40, "comment": "bad", "llm": {"provider": "p", "model_used": "m"}}
+
+    monkeypatch.setattr(exec_mod, "_execute_node", fake_execute)
+    monkeypatch.setattr(exec_mod, "_invoke_auto_reviewer", fake_review)
+    monkeypatch.setenv("FEEDBACK_CRITICAL_THRESHOLD", "60")
+
+    node = PlanNode(id="n1", title="N1", type="execute", suggested_agent_role="Researcher")
+    node.db_id = str(uuid.uuid4())
+    dag = TaskGraph([node])
+    storage = DummyStorage()
+
+    run_id = str(uuid.uuid4())
+    await exec_mod.run_graph(dag, storage, run_id)
+
+    assert storage.feedbacks, "feedback should be saved"
+    fb = storage.feedbacks[0]
+    assert fb["source"] == "auto" and fb["score"] == 40
+
+    sidecar = Path(f".runs/{run_id}/nodes/n1/n1.review.llm.json")
+    assert sidecar.exists()
+    data = json.loads(sidecar.read_text())
+    assert data.get("model") == "m"
+
+    assert storage.events, "critical event should be emitted"
+    assert storage.events[0]["message"] == "feedback.critical"
+


### PR DESCRIPTION
## Summary
- add auto-review LLM hook in orchestrator
- persist feedbacks and critical events
- document feedback API and update README

## Testing
- `pytest tests/test_orchestrator_autoreview.py api/tests/test_feedbacks_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ba3044808327acaa3e8673c5bad8