### PR TITLE
Skip auto-review during dry runs

### DIFF
--- a/apps/orchestrator/executor.py
+++ b/apps/orchestrator/executor.py
@@ -644,10 +644,17 @@ async def _run_single_node(
                 node_dbid = getattr(node, "db_id", None)
             except Exception:
                 node_dbid = None
-            try:
-                await _maybe_auto_review(storage, run_id, node_id_txt, str(node_dbid) if node_dbid else None, result or {})
-            except Exception:
-                pass
+            if not dry_run:
+                try:
+                    await _maybe_auto_review(
+                        storage,
+                        run_id,
+                        node_id_txt,
+                        str(node_dbid) if node_dbid else None,
+                        result or {},
+                    )
+                except Exception:
+                    pass
             if node.type == "manage" and isinstance(result, dict):
                 for assignment in result.get("assignments", []) or []:
                     node_id = assignment.get("node_id")


### PR DESCRIPTION
## Summary
- avoid launching auto-review when running in dry mode
- adjust orchestrator service tests for auto-review behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88e7d53c083278ab26dca1bc1cbaa