### PR TITLE
fix: ajoute deps de test manquantes

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -33,6 +33,8 @@
     "eslint-config-next": "15.5.2",
     "jsdom": "^25.0.0",
     "typescript": "^5.6.3",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "jest": "^29.7.0",
+    "@playwright/test": "^1.49.0"
   }
 }


### PR DESCRIPTION
## Résumé
- ajoute jest et @playwright/test aux dépendances de développement
- restaure le fichier package-lock.json d'origine (exécuter `npm i` après fusion)

## Test
- `npm i`
- `npm run build` (échec : Property 'delta' does not exist on type 'NextWebVitalsMetric')
- `npm test` (échec : Invalid PostCSS Plugin found at: plugins[0])

------
https://chatgpt.com/codex/tasks/task_e_68b85e5b15888327a734d438b0322264