### PR TITLE
feat(cockpit): tableau de bord avec requêtes parallèles

### DIFF
--- a/apps/cockpit/src/app/dashboard/page.tsx
+++ b/apps/cockpit/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { Activity, ThumbsUp, Timer } from "lucide-react";
 import { KpiCard } from "@/components/kpi/KpiCard";
 import { ThroughputChart } from "@/components/charts/ThroughputChart";
@@ -12,19 +12,21 @@ import { useToast } from "@/components/ds/Toast";
 export default function DashboardPage() {
   const toast = useToast();
 
-  const throughput = useQuery({
-    queryKey: ["throughput"],
-    queryFn: () => fetch("/api/agents").then((r) => r.json()),
-  });
-
-  const latency = useQuery({
-    queryKey: ["latency"],
-    queryFn: () => fetch("/api/runs").then((r) => r.json()),
-  });
-
-  const feedback = useQuery({
-    queryKey: ["feedback"],
-    queryFn: () => fetch("/api/feedbacks").then((r) => r.json()),
+  const [throughput, latency, feedback] = useQueries({
+    queries: [
+      {
+        queryKey: ["throughput"],
+        queryFn: () => fetch("/api/agents").then((r) => r.json()),
+      },
+      {
+        queryKey: ["latency"],
+        queryFn: () => fetch("/api/runs").then((r) => r.json()),
+      },
+      {
+        queryKey: ["feedback"],
+        queryFn: () => fetch("/api/feedbacks").then((r) => r.json()),
+      },
+    ],
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Résumé
- récupération parallèle des métriques via `useQueries`
- calcul des KPI et affichage des cartes
- rendu des graphiques avec gestion des erreurs et chargement

## Tests
- `npm test`
- `npm run lint` *(échoue: 7 erreurs `@typescript-eslint/no-explicit-any` et `no-empty-object-type`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7578b6dc88327be7b70137cc8b42f