### PR TITLE
feat: add ThemeToggle to fix theme mismatch

### DIFF
--- a/apps/cockpit/src/components/shell/Header.tsx
+++ b/apps/cockpit/src/components/shell/Header.tsx
@@ -1,14 +1,10 @@
 "use client";
 import { Input } from "@/components/ds/Input";
-import { Button } from "@/components/ds/Button";
-import { Sun, Moon, Bell } from "lucide-react";
-import { useTheme } from "next-themes";
+import { Bell } from "lucide-react";
 import { CommandPalette } from "./CommandPalette";
+import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
-  const { theme, setTheme } = useTheme();
-  const toggleTheme = () => setTheme(theme === "dark" ? "light" : "dark");
-
   return (
     <header
       className="flex items-center justify-between px-4 py-2 border-b"
@@ -27,17 +23,7 @@ export function Header() {
           <Bell className="h-5 w-5" />
           <span className="absolute top-1 right-1 inline-flex h-2 w-2 rounded-full bg-red-500" />
         </button>
-        <Button
-          aria-label="Changer de thème"
-          onClick={toggleTheme}
-          className="p-2 h-8 w-8 flex items-center justify-center"
-        >
-          {theme === "dark" ? (
-            <Sun className="h-4 w-4" />
-          ) : (
-            <Moon className="h-4 w-4" />
-          )}
-        </Button>
+        <ThemeToggle />
         <CommandPalette />
       </div>
     </header>

--- a/apps/cockpit/src/components/shell/ThemeToggle.tsx
+++ b/apps/cockpit/src/components/shell/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ds/Button";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <Button
+      aria-label="Changer de thème"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      className="p-2 h-8 w-8 flex items-center justify-center"
+    >
+      {mounted && (resolvedTheme === "dark" ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      ))}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add ThemeToggle component using next-themes resolvedTheme
- use ThemeToggle in Header to avoid hydration mismatch

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b754e34d448327b64f10bf29cc4a59