### PR TITLE
fix: éviter décalage d'hydratation sur recherche

### DIFF
--- a/apps/cockpit/src/components/shell/Header.tsx
+++ b/apps/cockpit/src/components/shell/Header.tsx
@@ -18,6 +18,15 @@ export function Header({
   commandPaletteOpen,
   onCommandPaletteOpenChange,
 }: HeaderProps) {
+  React.useEffect(() => {
+    const input = searchRef.current;
+    if (!input) return;
+    for (const attr of Array.from(input.attributes)) {
+      if (attr.name.startsWith("data-dashlane-")) {
+        input.removeAttribute(attr.name);
+      }
+    }
+  }, [searchRef]);
   return (
     <header
       className="glass glass-muted sticky top-0 z-10 flex h-14 items-center justify-between border-b px-4"
@@ -29,6 +38,7 @@ export function Header({
           aria-label="Recherche"
           placeholder="Rechercher..."
           className="w-full max-w-sm"
+          suppressHydrationWarning
         />
       </div>
       <div className="ml-4 flex items-center gap-2">


### PR DESCRIPTION
## Résumé
- supprime les attributs data-dashlane injectés sur le champ recherche
- ignore les divergences d'hydratation sur le champ de recherche

## Tests
- `npm test` (échec : Failed to load PostCSS config)
- `npm run lint` (échec : Unexpected any)
- `npm run build` (échec : Unexpected any)
- `pytest` (échec : 3 failed, 153 passed)


------
https://chatgpt.com/codex/tasks/task_e_68b85e310f088327924e2fe6d579b40a