### PR TITLE
feat(cockpit): afficher indicateurs dashboard

### DIFF
--- a/apps/cockpit/src/app/dashboard/page.tsx
+++ b/apps/cockpit/src/app/dashboard/page.tsx
@@ -1,29 +1,69 @@
 "use client";
 
-
 import { useQuery } from "@tanstack/react-query";
 import { fetchJson } from "@/lib/http";
+import { KpiCard } from "@/components/kpi/KpiCard";
+import { ThroughputChart } from "@/components/charts/ThroughputChart";
+import { LatencyChart } from "@/components/charts/LatencyChart";
+import { FeedbackChart } from "@/components/charts/FeedbackChart";
+
+interface AgentPoint {
+  date: string;
+  value: number;
+}
+
+interface RunPoint {
+  date: string;
+  p50: number;
+  p95: number;
+}
+
+interface FeedbackPoint {
+  date: string;
+  positive: number;
+  neutral: number;
+  negative: number;
+}
 
 function DashboardContent() {
-  useQuery({
+  const { data: agents = [] } = useQuery<AgentPoint[]>({
     queryKey: ["agents"],
-    queryFn: ({ signal }) => fetchJson("/api/agents", { signal }),
+    queryFn: ({ signal }) => fetchJson<AgentPoint[]>("/api/agents", { signal }),
   });
 
-  useQuery({
+  const { data: runs = [] } = useQuery<RunPoint[]>({
     queryKey: ["runs"],
-    queryFn: ({ signal }) => fetchJson("/api/runs", { signal }),
+    queryFn: ({ signal }) => fetchJson<RunPoint[]>("/api/runs", { signal }),
   });
 
-  useQuery({
+  const { data: feedbacks = [] } = useQuery<FeedbackPoint[]>({
     queryKey: ["feedbacks"],
-    queryFn: ({ signal }) => fetchJson("/api/feedbacks", { signal }),
+    queryFn: ({ signal }) => fetchJson<FeedbackPoint[]>("/api/feedbacks", { signal }),
   });
+
+  const agentsCount = agents.at(-1)?.value ?? 0;
+  const latencyP50 = runs.at(-1)?.p50 ?? 0;
+  const positiveRate = feedbacks.at(-1)?.positive ?? 0;
 
   return (
-    <main className="p-6">
+    <main className="p-6 space-y-8">
       <h1 className="text-2xl font-semibold">Dashboard</h1>
       <p data-testid="dashboard-welcome">Bienvenue sur le cockpit.</p>
+
+      <section
+        className="grid gap-4 md:grid-cols-3"
+        aria-label="Indicateurs clés"
+      >
+        <KpiCard title="Agents actifs" value={agentsCount} />
+        <KpiCard title="Latence p50" value={latencyP50} />
+        <KpiCard title="Feedback positif (%)" value={positiveRate} />
+      </section>
+
+      <section className="space-y-8" aria-label="Graphiques">
+        <ThroughputChart data={agents} />
+        <LatencyChart data={runs} />
+        <FeedbackChart data={feedbacks} />
+      </section>
     </main>
   );
 }
@@ -31,3 +71,4 @@ function DashboardContent() {
 export default function DashboardPage() {
   return <DashboardContent />;
 }
+


### PR DESCRIPTION
## Summary
- affiche trois KPI avec des valeurs simulées
- ajoute graphiques pour agents, exécutions et feedbacks
- récupère les données via useQuery depuis `/api/agents`, `/api/runs` et `/api/feedbacks`

## Testing
- `npx --yes jest` *(échoue: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b886dcc55c83279907aa8254f5771a