### PR TITLE
feat: collecte web vitals et dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 artifacts/
 *.md
 !README.md
+!docs/**/*.md
 
 # Caches / temporaires Python
 __pycache__/

--- a/apps/cockpit/package-lock.json
+++ b/apps/cockpit/package-lock.json
@@ -16,7 +16,8 @@
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "recharts": "^2.13.0"
+        "recharts": "^2.13.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -12260,6 +12261,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -21,7 +21,8 @@
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "recharts": "^2.13.0"
+    "recharts": "^2.13.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/cockpit/src/app/api/vitals/route.ts
+++ b/apps/cockpit/src/app/api/vitals/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { addVital, aggregate, vitalSchema } from "@/lib/vitals";
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    const vital = vitalSchema.parse(data);
+    addVital(vital);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const range = Number(searchParams.get("range")) || 24 * 60 * 60 * 1000;
+  const result = aggregate(range);
+  return NextResponse.json(result);
+}

--- a/apps/cockpit/src/app/performance/page.tsx
+++ b/apps/cockpit/src/app/performance/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+interface Totals {
+  [name: string]: { count: number; mean: number; p75: number; p95: number };
+}
+interface TimelinePoint {
+  timestamp: number;
+  p50: number;
+  p75: number;
+  p95: number;
+}
+interface Timeline {
+  [name: string]: TimelinePoint[];
+}
+interface PathMetric {
+  p75: number;
+  count: number;
+}
+interface PathData {
+  path: string;
+  metrics: Record<string, PathMetric>;
+}
+interface ApiData {
+  totals: Totals;
+  timeline: Timeline;
+  paths: PathData[];
+}
+
+export default function PerformancePage() {
+  const [data, setData] = useState<ApiData | null>(null);
+  const [prev, setPrev] = useState<ApiData | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const toastRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch("/api/vitals");
+      const json = await res.json();
+      setData(json);
+      const resPrev = await fetch(
+        "/api/vitals?range=" + 2 * 24 * 60 * 60 * 1000
+      );
+      const jsonPrev = await resPrev.json();
+      setPrev(jsonPrev);
+
+      const t = json.totals;
+      if (t?.LCP?.p75 > 2500) setToast("LCP supérieur à 2.5s");
+      else if ((t?.INP?.p75 ?? t?.FID?.p75 ?? 0) > 200)
+        setToast("INP supérieur à 200ms");
+      else if (t?.CLS?.p75 > 0.1) setToast("CLS supérieur à 0.1");
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (toastRef.current) {
+      toastRef.current.focus();
+    }
+  }, [toast]);
+
+  if (!data) return <p>Chargement…</p>;
+
+  const alerts: string[] = [];
+  if (data.totals.LCP?.p75 > 2500) alerts.push("LCP");
+  if ((data.totals.INP?.p75 ?? data.totals.FID?.p75 ?? 0) > 200)
+    alerts.push("INP");
+  if (data.totals.CLS?.p75 > 0.1) alerts.push("CLS");
+
+  const trend = (metric: string) => {
+    if (!prev) return 0;
+    const curr = data.totals[metric]?.p75 ?? 0;
+    const prevVal = prev.totals[metric]?.p75 ?? 0;
+    return curr - prevVal;
+  };
+
+  return (
+    <div className="space-y-8 p-4">
+      {alerts.length > 0 && (
+        <div className="bg-yellow-100 p-2 rounded" role="alert">
+          {alerts.join(", ")} dépassent les seuils Core Web Vitals
+        </div>
+      )}
+
+      {toast && (
+        <div
+          ref={toastRef}
+          tabIndex={0}
+          role="status"
+          className="fixed top-4 right-4 bg-gray-800 text-white p-2 rounded shadow"
+        >
+          {toast}
+        </div>
+      )}
+
+      <section
+        className="grid gap-4 md:grid-cols-3"
+        aria-label="Indicateurs clés des Web Vitals"
+      >
+        {["LCP", "INP", "CLS"].map((m) => {
+          const value = data.totals[m]?.p75 ?? 0;
+          return (
+            <div key={m} className="border p-4 rounded" tabIndex={0}>
+              <h2 className="text-lg font-semibold">{m}</h2>
+              <p>{value.toFixed(2)}</p>
+              <p className="text-sm text-gray-500">
+                Δ {trend(m).toFixed(2)}
+              </p>
+            </div>
+          );
+        })}
+      </section>
+
+      <section className="space-y-6" aria-label="Graphiques des Web Vitals">
+        {Object.entries(data.timeline).map(([name, points]) => (
+          <div key={name} className="h-64" tabIndex={0}>
+            <h3 className="font-medium">{name}</h3>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={points} aria-hidden="true">
+                <XAxis
+                  dataKey="timestamp"
+                  tickFormatter={(n) => new Date(n).toLocaleTimeString()}
+                />
+                <YAxis />
+                <Tooltip labelFormatter={(n) => new Date(n).toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="p50" stroke="#8884d8" />
+                <Line type="monotone" dataKey="p75" stroke="#82ca9d" />
+                <Line type="monotone" dataKey="p95" stroke="#ffc658" />
+              </LineChart>
+            </ResponsiveContainer>
+            <span className="sr-only">Graphique de {name}</span>
+          </div>
+        ))}
+      </section>
+
+      <section aria-label="Performances par page">
+        <table className="w-full text-left border" role="table">
+          <thead>
+            <tr>
+              <th className="p-2 border">Page</th>
+              <th className="p-2 border">LCP p75</th>
+              <th className="p-2 border">INP/FID p75</th>
+              <th className="p-2 border">CLS p75</th>
+              <th className="p-2 border">Échantillons</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.paths.map((p) => (
+              <tr key={p.path} tabIndex={0}>
+                <td className="p-2 border">{p.path}</td>
+                <td className="p-2 border">
+                  {p.metrics.LCP ? p.metrics.LCP.p75.toFixed(2) : "-"}
+                </td>
+                <td className="p-2 border">
+                  {p.metrics.INP
+                    ? p.metrics.INP.p75.toFixed(2)
+                    : p.metrics.FID
+                    ? p.metrics.FID.p75.toFixed(2)
+                    : "-"}
+                </td>
+                <td className="p-2 border">
+                  {p.metrics.CLS ? p.metrics.CLS.p75.toFixed(2) : "-"}
+                </td>
+                <td className="p-2 border">
+                  {p.metrics.LCP ? p.metrics.LCP.count : 0}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/apps/cockpit/src/app/reportWebVitals.ts
+++ b/apps/cockpit/src/app/reportWebVitals.ts
@@ -1,0 +1,32 @@
+export function reportWebVitals(metric: any) {
+  if (process.env.NODE_ENV !== "production") {
+    return;
+  }
+
+  const body = {
+    name: metric.name,
+    id: metric.id,
+    value: metric.value,
+    delta: metric.delta,
+    label: metric.label,
+    path: window.location.pathname,
+    userAgent: navigator.userAgent,
+    timestamp: Date.now(),
+  };
+
+  const url = "/api/vitals";
+  try {
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(url, JSON.stringify(body));
+    } else {
+      fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        keepalive: true,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  } catch (err) {
+    // Erreurs ignorées
+  }
+}

--- a/apps/cockpit/src/lib/vitals.ts
+++ b/apps/cockpit/src/lib/vitals.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+export const vitalSchema = z.object({
+  name: z.string(),
+  id: z.string(),
+  value: z.number(),
+  delta: z.number(),
+  label: z.string(),
+  path: z.string(),
+  userAgent: z.string().optional(),
+  timestamp: z.number(),
+});
+
+export type Vital = z.infer<typeof vitalSchema>;
+
+const WINDOW = 24 * 60 * 60 * 1000; // 24h
+const store: Vital[] = [];
+
+function cleanup() {
+  const cutoff = Date.now() - WINDOW;
+  while (store.length && store[0].timestamp < cutoff) {
+    store.shift();
+  }
+}
+
+export function addVital(vital: Vital) {
+  store.push(vital);
+  cleanup();
+}
+
+export function getVitals(range: number = WINDOW) {
+  cleanup();
+  const cutoff = Date.now() - range;
+  return store.filter((v) => v.timestamp >= cutoff);
+}
+
+function quantile(values: number[], q: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+  return sorted[base];
+}
+
+export function aggregate(range: number = WINDOW) {
+  const vitals = getVitals(range);
+  const byName: Record<string, Vital[]> = {};
+  const byPath: Record<string, Record<string, Vital[]>> = {};
+
+  vitals.forEach((v) => {
+    (byName[v.name] ||= []).push(v);
+    (byPath[v.path] ||= {});
+    (byPath[v.path][v.name] ||= []).push(v);
+  });
+
+  const totals = Object.fromEntries(
+    Object.entries(byName).map(([name, arr]) => {
+      const values = arr.map((v) => v.value);
+      return [
+        name,
+        {
+          count: values.length,
+          mean: values.reduce((s, n) => s + n, 0) / values.length,
+          p75: quantile(values, 0.75),
+          p95: quantile(values, 0.95),
+        },
+      ];
+    })
+  );
+
+  const timeline: Record<string, { timestamp: number; p50: number; p75: number; p95: number }[]> = {};
+  Object.entries(byName).forEach(([name, arr]) => {
+    const buckets: Record<number, number[]> = {};
+    arr.forEach((v) => {
+      const bucket = Math.floor(v.timestamp / 600000) * 600000; // 10m
+      (buckets[bucket] ||= []).push(v.value);
+    });
+    timeline[name] = Object.entries(buckets)
+      .sort((a, b) => Number(a[0]) - Number(b[0]))
+      .map(([ts, values]) => ({
+        timestamp: Number(ts),
+        p50: quantile(values, 0.5),
+        p75: quantile(values, 0.75),
+        p95: quantile(values, 0.95),
+      }));
+  });
+
+  const paths = Object.entries(byPath).map(([path, names]) => ({
+    path,
+    metrics: Object.fromEntries(
+      Object.entries(names).map(([name, arr]) => {
+        const values = arr.map((v) => v.value);
+        return [name, { p75: quantile(values, 0.75), count: values.length }];
+      })
+    ),
+  }));
+
+  return { totals, timeline, paths };
+}

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -1,0 +1,31 @@
+# Suivi des Web Vitals
+
+Ce module met en place une collecte des métriques Core Web Vitals en production.
+
+## Pipeline
+1. **Collecte** : `reportWebVitals` dans l'application Next.js envoie LCP, FID/INP, CLS, FCP et TTFB via `POST /api/vitals`.
+2. **API** : l'endpoint valide les données (Zod) et les stocke en mémoire sur une fenêtre glissante de 24 h.
+3. **Agrégations** : les métriques sont agrégées par nom et par page, avec calcul des moyennes et percentiles (p50/p75/p95).
+4. **Dashboard** : `/performance` affiche les KPI, les graphiques temporels et une table par page.
+
+## Limites
+- Stockage en mémoire : les données disparaissent au redémarrage du serveur.
+- Pas de sampling : toutes les valeurs sont collectées ; ajouter un échantillonnage si nécessaire.
+- Aucune PII n'est transmise, uniquement les métriques techniques et l'agent utilisateur.
+
+## Confidentialité
+Les requêtes ne contiennent aucune information personnelle. Seuls `path`, `userAgent` et les mesures de performance sont envoyés.
+
+## Tests
+- Lancer l'application `npm run dev` (ou `npm start` en production).
+- Simuler l'envoi de métriques via la console :
+  ```js
+  window.reportWebVitals({
+    name: 'LCP',
+    id: 'test',
+    value: 3000,
+    delta: 3000,
+    label: 'web-vital'
+  });
+  ```
+- Consulter `/performance` pour voir les agrégations et alertes.


### PR DESCRIPTION
## Résumé
- collecte des Web Vitals en production via `reportWebVitals`
- API `/api/vitals` avec stockage mémoire et agrégations
- page `/performance` avec KPI, graphiques et alertes

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75b868f9c8327804b405491fc9065