### PR TITLE
feat: résilience data fetching

### DIFF
--- a/apps/cockpit/package-lock.json
+++ b/apps/cockpit/package-lock.json
@@ -22,6 +22,7 @@
         "@eslint/eslintrc": "^3",
         "@swc/jest": "^0.2.36",
         "@tailwindcss/postcss": "^4",
+        "@tanstack/react-query-devtools": "^5.85.9",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^30.0.0",
@@ -3227,6 +3228,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.84.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.84.0.tgz",
+      "integrity": "sha512-fbF3n+z1rqhvd9EoGp5knHkv3p5B2Zml1yNRjh7sNXklngYI5RVIWUrUjZ1RIcEoscarUb0+bOvIs5x9dwzOXQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.85.9",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.9.tgz",
@@ -3240,6 +3252,24 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.85.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.85.9.tgz",
+      "integrity": "sha512-BAdhgwpzxkC1vdyCfiPbbC7FU/t/x6q2d9ZyhON/WykVUdznD69nlppuWpSIlIGipdRG7sF6tRZ6x3GtSq0EUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.84.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.85.9",
         "react": "^18 || ^19"
       }
     },

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -12,19 +12,21 @@
     "test:a11y": "jest -t accessibilité"
   },
   "dependencies": {
-    "cmdk": "^1.1.1",
-    "lucide-react": "^0.542.0",
-    "framer-motion": "^11.1.2",
     "@tanstack/react-query": "^5.62.7",
-    "recharts": "^2.13.0",
+    "cmdk": "^1.1.1",
+    "framer-motion": "^11.1.2",
+    "lucide-react": "^0.542.0",
     "next": "15.5.2",
     "next-themes": "^0.4.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "recharts": "^2.13.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@swc/jest": "^0.2.36",
     "@tailwindcss/postcss": "^4",
+    "@tanstack/react-query-devtools": "^5.85.9",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
@@ -38,7 +40,6 @@
     "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^30.1.2",
     "tailwindcss": "^4",
-    "@swc/jest": "^0.2.36",
     "typescript": "^5"
   }
 }

--- a/apps/cockpit/src/__tests__/dashboard.test.tsx
+++ b/apps/cockpit/src/__tests__/dashboard.test.tsx
@@ -8,35 +8,46 @@ expect.extend(toHaveNoViolations);
 
 describe("Dashboard", () => {
   beforeEach(() => {
-    global.fetch = jest.fn((url: string) => {
+    global.fetch = jest.fn((url: string): Promise<Response> => {
       if (url.includes("/api/agents")) {
-        return Promise.resolve({
-          json: () =>
-            Promise.resolve([
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
               { date: "1", value: 1 },
               { date: "2", value: 2 },
             ]),
-        }) as any;
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
       }
       if (url.includes("/api/runs")) {
-        return Promise.resolve({
-          json: () =>
-            Promise.resolve([
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
               { date: "1", p50: 1, p95: 2 },
               { date: "2", p50: 1, p95: 2 },
             ]),
-        }) as any;
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
       }
       if (url.includes("/api/feedbacks")) {
-        return Promise.resolve({
-          json: () =>
-            Promise.resolve([
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
               { date: "1", positive: 1, neutral: 1, negative: 1 },
               { date: "2", positive: 2, neutral: 1, negative: 1 },
             ]),
-        }) as any;
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
       }
-      return Promise.resolve({ json: () => Promise.resolve([]) }) as any;
+      return Promise.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
     });
   });
 

--- a/apps/cockpit/src/app/dashboard/page.tsx
+++ b/apps/cockpit/src/app/dashboard/page.tsx
@@ -8,13 +8,14 @@ import { LatencyChart } from "@/components/charts/LatencyChart";
 import { FeedbackChart } from "@/components/charts/FeedbackChart";
 import { Skeleton } from "@/components/ds/Skeleton";
 import { useToast } from "@/components/ds/Toast";
+import { fetchJson } from "@/lib/http";
 
 export default function DashboardPage() {
   const toast = useToast();
 
   const throughput = useQuery({
     queryKey: ["throughput"],
-    queryFn: () => fetch("/api/agents").then((r) => r.json()),
+    queryFn: ({ signal }) => fetchJson("/api/agents", { signal }),
   });
 
   const latency = useQuery({

--- a/apps/cockpit/src/components/Providers.tsx
+++ b/apps/cockpit/src/components/Providers.tsx
@@ -1,17 +1,33 @@
 "use client";
-import * as React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { queryClient, setQueryErrorNotifier } from "@/lib/queryClient";
 import { ThemeProvider } from "./ThemeProvider";
-import { ToastProvider } from "./ds/Toast";
+import { ToastProvider, useToast } from "./ds/Toast";
+
+function ToastBridge() {
+  const toast = useToast();
+  useEffect(() => {
+    setQueryErrorNotifier((msg) => toast(msg, "error"));
+  }, [toast]);
+  return null;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = React.useState(() => new QueryClient());
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <ToastProvider>{children}</ToastProvider>
+        <ToastProvider>
+          <ToastBridge />
+          {children}
+          {process.env.NODE_ENV === "development" && (
+            <ReactQueryDevtools initialIsOpen={false} />
+          )}
+        </ToastProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );
 }
 
+export default Providers;

--- a/apps/cockpit/src/components/QueryErrorBoundary.tsx
+++ b/apps/cockpit/src/components/QueryErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ReactNode } from 'react';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+
+class ErrorBoundary extends Component<{ onReset: () => void; children: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false });
+    this.props.onReset();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="p-4 border rounded">
+          <p>Une erreur est survenue.</p>
+          <button onClick={this.handleReset}>Réessayer</button>
+        </div>
+      );
+    }
+    return this.props.children as ReactNode;
+  }
+}
+
+export function QueryErrorBoundary({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => <ErrorBoundary onReset={reset}>{children}</ErrorBoundary>}
+    </QueryErrorResetBoundary>
+  );
+}
+
+export default QueryErrorBoundary;

