### PR TITLE
Ajout du panneau de feedbacks et tests E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test-feedbacks: ensure-venv
 
 .PHONY: ui-feedbacks-e2e
 ui-feedbacks-e2e:
-	@echo "⏭️  Tests e2e UI feedbacks non implémentés"
+	@cd dashboard/mini && npx playwright test tests-e2e/feedback.spec.ts
 
 # ---- Exécution ------------------------------------------------
 # Mode plan JSON explicite

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ défaut) :
 émis.
 2. Depuis l'interface, un re-run guidé peut être déclenché après avoir
 corrigé le prompt ou relancé le nœud.
+![Feedback Panel](docs/feedback-panel.png)
+
+Workflow complet :
+
+1. Saisir un feedback humain dans le panneau Feedback (score, commentaire).
+2. Le tableau affiche immédiatement les feedbacks auto et humains.
+3. En cas de score critique, utiliser « Re-run guidé » pour relancer le nœud.
 
 ### Scénario E2E feedback auto + re-run
 
@@ -67,6 +74,19 @@ corrigé le prompt ou relancé le nœud.
    panneau Feedback du dashboard.
 3. En cas de score critique, utiliser le bouton « Re-run guidé » pour
    relancer le nœud après correction.
+
+### Tests E2E UI (Playwright)
+
+1. Lancer le front en mode dev ou preview :
+   ```bash
+   (cd dashboard/mini && npm i && npm run dev)
+   # repérez l'URL, par ex. http://localhost:5173
+   ```
+2. Exécuter les tests :
+   ```bash
+   PREVIEW_URL=http://localhost:5173 make ui-feedbacks-e2e
+   ```
+   Le test est ignoré si `PREVIEW_URL` n'est pas défini.
 
 ## Scénario E2E (API + UI)
 
