### PR TITLE
feat: expose focus token

### DIFF
--- a/apps/cockpit/src/app/globals.css
+++ b/apps/cockpit/src/app/globals.css
@@ -136,6 +136,7 @@
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
   --color-ring: hsl(var(--ring));
+  --color-focus: hsl(var(--focus-ring));
   --color-ring-foreground: hsl(var(--ring-foreground));
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
@@ -173,7 +174,7 @@ body {
 }
 
 :focus-visible {
-  outline: var(--focus-width) solid hsl(var(--focus-ring));
+  outline: var(--focus-width) solid var(--color-focus);
   outline-offset: var(--outline-offset);
 }
 


### PR DESCRIPTION
## Summary
- expose focus design token to Tailwind via `--color-focus`
- use `--color-focus` for `:focus-visible`

## Testing
- `npm run lint` (fails: Unexpected any in reportWebVitals.ts)
- `npm test` (fails: Invalid PostCSS Plugin found at: plugins[0])

------
https://chatgpt.com/codex/tasks/task_e_68b85e50c7748327899510771fd114c1