### PR TITLE
chore(cockpit): force le root turbopack

### DIFF
--- a/apps/cockpit/next.config.ts
+++ b/apps/cockpit/next.config.ts
@@ -1,10 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Config minimale; on retirera/rajoutera proprement plus tard si besoin.
   experimental: {
     turbopack: {
-      root: __dirname,
+      root: __dirname, // force le root sur apps/cockpit
     },
   },
 };


### PR DESCRIPTION
## Résumé
- force `turbopack.root` sur `apps/cockpit`

## Tests
- `pre-commit run --files apps/cockpit/next.config.ts`
- `npm test` *(échoue : jest manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68b88f3fb75083278f17ec531f88b245