### PR TITLE
feat: pages placeholders pour tasks/plans/runs/settings

### DIFF
--- a/apps/cockpit/src/app/plans/page.tsx
+++ b/apps/cockpit/src/app/plans/page.tsx
@@ -1,0 +1,7 @@
+export default function PlansPage() {
+  return (
+    <main role="main" className="flex items-center justify-center min-h-screen p-8">
+      <h1 className="text-2xl font-semibold">Plans</h1>
+    </main>
+  );
+}

--- a/apps/cockpit/src/app/runs/page.tsx
+++ b/apps/cockpit/src/app/runs/page.tsx
@@ -1,0 +1,7 @@
+export default function RunsPage() {
+  return (
+    <main role="main" className="flex items-center justify-center min-h-screen p-8">
+      <h1 className="text-2xl font-semibold">Runs</h1>
+    </main>
+  );
+}

--- a/apps/cockpit/src/app/settings/page.tsx
+++ b/apps/cockpit/src/app/settings/page.tsx
@@ -1,0 +1,7 @@
+export default function SettingsPage() {
+  return (
+    <main role="main" className="flex items-center justify-center min-h-screen p-8">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+    </main>
+  );
+}

--- a/apps/cockpit/src/app/tasks/page.tsx
+++ b/apps/cockpit/src/app/tasks/page.tsx
@@ -1,0 +1,7 @@
+export default function TasksPage() {
+  return (
+    <main role="main" className="flex items-center justify-center min-h-screen p-8">
+      <h1 className="text-2xl font-semibold">Tasks</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
## Résumé
- ajout de pages minimalistes pour tasks, plans, runs et settings
- chaque page expose un `<main>` avec un titre `h1`

## Tests
- `npx playwright test` (échec: navigateurs Playwright non installés)

------
https://chatgpt.com/codex/tasks/task_e_68b85e688a8083279d123bbff42633f8