### PR TITLE
fix: corrige types plan pour mini dashboard

### DIFF
--- a/dashboard/mini/src/api/hooks.ts
+++ b/dashboard/mini/src/api/hooks.ts
@@ -22,7 +22,6 @@ import {
   Status,
   Task,
   TaskDetail,
-  Plan,
 } from './types';
 
 export const useRuns = (

--- a/dashboard/mini/src/api/types.ts
+++ b/dashboard/mini/src/api/types.ts
@@ -96,11 +96,6 @@ export type TaskStatus =
   | 'completed'
   | 'failed';
 
-export interface Plan {
-  status: 'draft' | 'ready' | 'invalid';
-  errors?: string[];
-}
-
 export interface Task {
   id: string;
   title: string;
@@ -131,9 +126,10 @@ export interface Assignment {
 }
 
 export interface Plan {
-  id: string;
+  id?: string;
   status: 'draft' | 'ready' | 'invalid';
-  graph: {
+  errors?: string[];
+  graph?: {
     nodes: Array<{ id: string; role?: string }>;
     edges: Array<{ from: string; to: string }>;
   };


### PR DESCRIPTION
## Résumé
- Unifie l'interface `Plan` et supprime les doublons dans les types API
- Nettoie les imports inutilisés dans les hooks API

## Tests
- `make dash-mini-build` *(échoue : erreurs TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_68b72ae090cc83279489ac4a0c32a5e6