### PR TITLE
feat(ci): ajoute budgets de performance et vérifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,36 @@ jobs:
               repo: context.repo.repo,
               body: `Preview Vercel : ${url}`
             });
+  perf-budgets:
+    needs: vercel-deploy-pr
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install Lighthouse
+        run: npm install -g lighthouse chrome-launcher
+      - name: Vérifier les budgets de perf
+        env:
+          PREVIEW_URL: ${{ needs.vercel-deploy-pr.outputs.preview-url }}
+        run: node scripts/lh-ci.mjs
+      - name: Commenter le rapport budgets
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('lh-budgets-report.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: report
+            });
 
   e2e-preview:
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 artifacts/
 *.md
 !README.md
+!docs/**/*.md
 
 # Caches / temporaires Python
 __pycache__/

--- a/docs/perf-budgets.md
+++ b/docs/perf-budgets.md
@@ -1,0 +1,42 @@
+# Budgets de performance
+
+Ce dépôt applique des budgets de performance pour les principales pages du cockpit
+(`/dashboard`, `/runs`, `/performance`). Les budgets sont définis dans
+`perf-budgets.json` et vérifiés en CI via `scripts/lh-ci.mjs`.
+
+## Metriques surveillées
+
+- **LCP p75** ≤ 2,5 s
+- **INP p75** ≤ 200 ms
+- **CLS p75** ≤ 0,1
+- **Temps d’interactivité (TTI)** ≤ 3 s
+- Poids des ressources transférées :
+  - JavaScript ≤ 180 KB
+  - CSS ≤ 60 KB
+  - Total ≤ 350 KB
+- **Nombre de requêtes** ≤ 25
+
+## Ajuster les budgets
+
+1. Modifier les valeurs dans `perf-budgets.json`.
+2. Lancer localement `node scripts/lh-ci.mjs` avec `PREVIEW_URL` pointant
+   vers l’instance à tester.
+3. Commiter le fichier mis à jour avec une description du changement.
+
+## Workflow de mise à jour
+
+- Les budgets doivent être stricts mais réalistes. Toute augmentation doit être
+  justifiée dans le message de commit et la revue de code.
+- En cas d’amélioration durable, réduire les limites plutôt que de les laisser
+  dériver.
+
+## Assouplissement temporaire (waiver)
+
+Si une régression ponctuelle est inévitable :
+
+1. Augmenter le budget concerné et préciser la durée de validité dans la PR.
+2. Ouvrir un ticket pour le retour à la valeur initiale.
+3. Réduire le budget dès que la régression est résolue.
+
+Ces étapes garantissent que les budgets restent un garde‑fou efficace et que les
+écarts sont documentés et suivis.

--- a/perf-budgets.json
+++ b/perf-budgets.json
@@ -1,0 +1,44 @@
+{
+  "/dashboard": {
+    "metrics": {
+      "lcp": 2500,
+      "inp": 200,
+      "cls": 0.1,
+      "tti": 3000
+    },
+    "transferSize": {
+      "js": 180,
+      "css": 60,
+      "total": 350
+    },
+    "requests": 25
+  },
+  "/runs": {
+    "metrics": {
+      "lcp": 2500,
+      "inp": 200,
+      "cls": 0.1,
+      "tti": 3000
+    },
+    "transferSize": {
+      "js": 180,
+      "css": 60,
+      "total": 350
+    },
+    "requests": 25
+  },
+  "/performance": {
+    "metrics": {
+      "lcp": 2500,
+      "inp": 200,
+      "cls": 0.1,
+      "tti": 3000
+    },
+    "transferSize": {
+      "js": 180,
+      "css": 60,
+      "total": 350
+    },
+    "requests": 25
+  }
+}

