### PR TITLE
Ajout du workflow CI pour Cockpit

### DIFF
--- a/.github/workflows/cockpit-ci.yml
+++ b/.github/workflows/cockpit-ci.yml
@@ -1,0 +1,81 @@
+name: Cockpit CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - run: npm ci
+        working-directory: apps/cockpit
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: install
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - run: npm ci
+        working-directory: apps/cockpit
+      - run: npm run lint
+        working-directory: apps/cockpit
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eslint-report-${{ matrix.node }}
+          path: apps/cockpit/reports/lint
+
+  unit:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - run: npm ci
+        working-directory: apps/cockpit
+      - run: npm test
+        working-directory: apps/cockpit
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jest-report-${{ matrix.node }}
+          path: apps/cockpit/reports/jest
+
+  build:
+    runs-on: ubuntu-latest
+    needs: unit
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - run: npm ci
+        working-directory: apps/cockpit
+      - run: npm run build
+        working-directory: apps/cockpit


### PR DESCRIPTION
## Résumé
- Ajout d'un workflow GitHub Actions `cockpit-ci.yml` avec jobs d'installation, lint, tests unitaires et build
- Exécution sur Node.js 20 et 22 avec cache npm
- Téléversement des rapports de lint et Jest en cas d'échec

## Tests
- `npm test` (réussi)
- `npm run lint` (échoué : typescript-eslint)
- `npm run build` (échoué : fonts Google)

------
https://chatgpt.com/codex/tasks/task_e_68b757b7ca7883278a5575b73363025d