### PR TITLE
test: couverture de la palette de commandes

### DIFF
--- a/apps/cockpit/e2e/command-palette.spec.ts
+++ b/apps/cockpit/e2e/command-palette.spec.ts
@@ -4,7 +4,14 @@ test('naviguer via la palette de commandes', async ({ page }) => {
   await page.goto('/');
   const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
   await page.keyboard.press(`${modifier}+K`);
+  await expect(page.getByRole('textbox')).toBeFocused();
   await page.getByRole('textbox').fill('Runs');
   await page.keyboard.press('Enter');
   await expect(page).toHaveURL(/runs/);
+});
+
+test('ouvrir la palette via le bouton', async ({ page }) => {
+  await page.goto('/');
+  await page.getByLabel('Ouvrir la palette de commandes').click();
+  await expect(page.getByRole('textbox')).toBeFocused();
 });

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -34,7 +34,7 @@
     "eslint-config-next": "15.5.2",
     "jsdom": "^25.0.0",
     "typescript": "^5.6.3",
-    "@playwright/test": "^1.49.0"
+    "@playwright/test": "^1.49.0",
     "jest": "^30.1.3",
     "jest-environment-jsdom": "^30.1.2",
     "jest-axe": "^10.0.0"


### PR DESCRIPTION
## Résumé
- ajoute un test e2e pour l'ouverture de la palette via le bouton
- vérifie le focus après ouverture par raccourci clavier
- corrige la syntaxe de package.json pour les dépendances de test

## Tests
- `npm test` *(échec : jest manquant)*
- `npx playwright test` *(échec : installation de playwright requise)*

------
https://chatgpt.com/codex/tasks/task_e_68b886d45f148327869b4d82f52dd1ed