### PR TITLE
chore(migrations): configure Alembic via %(here)s et URL env

### DIFF
--- a/backend/migrations/alembic.ini
+++ b/backend/migrations/alembic.ini
@@ -1,7 +1,12 @@
 [alembic]
-script_location = .
-sqlalchemy.url = postgresql://placeholder/placeholder
-prepend_sys_path = ..
+# Emplacement du répertoire Alembic (env.py, versions/)
+# %(here)s = dossier où se trouve CE fichier alembic.ini
+script_location = %(here)s
+prepend_sys_path = %(here)s/..
+
+# Optionnel mais pratique : où logguer les migrations
+# file_template = %%(rev)s_%%(slug)s
+# timezone = utc
 
 [loggers]
 keys = root,sqlalchemy,alembic
@@ -23,15 +28,14 @@ qualname = sqlalchemy.engine
 
 [logger_alembic]
 level = INFO
-handlers =
+handlers = console
 qualname = alembic
 
 [handler_console]
 class = StreamHandler
-args = (sys.stderr,)
+args = (sys.stdout,)
 level = NOTSET
 formatter = generic
 
 [formatter_generic]
 format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -14,6 +14,11 @@ from app.db.base import Base  # noqa: F401
 from dotenv import load_dotenv
 load_dotenv()  # charge le .env tôt
 
+# Si tu veux forcer alembic à lire l'URL depuis l'env:
+db_url = os.getenv("ALEMBIC_DATABASE_URL")
+if db_url:
+    context.config.set_main_option("sqlalchemy.url", db_url)
+
 # Alembic Config object
 config = context.config
 
@@ -25,9 +30,14 @@ def _sync_url() -> str:
     Récupère l'URL de BDD pour Alembic (driver *synchrone*).
 
     Priorité :
-      1) DATABASE_URL_SYNC (si défini)
-      2) DATABASE_URL converti (remplace 'postgresql+asyncpg' -> 'postgresql+psycopg')
+      1) ALEMBIC_DATABASE_URL (si défini)
+      2) DATABASE_URL_SYNC (si défini)
+      3) DATABASE_URL converti (remplace 'postgresql+asyncpg' -> 'postgresql+psycopg')
     """
+    env_alembic = os.getenv("ALEMBIC_DATABASE_URL")
+    if env_alembic:
+        return env_alembic
+
     env_sync = os.getenv("DATABASE_URL_SYNC")
     if env_sync:
         return env_sync
@@ -40,7 +50,7 @@ def _sync_url() -> str:
         return env
 
     raise RuntimeError(
-        "Aucune URL de BDD trouvée. Définis DATABASE_URL ou DATABASE_URL_SYNC (dans .env)."
+        "Aucune URL de BDD trouvée. Définis ALEMBIC_DATABASE_URL, DATABASE_URL ou DATABASE_URL_SYNC (dans .env).",
     )
 
 def run_migrations_offline() -> None:


### PR DESCRIPTION
## Résumé
- ajuste `alembic.ini` pour utiliser `%(here)s` et `sys.stdout`
- permet à `env.py` de lire `ALEMBIC_DATABASE_URL`

## Tests
- `pre-commit run --files backend/migrations/alembic.ini backend/migrations/env.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9806b9d208327a392658f000c9ded