### PR TITLE
feat: ajout des design tokens et thèmes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 artifacts/
 *.md
 !README.md
+!docs/design-tokens.md
 
 # Caches / temporaires Python
 __pycache__/

--- a/apps/cockpit/src/app/globals.css
+++ b/apps/cockpit/src/app/globals.css
@@ -1,52 +1,145 @@
 @import "tailwindcss";
 
 :root {
-  --color-background: 0 0% 100%;
-  --color-foreground: 240 10% 3.9%;
-  --color-muted: 240 4.8% 95.9%;
-  --color-muted-foreground: 240 3.8% 46.1%;
-  --color-primary: 262 83% 58%;
-  --color-primary-foreground: 0 0% 100%;
+  color-scheme: light;
+  /* Couleurs */
+  --bg: 0 0% 100%;
+  --fg: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --primary: 262 83% 58%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 10% 3.9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --ring: 262 83% 58%;
+  --ring-foreground: 0 0% 100%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+
+  /* Surfaces */
+  --elev-0: 1;
+  --elev-1: 0.9;
+  --elev-2: 0.75;
+  --elev-3: 0.6;
+  --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.05);
+  --shadow-md: 0 4px 6px hsl(0 0% 0% / 0.1);
+  --shadow-lg: 0 10px 15px hsl(0 0% 0% / 0.15);
   --radius-sm: 0.125rem;
   --radius-md: 0.375rem;
   --radius-lg: 0.5rem;
-  --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.05);
-  --shadow-md: 0 4px 6px hsl(0 0% 0% / 0.1);
+  --radius-2xl: 1rem;
+
+  /* Typographie */
+  --font-sans: var(--font-geist-sans, system-ui, sans-serif);
+  --font-mono: var(--font-geist-mono, monospace);
+  --scale-1: 0.875rem;
+  --scale-2: 1rem;
+  --scale-3: 1.25rem;
+  --scale-4: 1.5rem;
+
+  /* Motion */
   --duration-fast: 150ms;
   --duration-normal: 300ms;
