### PR TITLE
feat: clients API typés et hooks pour agents et runs

### DIFF
--- a/dashboard/mini/src/components/RunsTimeline.tsx
+++ b/dashboard/mini/src/components/RunsTimeline.tsx
@@ -1,0 +1,32 @@
+import type { JSX } from 'react';
+import { useRuns, useFeedbacks, useRunAction } from '../lib/hooks';
+
+const RunsTimeline = (): JSX.Element => {
+  const runs = useRuns();
+  const feedbacks = useFeedbacks();
+  const runAction = useRunAction();
+
+  if (runs.isLoading) return <p>Chargement...</p>;
+  if (runs.isError) return <p>Erreur de chargement.</p>;
+
+  return (
+    <div>
+      <h2>Runs</h2>
+      <ul>
+        {runs.data?.map((r) => (
+          <li key={r.id}>
+            {r.title ?? r.id} - {r.status}
+            <button
+              onClick={() => runAction.mutate({ id: r.id, action: 'pause' })}
+            >
+              Pause
+            </button>
+          </li>
+        ))}
+      </ul>
+      <p>Feedbacks: {feedbacks.data?.length ?? 0}</p>
+    </div>
+  );
+};
+
+export default RunsTimeline;

--- a/dashboard/mini/src/lib/api.ts
+++ b/dashboard/mini/src/lib/api.ts
@@ -1,0 +1,35 @@
+import { getJSON, postJSON } from './http';
+import {
+  AgentSchema,
+  Agent,
+  RunSchema,
+  Run,
+  FeedbackSchema,
+  Feedback,
+} from './models';
+
+export type RunAction = 'pause' | 'resume' | 'cancel' | 'retry';
+
+export async function fetchAgents(): Promise<Agent[]> {
+  const res = await getJSON<unknown>('/api/agents');
+  if (res.error || !res.data) throw res.error ?? new Error('No data');
+  return AgentSchema.array().parse(res.data);
+}
+
+export async function fetchRuns(): Promise<Run[]> {
+  const res = await getJSON<unknown>('/api/runs');
+  if (res.error || !res.data) throw res.error ?? new Error('No data');
+  return RunSchema.array().parse(res.data);
+}
+
+export async function fetchFeedbacks(): Promise<Feedback[]> {
+  const res = await getJSON<unknown>('/api/feedbacks');
+  if (res.error || !res.data) throw res.error ?? new Error('No data');
+  return FeedbackSchema.array().parse(res.data);
+}
+
+export async function runAction(id: string, action: RunAction): Promise<Run> {
+  const res = await postJSON<unknown>(`/api/runs/${id}/actions`, { action });
+  if (res.error || !res.data) throw res.error ?? new Error('No data');
+  return RunSchema.parse(res.data);
+}

--- a/dashboard/mini/src/lib/hooks.ts
+++ b/dashboard/mini/src/lib/hooks.ts
@@ -1,0 +1,53 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchAgents,
+  fetchRuns,
+  fetchFeedbacks,
+  runAction,
+  RunAction,
+} from './api';
+import { Agent, Run, Feedback } from './models';
+
+export const useAgents = () =>
+  useQuery<Agent[]>({ queryKey: ['agents'], queryFn: fetchAgents });
+
+export const useRuns = () =>
+  useQuery<Run[]>({ queryKey: ['runs'], queryFn: fetchRuns });
+
+export const useFeedbacks = () =>
+  useQuery<Feedback[]>({ queryKey: ['feedbacks'], queryFn: fetchFeedbacks });
+
+export const useRunAction = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, action }: { id: string; action: RunAction }) =>
+      runAction(id, action),
+    onMutate: async ({ id, action }) => {
+      await queryClient.cancelQueries({ queryKey: ['runs'] });
+      const prev = queryClient.getQueryData<Run[]>(['runs']);
+      if (prev) {
+        const nextStatus =
+          action === 'pause'
+            ? 'paused'
+            : action === 'resume' || action === 'retry'
+              ? 'running'
+              : action === 'cancel'
+                ? 'canceled'
+                : undefined;
+        if (nextStatus) {
+          queryClient.setQueryData<Run[]>(
+            ['runs'],
+            prev.map((r) => (r.id === id ? { ...r, status: nextStatus } : r)),
+          );
+        }
+      }
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(['runs'], ctx.prev);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['runs'] });
+    },
+  });
+};

--- a/dashboard/mini/src/lib/models.ts
+++ b/dashboard/mini/src/lib/models.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export const AgentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export type Agent = z.infer<typeof AgentSchema>;
+
+export const RunSchema = z.object({
+  id: z.string(),
+  title: z.string().optional(),
+  status: z.enum([
+    'queued',
+    'running',
+    'succeeded',
+    'failed',
+    'canceled',
+    'partial',
+    'paused',
+  ]),
+  started_at: z.string().optional(),
+  ended_at: z.string().optional(),
+  counters: z
+    .object({
+      tokens_total: z.number().optional(),
+      nodes_total: z.number().optional(),
+      errors: z.number().optional(),
+    })
+    .optional(),
+});
+
+export type Run = z.infer<typeof RunSchema>;
+
+export const FeedbackSchema = z.object({
+  id: z.string(),
+  run_id: z.string(),
+  node_id: z.string(),
+  source: z.enum(['auto', 'human']),
+  reviewer: z.string().optional(),
+  score: z.number(),
+  comment: z.string(),
+  metadata: z.record(z.any()).optional(),
+  created_at: z.string(),
+  updated_at: z.string().optional(),
+});
+
+export type Feedback = z.infer<typeof FeedbackSchema>;

--- a/dashboard/mini/src/pages/Dashboard.tsx
+++ b/dashboard/mini/src/pages/Dashboard.tsx
@@ -1,0 +1,25 @@
+import type { JSX } from 'react';
+import { useAgents, useRuns } from '../lib/hooks';
+
+const Dashboard = (): JSX.Element => {
+  const agents = useAgents();
+  const runs = useRuns();
+
+  if (agents.isLoading || runs.isLoading) {
+    return <p>Chargement...</p>;
+  }
+
+  if (agents.isError || runs.isError) {
+    return <p>Erreur de chargement.</p>;
+  }
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>Agents: {agents.data?.length ?? 0}</p>
+      <p>Runs: {runs.data?.length ?? 0}</p>
+    </div>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
## Résumé
- ajoute schémas Zod pour Agent, Run et Feedback
- crée client API typé avec validation et mutation d'action de run
- fournit hooks React Query et exemples d'usage Dashboard/RunsTimeline

## Tests
- `npm test src/__tests__/api --run`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint src/lib/models.ts src/lib/api.ts src/lib/hooks.ts src/pages/Dashboard.tsx src/components/RunsTimeline.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b75798cfe8832797bf08980e639548