--- a/apps/cockpit/src/lib/http.ts
+++ b/apps/cockpit/src/lib/http.ts
@@ -1,0 +1,38 @@
+export interface FetchOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export async function fetchJson<T>(
+  url: string,
+  { timeoutMs = 10_000, signal }: FetchOptions = {},
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      interface HttpError extends Error {
+        status?: number;
+      }
+      const err: HttpError = new Error(res.statusText || `HTTP ${res.status}`);
+      err.status = res.status;
+      throw err;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error('Invalid JSON');
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/cockpit/src/lib/queryClient.ts
+++ b/apps/cockpit/src/lib/queryClient.ts
@@ -1,0 +1,50 @@
+import { QueryClient, QueryCache, onlineManager } from '@tanstack/react-query';
+
+let notifyError: ((msg: string) => void) | null = null;
+export const setQueryErrorNotifier = (fn: (msg: string) => void): void => {
+  notifyError = fn;
+};
+
+if (typeof window !== 'undefined') {
+  onlineManager.setEventListener((setOnline) => {
+    const update = () => setOnline(navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  });
+  onlineManager.setOnline(navigator.onLine);
+}
+
+const retry = (failureCount: number, error: unknown): boolean => {
+  const err = error as { status?: number; response?: { status?: number } };
+  const status = err.status ?? err.response?.status;
+  if (status && status >= 400 && status < 500) return false;
+  return failureCount < 5;
+};
+
+const retryDelay = (attempt: number) => {
+  const base = Math.min(10_000, 500 * 2 ** attempt);
+  return base / 2 + Math.random() * (base / 2);
+};
+
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (err) => {
+      notifyError?.((err as Error).message);
+    },
+  }),
+  defaultOptions: {
+    queries: {
+      retry,
+      retryDelay,
+      staleTime: 30_000,
+      gcTime: 5 * 60 * 1000,
+      networkMode: 'online',
+    },
+  },
+});
+
+export default queryClient;


### PR DESCRIPTION
## Summary
- instancie un QueryClient centralisé avec retries exponentiels, détection offline et toast global
- ajoute un utilitaire `fetchJson` avec timeout/annulation et gestion d'erreurs JSON
- introduit `QueryErrorBoundary` et branchement du toast via les Providers
- utilise `fetchJson` pour la requête de débit

## Testing
- `npm test`
- `npm run lint` *(échoue: Unexpected any / empty interfaces)*

------
https://chatgpt.com/codex/tasks/task_e_68b7586ab9a08327ab07226903329efd