@@ -147,6 +167,8 @@ Les variables essentielles sont définies dans `.env` (voir [`.env.example`](.en
 - `DATABASE_URL` — URL de connexion asynchrone à la base.
 - `CORS_ORIGINS` — origines autorisées pour CORS.
 - `LLM_DEFAULT_PROVIDER` et `LLM_DEFAULT_MODEL` — fournisseur et modèle par défaut des agents.
+- `FEEDBACK_CRITICAL_THRESHOLD` — seuil (0-100) déclenchant un badge critique (défaut 60).
+- `FEEDBACK_REVIEW_TIMEOUT_MS` — délai d'attente de l'auto‑review en ms (défaut 3500).
 
 ### Presets dev / prod
 

--- a/api/fastapi_app/app.py
+++ b/api/fastapi_app/app.py
@@ -44,7 +44,10 @@ TAGS_METADATA = [
     {"name": "events", "description": "Lecture des événements/logs d'un run."},
     {"name": "tasks", "description": "Déclenchement d’un run ad-hoc et suivi de statut."},
     {"name": "agents", "description": "Gestion des agents, recrutement et matrice modèles."},
-    {"name": "feedbacks", "description": "Feedbacks auto-générés ou humains."},
+    {
+        "name": "feedbacks",
+        "description": "Gestion des feedbacks auto ou humains: création et listing par nœud ou run.",
+    },
 ]
 
 def _build_storage():

--- a/api/fastapi_app/routes/nodes.py
+++ b/api/fastapi_app/routes/nodes.py
@@ -93,7 +93,7 @@ async def list_nodes(
                     comment=f.comment,
                     metadata=f.meta,
                     created_at=to_tz(f.created_at, tz),
-                    updated_at=to_tz(f.updated_at, tz),
+                    updated_at=to_tz(getattr(f, "updated_at", None), tz),
                 )
             )
 

--- a/api/fastapi_app/schemas/feedbacks.py
+++ b/api/fastapi_app/schemas/feedbacks.py
@@ -12,13 +12,21 @@ class FeedbackCreate(BaseModel):
 
     run_id: UUID = Field(..., examples=["11111111-1111-1111-1111-111111111111"])
     node_id: UUID = Field(..., examples=["22222222-2222-2222-2222-222222222222"])
-    source: str = Field(..., examples=["auto", "human"])
+    source: str = Field(
+        ..., description="Origine du feedback (auto ou human)", examples=["auto", "human"]
+    )
     reviewer: Optional[str] = Field(
         default=None, examples=["reviewer-general"], description="Identité du reviewer"
     )
-    score: int = Field(ge=0, le=100, examples=[75])
-    comment: str = Field(..., examples=["Sortie invalide"])
-    metadata: Optional[Dict[str, Any]] = Field(default=None, examples=[{"foo": "bar"}])
+    score: int = Field(
+        ge=0, le=100, description="Score d'évaluation entre 0 et 100", examples=[75]
+    )
+    comment: str = Field(
+        ..., description="Commentaire du reviewer", examples=["Sortie invalide"]
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None, description="Méta-données additionnelles", examples=[{"foo": "bar"}]
+    )
 
 
 class FeedbackOut(FeedbackCreate):

--- a/api/fastapi_app/schemas_base.py
+++ b/api/fastapi_app/schemas_base.py
@@ -115,6 +115,7 @@ class RunOut(BaseModel):
     ended_at: Optional[datetime] = None
     meta: Optional[Dict[str, Any]] = None
     summary: Optional[RunSummaryOut] = None
+    dag: Optional['DagOut'] = None
 
 class NodeOut(BaseModel):
     id: UUID
@@ -128,6 +129,16 @@ class NodeOut(BaseModel):
     created_at: datetime
     updated_at: Optional[datetime] = None
     feedbacks: List[FeedbackOut] = Field(default_factory=list)
+
+class DagEdge(BaseModel):
+    source: UUID
+    target: UUID
+
+class DagOut(BaseModel):
+    nodes: List[NodeOut]
+    edges: List[DagEdge] = Field(default_factory=list)
+
+RunOut.model_rebuild()
 
 class ArtifactOut(BaseModel):
     id: UUID

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -139,7 +139,7 @@ export const listNodeArtifacts = async (
 
 // PATCH node actions (pause/resume/skip/override)
 export const patchNode = async (nodeId: string, body: Record<string, unknown>, opts: FetchOpts = {}) => {
-  const { requestId } = await fetchJson<unknown>(`/nodes/${nodeId}`, { ...opts, method: 'PATCH', body });
+  const { requestId } = await fetchJson<unknown>(`/nodes/${nodeId}`, { ...opts, method: 'PATCH', body, role: 'editor' });
   return { requestId };
 };
 

--- a/dashboard/mini/src/api/feedbacks.ts
+++ b/dashboard/mini/src/api/feedbacks.ts
@@ -1,0 +1,34 @@
+import { fetchJson, postJson, FetchOpts } from './http';
+import { Feedback, Page } from './types';
+
+export const listFeedbacks = async (
+  params: { run_id?: string; node_id?: string },
+  opts: FetchOpts = {},
+): Promise<Page<Feedback>> => {
+  const query: Record<string, string | undefined> = {
+    run_id: params.run_id,
+    node_id: params.node_id,
+  };
+  const { data, headers } = await fetchJson<{ items: Feedback[] }>('/feedbacks', {
+    ...opts,
+    query,
+  });
+  const totalHeader = headers.get('X-Total-Count');
+  const total = totalHeader ? Number(totalHeader) : undefined;
+  return {
+    items: data.items,
+    meta: { total },
+  };
+};
+
+export const createFeedback = async (
+  payload: Omit<Feedback, 'id' | 'created_at' | 'updated_at'>,
+  opts: FetchOpts = {},
+): Promise<Feedback> => {
+  const { data } = await postJson<Feedback, typeof payload>(
+    '/feedbacks',
+    payload,
+    { ...opts, role: 'editor' },
+  );
+  return data;
+};

--- a/dashboard/mini/src/api/http.ts
+++ b/dashboard/mini/src/api/http.ts
@@ -20,6 +20,7 @@ export interface FetchOpts {
   signal?: AbortSignal;
   method?: string;     // string pour autoriser PATCH
   body?: unknown;
+  role?: 'viewer' | 'editor' | 'admin';
 }
 
 export async function fetchJson<T>(
@@ -34,9 +35,12 @@ export async function fetchJson<T>(
   }
 
   const requestId = uuidv4();
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {
+    'X-Request-ID': requestId,
+  };
   const apiKey = getCurrentApiKey();
   if (apiKey) headers['X-API-Key'] = apiKey;
+  if (opts.role) headers['X-Role'] = opts.role;
   if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
 
   const timeoutCtrl = new AbortController();
@@ -100,9 +104,13 @@ export async function postJson<T, B = unknown>(
   }
 
   const requestId = uuidv4();
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'X-Request-ID': requestId,
+  };
   const apiKey = getCurrentApiKey();
   if (apiKey) headers['X-API-Key'] = apiKey;
+  if (opts.role) headers['X-Role'] = opts.role;
 
   const timeoutCtrl = new AbortController();
   const timeoutId = setTimeout(() => timeoutCtrl.abort(), API_TIMEOUT_MS);

--- a/dashboard/mini/src/api/types.ts
+++ b/dashboard/mini/src/api/types.ts
@@ -43,11 +43,23 @@ export interface RunSummary {
 export interface RunDetail extends Run {
   summary?: RunSummary;
   dag?: {
-    nodes: Array<{ id: string; label?: string; role?: string; status: Status }>;
+    nodes: Array<{ id: string; label?: string; role?: string; status: Status; feedbacks?: Feedback[] }>;
     edges: Array<{ from: string; to: string }>;
   };
 }
 
+export interface Feedback {
+  id: string;
+  run_id: string;
+  node_id: string;
+  source: 'auto' | 'human';
+  reviewer?: string;
+  score: number;
+  comment: string;
+  metadata?: Record<string, unknown>;
+  created_at: string;
+  updated_at?: string;
+}
 export interface NodeItem {
   id: string;
   role?: string;
@@ -56,6 +68,7 @@ export interface NodeItem {
   ended_at?: string;
   duration_ms?: number;
   checksum?: string;
+  feedbacks?: Feedback[];
 }
 
 export interface EventItem {

--- a/dashboard/mini/src/components/DagView.tsx
+++ b/dashboard/mini/src/components/DagView.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType, JSX } from 'react';
 import { useEffect, useState } from 'react';
+import FeedbackBadge from './FeedbackBadge';
 import type { RunDetail } from '../api/types';
 
 interface DagViewProps {
@@ -31,7 +32,14 @@ const DagView = ({ dag, onSelectNode, selectedNodeId }: DagViewProps): JSX.Eleme
     const nodes = dag.nodes.map((n, idx) => ({
       id: n.id,
       position: { x: idx * 200, y: 0 },
-      data: { label: `${n.role ?? n.id} (${n.status})` },
+      data: {
+        label: (
+          <span>
+            {n.role ?? n.id} ({n.status})
+            <FeedbackBadge feedbacks={n.feedbacks} />
+          </span>
+        ),
+      },
     }));
     const edges = dag.edges.map((e) => ({
       id: `${e.from}-${e.to}`,
@@ -126,6 +134,9 @@ const DagView = ({ dag, onSelectNode, selectedNodeId }: DagViewProps): JSX.Eleme
           >
             {n.status}
           </text>
+          <foreignObject x="62" y="-8" width="20" height="20">
+            <FeedbackBadge feedbacks={n.feedbacks} />
+          </foreignObject>
         </g>
       ))}
     </svg>

--- a/dashboard/mini/src/components/FeedbackBadge.tsx
+++ b/dashboard/mini/src/components/FeedbackBadge.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from 'react';
+import type { Feedback } from '../api/types';
+import { FEEDBACK_CRITICAL_THRESHOLD } from '../config/env';
+
+interface Props {
+  feedbacks?: Feedback[];
+}
+
+const FeedbackBadge = ({ feedbacks }: Props): JSX.Element | null => {
+  if (!feedbacks || feedbacks.length === 0) return null;
+  const sorted = [...feedbacks].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+  const critical = sorted.find((f) => f.score < FEEDBACK_CRITICAL_THRESHOLD);
+  const latest = sorted[0];
+  const color = critical ? 'red' : '#ccc';
+  const title = critical ? critical.comment : latest?.comment;
+  return (
+    <span
+      data-testid="feedback-badge"
+      title={title}
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: color,
+        marginLeft: 4,
+      }}
+    />
+  );
+};
+
+export default FeedbackBadge;

--- a/dashboard/mini/src/components/FeedbackPanel.tsx
+++ b/dashboard/mini/src/components/FeedbackPanel.tsx
@@ -1,0 +1,118 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { listFeedbacks, createFeedback } from '../api/feedbacks';
+import { patchNode } from '../api/client';
+import type { Feedback } from '../api/types';
+import { ApiError } from '../api/http';
+
+interface Props {
+  runId: string;
+  nodeId: string;
+}
+
+const FeedbackPanel = ({ runId, nodeId }: Props): JSX.Element => {
+  const [filter, setFilter] = useState<'all' | 'auto' | 'human'>('all');
+  const [score, setScore] = useState('');
+  const [comment, setComment] = useState('');
+  const [reviewer, setReviewer] = useState('');
+  const [requestId, setRequestId] = useState<string | undefined>();
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ['feedbacks', runId, nodeId],
+    queryFn: ({ signal }) => listFeedbacks({ run_id: runId, node_id: nodeId }, { signal }),
+  });
+
+  const mutation = useMutation({
+    mutationFn: (payload: Omit<Feedback, 'id' | 'created_at' | 'updated_at'>) =>
+      createFeedback(payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['feedbacks', runId, nodeId] });
+      setScore('');
+      setComment('');
+      setReviewer('');
+    },
+  });
+
+  const doAction = async (body: Record<string, unknown>) => {
+    if (!window.confirm('Confirmer ?')) return;
+    try {
+      const { requestId } = await patchNode(nodeId, body);
+      setRequestId(requestId);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        alert(`Erreur ${err.status}`);
+        setRequestId(err.requestId);
+      } else if (err instanceof Error) {
+        alert(err.message);
+      }
+    }
+  };
+
+  const items =
+    query.data?.items.filter(
+      (f) => filter === 'all' || f.source === filter,
+    ) ?? [];
+
+  const onSubmit = () => {
+    mutation.mutate({
+      run_id: runId,
+      node_id: nodeId,
+      source: 'human',
+      reviewer: reviewer || undefined,
+      score: Number(score),
+      comment,
+    });
+  };
+
+  return (
+    <aside style={{ borderLeft: '1px solid #ccc', padding: 16, width: 320 }} data-testid="feedback-panel">
+      <h4>Feedbacks</h4>
+      <div>
+        <button onClick={() => setFilter('all')} aria-pressed={filter === 'all'}>Tous</button>
+        <button onClick={() => setFilter('auto')} aria-pressed={filter === 'auto'}>Auto</button>
+        <button onClick={() => setFilter('human')} aria-pressed={filter === 'human'}>Humain</button>
+      </div>
+      <ul>
+        {items.map((f) => (
+          <li key={f.id}>
+            <span>{new Date(f.created_at).toLocaleString()} — </span>
+            <span>{f.source}</span> — <strong>{f.score}</strong> — {f.comment}
+            {f.reviewer && <em> ({f.reviewer})</em>}
+          </li>
+        ))}
+        {items.length === 0 && <li>Aucun feedback</li>}
+      </ul>
+      <div>
+        <h5>Ajouter un feedback</h5>
+        <input
+          placeholder="reviewer"
+          value={reviewer}
+          onChange={(e) => setReviewer(e.target.value)}
+        />
+        <input
+          placeholder="score"
+          type="number"
+          value={score}
+          onChange={(e) => setScore(e.target.value)}
+        />
+        <textarea
+          placeholder="commentaire"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+        />
+        <button onClick={onSubmit} disabled={mutation.isLoading}>Envoyer</button>
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <button onClick={() => void doAction({ action: 'resume' })}>Re-run guidé</button>
+        <button onClick={() => void doAction({ action: 'override' })}>Override</button>
+        <button onClick={() => void doAction({ action: 'pause' })}>Pause</button>
+        <button onClick={() => void doAction({ action: 'resume' })}>Resume</button>
+      </div>
+      {requestId && <p>Request ID: {requestId}</p>}
+    </aside>
+  );
+};
+
+export default FeedbackPanel;

