### PR TITLE
fix: autorise origines dev pour cockpit

### DIFF
--- a/apps/cockpit/next.config.ts
+++ b/apps/cockpit/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    // Autorise l'accès dev depuis l'IP locale et localhost
+    allowedDevOrigins: [
+      "http://192.168.1.50:3000",
+      "http://localhost:3000",
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Résumé
- autorise l'accès dev au cockpit depuis l'IP locale et localhost

## Test
- `SENTRY_DSN="" make test` (échoue: connexion refusée vers /api/1/envelope/)


------
https://chatgpt.com/codex/tasks/task_e_68b73cda19fc8327aaf717bae165efe8