### PR TITLE
feat: ajoute composant KpiCard

### DIFF
--- a/dashboard/mini/package-lock.json
+++ b/dashboard/mini/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
+        "framer-motion": "^11.1.2",
+        "lucide-react": "^0.542.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
@@ -4159,6 +4161,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5328,6 +5357,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -5469,6 +5507,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -7094,6 +7147,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/dashboard/mini/package.json
+++ b/dashboard/mini/package.json
@@ -22,7 +22,9 @@
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
     "uuid": "^9.0.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "framer-motion": "^11.1.2",
+    "lucide-react": "^0.542.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/dashboard/mini/src/components/kpi/KpiCard.tsx
+++ b/dashboard/mini/src/components/kpi/KpiCard.tsx
@@ -1,0 +1,48 @@
+import type { JSX } from 'react';
+import { ArrowDown, ArrowUp, type LucideIcon } from 'lucide-react';
+import { motion, useReducedMotion } from 'framer-motion';
+
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  delta: number;
+  icon: LucideIcon;
+  className?: string;
+}
+
+export function KpiCard({
+  title,
+  value,
+  delta,
+  icon: Icon,
+  className = '',
+}: KpiCardProps): JSX.Element {
+  const reduceMotion = useReducedMotion();
+  const deltaPositive = delta >= 0;
+  const DeltaIcon = deltaPositive ? ArrowUp : ArrowDown;
+  const deltaColor = deltaPositive ? 'text-green-600' : 'text-red-600';
+
+  return (
+    <motion.div
+      role="group"
+      tabIndex={0}
+      aria-label={`${title} ${value} (${deltaPositive ? 'augmentation' : 'diminution'} ${Math.abs(delta)}%)`}
+      initial={reduceMotion ? false : { opacity: 0, scale: 0.95 }}
+      animate={reduceMotion ? {} : { opacity: 1, scale: 1 }}
+      whileHover={reduceMotion ? {} : { scale: 1.03 }}
+      className={`rounded-lg border border-white/20 bg-white/60 p-4 shadow-sm backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neutral-500 dark:border-slate-700 dark:bg-slate-800/60 ${className}`.trim()}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-neutral-600 dark:text-neutral-300">{title}</span>
+        <Icon aria-hidden className="h-5 w-5 text-neutral-500" />
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+        {value}
+      </div>
+      <div className={`mt-1 flex items-center text-sm ${deltaColor}`}>
+        <DeltaIcon aria-hidden className="mr-1 h-3 w-3" />
+        <span>{Math.abs(delta)}%</span>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Résumé
- ajout du composant `KpiCard` animé et accessible
- intégration de `framer-motion` et `lucide-react`

## Tests
- `npm test` *(échoue : Playwright invoqué et dépassement mémoire)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b75779e8748327ab083d4b68197ca4