### PR TITLE
feat: ajouter commandes cockpit dans Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,3 +328,22 @@ db-reset:
 	else \
 		echo "ℹ️  ALEMBIC_DATABASE_URL non défini — migration skip"; \
 	fi
+
+# ---- Cockpit (Next.js) ---------------------------------------
+.PHONY: cockpit cockpit-install cockpit-build cockpit-test
+
+# Lancer le serveur de dev Next.js
+cockpit:
+	@cd apps/cockpit && npm run dev
+
+# Installer les dépendances
+cockpit-install:
+	@cd apps/cockpit && npm install
+
+# Build de production
+cockpit-build:
+	@cd apps/cockpit && npm run build
+
+# Tests côté cockpit (Vitest)
+cockpit-test:
+	@cd apps/cockpit && npm test


### PR DESCRIPTION
## Résumé
- ajouter des cibles Makefile pour la gestion du cockpit Next.js

## Tests
- `make test` *(échoué : 3 failed, 153 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b73a79412c83279ae0bef6acc4316f