### PR TITLE
feat(cockpit): centraliser query client et pont toast

### DIFF
--- a/apps/cockpit/src/app/dashboard/page.tsx
+++ b/apps/cockpit/src/app/dashboard/page.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useState } from "react";
-
 function DashboardContent() {
   return (
     <main className="p-6">
@@ -13,10 +10,5 @@ function DashboardContent() {
 }
 
 export default function DashboardPage() {
-  const [client] = useState(() => new QueryClient());
-  return (
-    <QueryClientProvider client={client}>
-      <DashboardContent />
-    </QueryClientProvider>
-  );
+  return <DashboardContent />;
 }

--- a/apps/cockpit/src/components/Providers.tsx
+++ b/apps/cockpit/src/components/Providers.tsx
@@ -1,7 +1,6 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient, setQueryErrorNotifier } from "@/lib/queryClient";
 import { ThemeProvider } from "./ThemeProvider";
 import { ToastProvider, useToast } from "./ds/Toast";
@@ -15,15 +14,23 @@ function ToastBridge() {
 }
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  const [Devtools, setDevtools] = useState<React.ComponentType | null>(null);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "development") {
+      import("@tanstack/react-query-devtools").then((d) =>
+        setDevtools(() => d.ReactQueryDevtools)
+      );
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <ToastProvider>
           <ToastBridge />
           {children}
-          {process.env.NODE_ENV === "development" && (
-            <ReactQueryDevtools initialIsOpen={false} />
-          )}
+          {Devtools && <Devtools initialIsOpen={false} />}
         </ToastProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/apps/cockpit/src/components/ds/Toast.tsx
+++ b/apps/cockpit/src/components/ds/Toast.tsx
@@ -2,21 +2,35 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+type ToastType = "default" | "error";
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
 interface ToastContextValue {
-  add: (message: string) => void;
+  add: (message: string, type?: ToastType) => void;
 }
 
 const ToastContext = React.createContext<ToastContextValue | null>(null);
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
-  const [toasts, setToasts] = React.useState<Array<{ id: number; message: string }>>([]);
+  const [toasts, setToasts] = React.useState<ToastItem[]>([]);
 
-  const add = (message: string) => {
-    const id = Date.now();
-    setToasts((prev) => [...prev, { id, message }]);
-    setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id));
-    }, 3000);
+  const add = (message: string, type: ToastType = "default") => {
+    let id: number | null = null;
+    setToasts((prev) => {
+      if (prev.some((t) => t.message === message)) return prev;
+      id = Date.now();
+      return [...prev, { id, message, type }];
+    });
+    if (id !== null) {
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 3000);
+    }
   };
 
   return (
@@ -28,7 +42,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
             key={t.id}
             role="alert"
             className={cn(
-              "rounded bg-destructive px-4 py-2 text-destructive-foreground shadow"
+              "rounded px-4 py-2 shadow",
+              t.type === "error"
+                ? "bg-destructive text-destructive-foreground"
+                : "bg-primary text-primary-foreground",
             )}
           >
             {t.message}


### PR DESCRIPTION
## Résumé
- centralisation du `queryClient` et intégration d’un pont Toast pour les erreurs
- chargement dynamique de React Query Devtools seulement en développement
- simplification de la page Dashboard pour éviter un double `QueryClient`

## Test
- `npm test` *(échec: Failed to load PostCSS config)*
- `npm run lint` *(échec: Unexpected any in reportWebVitals.ts)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b85e3ebac88327923e86780a791bb4