-  --easing-default: cubic-bezier(0.4, 0, 0.2, 1);
+  --duration-slow: 500ms;
+  --easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --easing-emph: cubic-bezier(0.2, 0, 0, 1);
+
+  /* États d’accessibilité */
+  --focus-ring: 210 100% 50%;
+  --focus-width: 2px;
+  --outline-offset: 2px;
 }
 
 [data-theme="dark"] {
-  --color-background: 240 10% 3.9%;
-  --color-foreground: 0 0% 98%;
-  --color-muted: 240 3.7% 15.9%;
-  --color-muted-foreground: 240 5% 64.9%;
-  --color-primary: 262 83% 58%;
-  --color-primary-foreground: 0 0% 100%;
+  color-scheme: dark;
+  --bg: 240 10% 3.9%;
+  --fg: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --primary: 262 83% 58%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 240 5% 64.9%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --ring: 262 83% 58%;
+  --ring-foreground: 0 0% 100%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --bg: 240 10% 3.9%;
+    --fg: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --primary: 262 83% 58%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 240 5% 64.9%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
+    --ring: 262 83% 58%;
+    --ring-foreground: 0 0% 100%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --duration-fast: 0ms;
+    --duration-normal: 0ms;
+    --duration-slow: 0ms;
+    --easing-standard: linear;
+    --easing-emph: linear;
+  }
 }
 
 @theme inline {
-  --color-background: hsl(var(--color-background));
-  --color-foreground: hsl(var(--color-foreground));
-  --color-muted: hsl(var(--color-muted));
-  --color-muted-foreground: hsl(var(--color-muted-foreground));
-  --color-primary: hsl(var(--color-primary));
-  --color-primary-foreground: hsl(var(--color-primary-foreground));
+  --color-background: hsl(var(--bg));
+  --color-foreground: hsl(var(--fg));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-ring: hsl(var(--ring));
+  --color-ring-foreground: hsl(var(--ring-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-border: hsl(var(--muted));
+  --color-focus: hsl(var(--focus-ring));
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);
   --radius-lg: var(--radius-lg);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --radius-2xl: var(--radius-2xl);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-size-1: var(--scale-1);
+  --font-size-2: var(--scale-2);
+  --font-size-3: var(--scale-3);
+  --font-size-4: var(--scale-4);
 }
 
 body {
-  background: hsl(var(--color-background));
-  color: hsl(var(--color-foreground));
-  font-family: var(--font-geist-sans, Arial, sans-serif);
+  background: hsl(var(--bg));
+  color: hsl(var(--fg));
+  font-family: var(--font-sans);
 }
 
 :focus-visible {
-  outline: 2px solid hsl(var(--color-primary));
-  outline-offset: 2px;
+  outline: var(--focus-width) solid hsl(var(--focus-ring));
+  outline-offset: var(--outline-offset);
 }
+

--- a/apps/cockpit/src/components/ds/Button.tsx
+++ b/apps/cockpit/src/components/ds/Button.tsx
@@ -2,15 +2,14 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, ...props }, ref) => (
     <button
       ref={ref}
       className={cn(
-        "px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring",
+        "px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm transition-colors duration-[var(--duration-fast)] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-focus",
         className
       )}
       {...props}

--- a/apps/cockpit/src/components/ds/Input.tsx
+++ b/apps/cockpit/src/components/ds/Input.tsx
@@ -2,15 +2,14 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => (
     <input
       ref={ref}
       className={cn(
-        "px-3 py-2 border rounded-md bg-background text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring",
+        "px-3 py-2 border rounded-md bg-background text-foreground transition-colors duration-[var(--duration-fast)] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-focus",
         className
       )}
       {...props}

--- a/apps/cockpit/src/components/ds/KpiCard.tsx
+++ b/apps/cockpit/src/components/ds/KpiCard.tsx
@@ -13,7 +13,7 @@ export function KpiCard({ title, value, className }: KpiCardProps) {
       role="group"
       aria-label={`KPI ${title}`}
       className={cn(
-        "rounded-md border p-4 shadow-sm bg-background text-foreground",
+        "rounded-lg border p-4 shadow-sm bg-card text-card-foreground",
         className
       )}
     >

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,36 @@
+# Design Tokens
+
+| Token | Rôle | Exemple d’usage |
+| --- | --- | --- |
+| `--bg` | Couleur de fond principale | `class="bg-background"` |
+| `--fg` | Couleur de texte par défaut | `class="text-foreground"` |
+| `--muted` | Fonds discrets et bordures | `class="bg-muted"` |
+| `--muted-foreground` | Texte sur surfaces `muted` | `class="text-muted-foreground"` |
+| `--primary` | Action principale | `class="bg-primary"` |
+| `--primary-foreground` | Texte sur `primary` | `class="text-primary-foreground"` |
+| `--secondary` | Action secondaire | `class="bg-secondary"` |
+| `--secondary-foreground` | Texte sur `secondary` | `class="text-secondary-foreground"` |
+| `--destructive` | États d’erreur | `class="bg-destructive"` |
+| `--destructive-foreground` | Texte sur `destructive` | `class="text-destructive-foreground"` |
+| `--ring` | Couleur d’anneau générique | `class="ring-ring"` |
+| `--ring-foreground` | Contenu dans l’anneau | `class="text-ring-foreground"` |
+| `--card` | Fond des cartes | `class="bg-card"` |
+| `--card-foreground` | Texte sur cartes | `class="text-card-foreground"` |
+| `--elev-0..3` | Opacité pour effets verre | `bg-[hsl(var(--bg)/var(--elev-2))]` |
+| `--shadow-sm/md/lg` | Ombres de profondeur | `class="shadow-sm"` |
+| `--radius-sm/md/lg/2xl` | Rayons de bordure | `class="rounded-lg"` |
+| `--font-sans` | Police par défaut | `class="font-sans"` |
+| `--font-mono` | Police monospace | `class="font-mono"` |
+| `--scale-1..4` | Échelles de taille de texte | `class="text-[var(--scale-2)]"` |
+| `--duration-fast/normal/slow` | Durées de transition | `class="duration-[var(--duration-fast)]"` |
+| `--easing-standard/emph` | Courbes d’animation | `[transition-timing-function:var(--easing-standard)]` |
+| `--focus-ring` | Couleur du focus visible | `class="focus-visible:ring-focus"` |
+| `--focus-width` | Largeur du focus | gérée globalement |
+| `--outline-offset` | Décalage du focus | géré globalement |
+
+## Consignes d’accessibilité
+
+- Viser un contraste minimum de **4.5:1** entre le texte et son fond.
+- Assurer un focus toujours visible grâce à `--focus-ring`, `--focus-width` et `--outline-offset`.
+- Respecter les préférences utilisateur : `prefers-reduced-motion` neutralise les animations.
+


### PR DESCRIPTION
## Résumé
- définition des design tokens et thème sombre dans `globals.css`
- configuration Tailwind pour consommer les variables et exemples sur Button, Input, KpiCard
- documentation des tokens et bonnes pratiques d’accessibilité

## Tests
- `npm test`
- `npm run lint` *(erreurs existantes sur des `any` dans les tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b75b7e9af48327a76ca492715b254f