### PR TITLE
feat: ajoute configuration Playwright et tests e2e

### DIFF
--- a/apps/cockpit/e2e/command-palette.spec.ts
+++ b/apps/cockpit/e2e/command-palette.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('naviguer via la palette de commandes', async ({ page }) => {
+  await page.goto('/');
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await page.keyboard.press(`${modifier}+K`);
+  await page.getByRole('textbox').fill('Runs');
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/runs/);
+});

--- a/apps/cockpit/e2e/runs-actions.spec.ts
+++ b/apps/cockpit/e2e/runs-actions.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('actions Pause puis Resume affichent des toasts', async ({ page }) => {
+  await page.goto('/runs');
+  await page.getByRole('button', { name: 'Pause' }).click();
+  await expect(page.getByText('Run paused')).toBeVisible();
+  await page.getByRole('button', { name: 'Resume' }).click();
+  await expect(page.getByText('Run resumed')).toBeVisible();
+});

--- a/apps/cockpit/e2e/theme-toggle.spec.ts
+++ b/apps/cockpit/e2e/theme-toggle.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('bascule du thème et persistance', async ({ page }) => {
+  await page.goto('/');
+  const toggle = page.getByTestId('theme-toggle');
+  await toggle.click();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  await page.reload();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+});

--- a/apps/cockpit/package-lock.json
+++ b/apps/cockpit/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.55.0",
         "@swc/jest": "^0.2.36",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.8.0",
@@ -2299,6 +2300,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -9992,6 +10009,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -9,21 +9,24 @@
     "lint": "eslint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:a11y": "jest -t accessibilité"
+    "test:a11y": "jest -t accessibilité",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
-    "cmdk": "^1.1.1",
-    "lucide-react": "^0.542.0",
-    "framer-motion": "^11.1.2",
     "@tanstack/react-query": "^5.62.7",
-    "recharts": "^2.13.0",
+    "cmdk": "^1.1.1",
+    "framer-motion": "^11.1.2",
+    "lucide-react": "^0.542.0",
     "next": "15.5.2",
     "next-themes": "^0.4.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "recharts": "^2.13.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.55.0",
+    "@swc/jest": "^0.2.36",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
@@ -38,7 +41,6 @@
     "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^30.1.2",
     "tailwindcss": "^4",
-    "@swc/jest": "^0.2.36",
     "typescript": "^5"
   }
 }

--- a/apps/cockpit/playwright.config.ts
+++ b/apps/cockpit/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
## Résumé
- configure Playwright pour Cockpit
- ajoute tests e2e pour bascule de thème, palette de commande et actions sur les runs

## Tests
- `npx playwright test` *(échec: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b757b2723c8327b946809dde458f7b