### PR TITLE
feat(cockpit): bouton commande visible et kpi translucides

### DIFF
--- a/apps/cockpit/src/app/dashboard/page.tsx
+++ b/apps/cockpit/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { fetchJson } from "@/lib/http";
+import { KpiCard } from "@/components/kpi/KpiCard";
 
 function DashboardContent() {
   useQuery({
@@ -24,6 +25,10 @@ function DashboardContent() {
     <main className="p-6">
       <h1 className="text-2xl font-semibold">Dashboard</h1>
       <p data-testid="dashboard-welcome">Bienvenue sur le cockpit.</p>
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <KpiCard title="Agents" value="42" variant="glass" />
+        <KpiCard title="Runs" value="128" variant="glass" />
+      </div>
     </main>
   );
 }

--- a/apps/cockpit/src/components/shell/Header.tsx
+++ b/apps/cockpit/src/components/shell/Header.tsx
@@ -51,7 +51,7 @@ export function Header({
         <button
           aria-label="Ouvrir la palette de commandes"
           onClick={() => onCommandPaletteOpenChange(true)}
-          className="relative hidden h-10 w-10 items-center justify-center rounded-lg hover:bg-primary/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:flex"
+          className="relative flex h-10 w-10 items-center justify-center rounded-lg hover:bg-primary/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <CommandIcon className="h-5 w-5" />
           <kbd className="pointer-events-none absolute -bottom-1 -right-1 rounded bg-muted px-1 text-[10px] text-muted-foreground">⌘K</kbd>


### PR DESCRIPTION
## Résumé
- rendre le bouton ⌘K visible sur tous les écrans
- afficher deux cartes KPI avec le rendu "glass"

## Tests
- `npm test` *(échoué : Invalid package.json)*
- `pytest -q` *(3 tests en échec)*

------
https://chatgpt.com/codex/tasks/task_e_68b886cc8504832797761a7df90bb896