### PR TITLE
chore: configure ThemeProvider for next-themes

### DIFF
--- a/apps/cockpit/src/components/ThemeProvider.tsx
+++ b/apps/cockpit/src/components/ThemeProvider.tsx
@@ -6,9 +6,10 @@ import { ThemeProviderProps } from "next-themes/dist/types";
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
     <NextThemesProvider
-      attribute="data-theme"
+      attribute="class"
       defaultTheme="system"
       enableSystem
+      disableTransitionOnChange
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- configure ThemeProvider to use class attribute and disable transition on theme change

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68b754e79d5c832793388263e1b34e7d