### PR TITLE
Corrige les erreurs TypeScript du dashboard

### DIFF
--- a/dashboard/mini/src/__tests__/PlanEditor.assign.test.tsx
+++ b/dashboard/mini/src/__tests__/PlanEditor.assign.test.tsx
@@ -26,11 +26,9 @@ describe('PlanEditor assignments', () => {
       graph: { nodes: [{ id: 'n1' }], edges: [] },
       assignments: [],
     };
-    const fetchMock = vi
-      .fn<[
-        RequestInfo,
-        RequestInit | undefined
-      ], Promise<Response>>((url, opts) => {
+    const fetchMock = vi.fn<
+      (url: RequestInfo, _opts?: RequestInit) => Promise<Response>
+    >((url) => {
         if (url.toString().endsWith('/plans/p1')) {
           return Promise.resolve(
             new Response(JSON.stringify(plan), {
@@ -82,11 +80,11 @@ describe('PlanEditor assignments', () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
 
-    const calls = fetchMock.mock.calls.filter((c) =>
-      c[0].toString().endsWith('/plans/p1/assignments'),
-    );
+    const calls = (
+      fetchMock.mock.calls as Array<[RequestInfo, RequestInit | undefined]>
+    ).filter(([url]) => url.toString().endsWith('/plans/p1/assignments'));
     expect(JSON.parse(calls[0][1]?.body as string)).toEqual({
-      assignments: [
+      items: [
         {
           node_id: 'n1',
           role: 'r1',
@@ -98,7 +96,7 @@ describe('PlanEditor assignments', () => {
       ],
     });
     expect(JSON.parse(calls[1][1]?.body as string)).toEqual({
-      assignments: [
+      items: [
         {
           node_id: 'n1',
           role: 'r1',
@@ -118,11 +116,9 @@ describe('PlanEditor assignments', () => {
       graph: { nodes: [{ id: 'n1' }], edges: [] },
       assignments: [],
     };
-    const fetchMock = vi
-      .fn<[
-        RequestInfo,
-        RequestInit | undefined
-      ], Promise<Response>>((url, opts) => {
+    const fetchMock = vi.fn<
+      (url: RequestInfo, _opts?: RequestInit) => Promise<Response>
+    >((url) => {
         if (url.toString().endsWith('/plans/p1')) {
           return Promise.resolve(
             new Response(JSON.stringify(plan), {

--- a/dashboard/mini/src/api/client.ts
+++ b/dashboard/mini/src/api/client.ts
@@ -47,7 +47,7 @@ export const listRuns = async (
   const offset = (params.page - 1) * limit;
   const query: Record<string,string|number|boolean|undefined> = {
     limit, offset,
-    status: mapUiStatusesToApi(params.status).join('') || undefined,
+    status: mapUiStatusesToApi(params.status).join(',') || undefined,
     started_from: params.dateFrom,
     started_to: params.dateTo,
     title_contains: params.title,

--- a/dashboard/mini/src/components/FeedbackPanel.tsx
+++ b/dashboard/mini/src/components/FeedbackPanel.tsx
@@ -102,7 +102,7 @@ const FeedbackPanel = ({ runId, nodeId }: Props): JSX.Element => {
           value={comment}
           onChange={(e) => setComment(e.target.value)}
         />
-        <button onClick={onSubmit} disabled={mutation.isLoading}>Envoyer</button>
+        <button onClick={onSubmit} disabled={mutation.isPending}>Envoyer</button>
       </div>
       <div style={{ marginTop: 8 }}>
         <button onClick={() => void doAction({ action: 'resume' })}>Re-run guidé</button>

--- a/dashboard/mini/src/components/PlanGraph.tsx
+++ b/dashboard/mini/src/components/PlanGraph.tsx
@@ -43,7 +43,11 @@ const PlanGraph = ({ graph, selected, onSelect }: PlanGraphProps) => {
     }));
     return (
       <div style={{ width: '100%', height: 200 }} data-testid="plan-reactflow">
-        <ReactFlow nodes={nodes} edges={edges} onNodeClick={(_, node) => onSelect?.(node.id)} />
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodeClick={(_: unknown, node: { id: string }) => onSelect?.(node.id)}
+        />
       </div>
     );
   }

--- a/dashboard/mini/src/components/ToastProvider.tsx
+++ b/dashboard/mini/src/components/ToastProvider.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  type ReactNode,
+  type JSX,
+} from 'react';
 
 interface Toast {
   id: number;

--- a/dashboard/mini/src/pages/PlanEditor.tsx
+++ b/dashboard/mini/src/pages/PlanEditor.tsx
@@ -46,7 +46,7 @@ const PlanEditor = () => {
       const newMap = { ...assignments, [a.node_id]: a };
       setAssignments(newMap);
       setSuccess('Assignation sauvegardée');
-      if (plan && plan.graph.nodes.every((n) => newMap[n.id])) {
+      if (plan?.graph?.nodes.every((n) => newMap[n.id])) {
         await setPlanStatus(id, 'ready');
         setPlan({ ...plan, status: 'ready' });
       }

--- a/dashboard/mini/src/pages/RunDetail.tsx
+++ b/dashboard/mini/src/pages/RunDetail.tsx
@@ -39,7 +39,7 @@ const RunDetail = (): JSX.Element => {
   const { apiKey, useEnvKey } = useApiKey();
   const hasKey = Boolean(apiKey) || useEnvKey;
   const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>();
-  type DagNode = RunType['dag'] extends { nodes: (infer N)[] } ? N : never;
+  type DagNode = NonNullable<RunType['dag']>['nodes'][number];
   const [selectedNode, setSelectedNode] = useState<DagNode | undefined>();
   const [lastRequestId, setLastRequestId] = useState<string | undefined>();
   const runQuery = useQuery({

--- a/dashboard/mini/src/pages/TaskDetail.tsx
+++ b/dashboard/mini/src/pages/TaskDetail.tsx
@@ -80,7 +80,7 @@ const TaskDetailPage = (): JSX.Element => {
           )}
         </div>
       )}
-      <button onClick={generate} disabled={genMutation.isLoading}>
+      <button onClick={generate} disabled={genMutation.isPending}>
         Générer le plan
       </button>
     </div>


### PR DESCRIPTION
## Résumé
- Corrige les mocks de `fetch` dans les tests et s'assure que le corps de requête utilise `items`
- Remplace les indicateurs `isLoading` obsolètes par `isPending` et ajoute les types manquants
- Fixe la construction des paramètres `status` pour `listRuns`

## Tests
- `npm --prefix dashboard/mini run build`
- `npm --prefix dashboard/mini test` *(échoue : Playwright lance les tests E2E et épuise la mémoire)*
- `npm --prefix dashboard/mini test src/__tests__/PlanEditor.assign.test.tsx src/__tests__/api/client.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b72ed2ca7c832791bec78534c453d8