--- a/scripts/lh-ci.mjs
+++ b/scripts/lh-ci.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function toKB(bytes) {
+  return bytes / 1024;
+}
+
+function format(num, unit='ms') {
+  return unit === 'kb' ? `${num.toFixed(1)} KB` : `${Math.round(num)} ms`;
+}
+
+async function runLighthouse(url) {
+  const { default: lighthouse } = await import('lighthouse');
+  const chromeLauncher = await import('chrome-launcher');
+  const chrome = await chromeLauncher.launch({ chromeFlags: ['--headless'] });
+  const options = { logLevel: 'error', output: 'json', port: chrome.port };
+  const runnerResult = await lighthouse(url, options);
+  await chrome.kill();
+  return runnerResult.lhr;
+}
+
+function evaluate(lhr, budget) {
+  const details = { metrics: {}, transferSize: {}, requests: {}, bundles: [] };
+  let pass = true;
+
+  const metricsMap = {
+    lcp: lhr.audits['largest-contentful-paint']?.numericValue,
+    inp: lhr.audits['interaction-to-next-paint']?.numericValue,
+    cls: lhr.audits['cumulative-layout-shift']?.numericValue,
+    tti: lhr.audits['interactive']?.numericValue
+  };
+
+  for (const [key, value] of Object.entries(metricsMap)) {
+    const limit = budget.metrics[key];
+    if (limit != null) {
+      const ok = value <= limit;
+      details.metrics[key] = { value, limit, ok };
+      if (!ok) pass = false;
+    }
+  }
+
+  const items = lhr.audits['total-byte-weight'].details.items;
+  let js = 0, css = 0, total = 0;
+  for (const it of items) {
+    total += it.transferSize;
+    if (it.resourceType === 'Script') js += it.transferSize;
+    if (it.resourceType === 'Stylesheet') css += it.transferSize;
+  }
+  const sizeBudget = budget.transferSize;
+  const sizeMap = { js: toKB(js), css: toKB(css), total: toKB(total) };
+  for (const [key, value] of Object.entries(sizeMap)) {
+    const limit = sizeBudget[key];
+    const ok = value <= limit;
+    details.transferSize[key] = { value, limit, ok };
+    if (!ok) pass = false;
+  }
+
+  const reqs = lhr.audits['network-requests'].details.items.length;
+  const okReq = reqs <= budget.requests;
+  details.requests = { value: reqs, limit: budget.requests, ok: okReq };
+  if (!okReq) pass = false;
+
+  const topBundles = lhr.audits['network-requests'].details.items
+    .sort((a, b) => b.transferSize - a.transferSize)
+    .slice(0, 5)
+    .map(i => `${i.url} (${format(toKB(i.transferSize), 'kb')})`);
+  details.bundles = topBundles;
+
+  return { pass, details };
+}
+
+function renderReport(results) {
+  let out = '# Rapport budgets de performance\n\n';
+  for (const { path, pass, details } of results) {
+    out += `## ${path} — ${pass ? '✅' : '❌'}\n`;
+    out += `| Métrique | Valeur | Budget | OK |\n|---|---|---|---|\n`;
+    for (const [m, info] of Object.entries(details.metrics)) {
+      out += `| ${m.toUpperCase()} | ${format(info.value)} | ${format(info.limit)} | ${info.ok ? '✅' : '❌'} |\n`;
+    }
+    out += `| JS | ${format(details.transferSize.js.value, 'kb')} | ${details.transferSize.js.limit} KB | ${details.transferSize.js.ok ? '✅' : '❌'} |\n`;
+    out += `| CSS | ${format(details.transferSize.css.value, 'kb')} | ${details.transferSize.css.limit} KB | ${details.transferSize.css.ok ? '✅' : '❌'} |\n`;
+    out += `| Total | ${format(details.transferSize.total.value, 'kb')} | ${details.transferSize.total.limit} KB | ${details.transferSize.total.ok ? '✅' : '❌'} |\n`;
+    out += `| Requêtes | ${details.requests.value} | ${details.requests.limit} | ${details.requests.ok ? '✅' : '❌'} |\n`;
+    out += '\n### Plus gros bundles\n';
+    for (const b of details.bundles) {
+      out += `- ${b}\n`;
+    }
+    out += '\n';
+  }
+  return out;
+}
+
+(async () => {
+  const budgetsPath = process.argv[2] || path.join(__dirname, '..', 'perf-budgets.json');
+  const base = process.env.PREVIEW_URL || 'http://localhost:3000';
+  const budgets = readJSON(budgetsPath);
+  const results = [];
+  for (const [p, cfg] of Object.entries(budgets)) {
+    const url = new URL(p, base).toString();
+    const lhr = await runLighthouse(url);
+    const evaluation = evaluate(lhr, cfg);
+    results.push({ path: p, ...evaluation });
+  }
+  const report = renderReport(results);
+  fs.writeFileSync('lh-budgets-report.md', report);
+  console.log(report);
+  if (results.some(r => !r.pass)) {
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Résumé
- définit `perf-budgets.json` pour /dashboard, /runs et /performance
- ajoute `scripts/lh-ci.mjs` qui valide les budgets via Lighthouse et produit un rapport Markdown
- intègre une étape GitHub Actions pour exécuter le script et commenter le rapport
- documente l'ajustement et la gestion des budgets dans `docs/perf-budgets.md`

## Tests
- `pytest` *(échecs : 3 tests)*
- `node scripts/lh-ci.mjs` *(échoue : module `lighthouse` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68b75b8b3dd08327a9f8f3c93c3175ff