### PR TITLE
Corriger db-reset pour utiliser la configuration Alembic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,9 +325,9 @@ db-reset:
 	@docker compose up -d postgres pgadmin
 	@sleep 3
 	@if [ -n "$$ALEMBIC_DATABASE_URL" ]; then \
-		$(ACTIVATE) && alembic upgrade head; \
+	 $(ACTIVATE) && alembic -c backend/migrations/alembic.ini upgrade head; \
 	else \
-		echo "ℹ️  ALEMBIC_DATABASE_URL non défini — migration skip"; \
+	 echo "ℹ️  ALEMBIC_DATABASE_URL non défini — migration skip"; \
 	fi
 
 # ---- Cockpit (Next.js) ---------------------------------------


### PR DESCRIPTION
## Résumé
- aligne la cible `db-reset` sur `api-migrate` en précisant le fichier `backend/migrations/alembic.ini`
- corrige les antislashs et l'indentation de la recette `db-reset`

## Tests
- `pre-commit run --files Makefile`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b96a13dd70832791fba461743d627a