--- a/dashboard/mini/src/components/NodesTable.tsx
+++ b/dashboard/mini/src/components/NodesTable.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 import { useRunNodes } from '../api/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { ApiError } from '../api/http';
+import FeedbackBadge from './FeedbackBadge';
 
 export type NodesTableProps = {
   runId: string;
@@ -144,6 +145,7 @@ const NodesTable = ({
                 <span className={`badge status-${node.status}`}>
                   {node.status}
                 </span>
+                <FeedbackBadge feedbacks={node.feedbacks} />
               </td>
               <td>{formatDate(node.started_at)}</td>
               <td>{formatDate(node.ended_at)}</td>

--- a/dashboard/mini/src/config/env.ts
+++ b/dashboard/mini/src/config/env.ts
@@ -22,6 +22,10 @@ export const API_TIMEOUT_MS =
 export const DEMO_API_KEY =
   String(import.meta.env.VITE_DEMO_API_KEY ?? '').trim() || undefined;
 
+const rawFbThreshold = Number(import.meta.env.VITE_FEEDBACK_CRITICAL_THRESHOLD);
+export const FEEDBACK_CRITICAL_THRESHOLD =
+  Number.isFinite(rawFbThreshold) ? rawFbThreshold : 60;
+
 export default {
   getApiBaseUrl,
   setApiBaseUrl,

--- a/dashboard/mini/src/pages/RunDetailPage.tsx
+++ b/dashboard/mini/src/pages/RunDetailPage.tsx
@@ -10,6 +10,7 @@ import DagView from '../components/DagView';
 import NodesTable from '../components/NodesTable';
 import EventsTable from '../components/EventsTable';
 import ArtifactsList from '../components/ArtifactsList';
+import FeedbackPanel from '../components/FeedbackPanel';
 
 const RunDetailPage = (): JSX.Element => {
   const { apiKey, useEnvKey } = useApiKey();
@@ -119,12 +120,19 @@ const RunDetailPage = (): JSX.Element => {
         <RunSummary run={run} summary={summary} />
       )}
       {activeTab === 'dag' && run.dag && (
-        <section>
-          <DagView dag={run.dag} />
+        <section style={{ display: 'flex' }}>
+          <DagView
+            dag={run.dag}
+            onSelectNode={setSelectedNodeId}
+            selectedNodeId={selectedNodeId}
+          />
+          {selectedNodeId && (
+            <FeedbackPanel runId={run.id} nodeId={selectedNodeId} />
+          )}
         </section>
       )}
       {activeTab === 'nodes' && (
-        <section>
+        <section style={{ display: 'flex' }}>
           <NodesTable
             runId={run.id}
             page={nodesPage}
@@ -147,6 +155,9 @@ const RunDetailPage = (): JSX.Element => {
               setNodesPage(1);
             }}
           />
+          {selectedNodeId && (
+            <FeedbackPanel runId={run.id} nodeId={selectedNodeId} />
+          )}
         </section>
       )}
       {activeTab === 'events' && (

--- a/dashboard/mini/tests-e2e/feedback.spec.ts
+++ b/dashboard/mini/tests-e2e/feedback.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+
+const PREVIEW_URL = process.env.PREVIEW_URL;
+
+test('feedback panel & actions', async ({ page }) => {
+  test.skip(!PREVIEW_URL, 'PREVIEW_URL non défini');
+
+  const apiBase = 'https://mock.api';
+  const apiKey = 'test-key';
+  let feedbacks = [
+    {
+      id: 'f1',
+      run_id: 'run-1',
+      node_id: 'node-1',
+      source: 'auto',
+      reviewer: 'auto',
+      score: 55,
+      comment: 'auto bad',
+      created_at: new Date().toISOString(),
+    },
+  ];
+  let patchCalled = false;
+
+  await page.route(`${apiBase}/**`, async (route) => {
+    const req = route.request();
+    const url = req.url();
+    if (url.endsWith('/runs/run-1')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'run-1',
+          status: 'running',
+          dag: {
+            nodes: [
+              { id: 'node-1', status: 'running', role: 'agent', feedbacks },
+            ],
+            edges: [],
+          },
+        }),
+      });
+    } else if (url.includes('/runs/run-1/nodes')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'X-Total-Count': '1' },
+        body: JSON.stringify({
+          items: [
+            {
+              id: 'node-1',
+              status: 'running',
+              role: 'agent',
+              feedbacks,
+            },
+          ],
+        }),
+      });
+    } else if (url.includes('/feedbacks') && req.method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'X-Total-Count': String(feedbacks.length) },
+        body: JSON.stringify({ items: feedbacks }),
+      });
+    } else if (url.includes('/feedbacks') && req.method() === 'POST') {
+      const body = JSON.parse(req.postData() || '{}');
+      const fb = {
+        id: `f${feedbacks.length + 1}`,
+        created_at: new Date().toISOString(),
+        ...body,
+      };
+      feedbacks.push(fb);
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(fb),
+      });
+    } else if (url.includes('/nodes/node-1') && req.method() === 'PATCH') {
+      patchCalled = true;
+      await route.fulfill({ status: 200, body: '{}' });
+    } else {
+      await route.fulfill({ status: 200, body: '{}' });
+    }
+  });
+
+  await page.goto(PREVIEW_URL!);
+  await page.getByTestId('apiUrlInput').fill(apiBase);
+  await page.getByRole('button', { name: 'Enregistrer' }).last().click();
+  await page.getByLabel('api-key').fill(apiKey);
+  await page.getByRole('button', { name: 'Enregistrer' }).first().click();
+
+  await page.goto(`${PREVIEW_URL}/runs/run-1`);
+  await page.getByRole('tab', { name: 'Nodes' }).click();
+  await page.getByTestId('node-row-node-1').click();
+  const panel = page.getByTestId('feedback-panel');
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('auto bad')).toBeVisible();
+
+  // Ajouter feedback humain
+  await panel.getByPlaceholder('score').fill('80');
+  await panel.getByPlaceholder('commentaire').fill('good');
+  await panel.getByRole('button', { name: 'Envoyer' }).click();
+  await expect(panel.getByText('good')).toBeVisible();
+
+  // Badge critique
+  const badge = page.getByTestId('node-row-node-1').getByTestId('feedback-badge');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+
+  // Re-run guidé
+  page.on('dialog', (d) => d.accept());
+  await panel.getByRole('button', { name: 'Re-run guidé' }).click();
+  await expect.poll(() => patchCalled).toBeTruthy();
+});


### PR DESCRIPTION
## Résumé
- documente et active les tests E2E Playwright
- enrichit l’API des feedbacks et expose les feedbacks dans le détail d’un run
- ajoute un panneau de feedbacks et un badge critique sur l’interface
- supprime l’image illustrative `feedback-panel.png`

## Tests
- `make test-feedbacks`
- `make ui-feedbacks-e2e` *(échec : navigateur Playwright manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68b7079871188327a9458f7d831711ef