### PR TITLE
Corrige l'import des modèles et l'export du PYTHONPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ PYTHON              ?= python3
 PIP                 ?= pip
 VENV_DIR            ?= .venv
 PYTHONPATH         ?= backend
-ACTIVATE            := PYTHONPATH=$(PYTHONPATH) . $(VENV_DIR)/bin/activate
+# Ensure PYTHONPATH is exported so subsequent commands (like uvicorn) can import the API.
+ACTIVATE            := export PYTHONPATH=$(PYTHONPATH); . $(VENV_DIR)/bin/activate
 REQ_FILE            ?= requirements.txt
 ENV_FILE            ?= .env
 UVICORN := .venv/bin/uvicorn

--- a/backend/api/fastapi_app/models/__init__.py
+++ b/backend/api/fastapi_app/models/__init__.py
@@ -1,3 +1,19 @@
-from .request_id import RequestIDMiddleware
+"""Exports for the FastAPI app models package.
 
-__all__ = ["RequestIDMiddleware"]
+This module exposes the core data models used by the API layer.
+"""
+
+from .agent import Agent, AgentTemplate, AgentModelsMatrix
+from .feedback import Feedback
+from .node import Node
+from .run import Run
+
+__all__ = [
+    "Agent",
+    "AgentTemplate",
+    "AgentModelsMatrix",
+    "Feedback",
+    "Node",
+    "Run",
+]
+


### PR DESCRIPTION
## Résumé
- Corrige le paquet `models` de l'API en supprimant l'import erroné du middleware et en exposant les modèles nécessaires.
- Exporte correctement `PYTHONPATH` dans la commande d'activation pour que FastAPI démarre sans erreur.

## Tests
- `make test`
- `timeout 5 make api-run` (échoue ensuite à cause du timeout, mais l'application démarre bien)


------
https://chatgpt.com/codex/tasks/task_e_68b9ecd18af483278ad1444a8f7cf823