### PR TITLE
Gestion complète des événements de nœuds et clôture de run

### DIFF
--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -26,6 +26,8 @@ class OrchestratorService:
         self._overrides: Dict[str, Dict[str, Any]] = {}
         self._node_ids: Dict[str, uuid.UUID] = {}
         self.run_id: Optional[str] = None
+        # timestamps pour calculer la durée des nœuds
+        self._node_started_at: Dict[str, datetime] = {}
 
     def override(self, node_key: str, *, prompt: str | None = None, params: Dict[str, Any] | None = None) -> None:
         self._overrides[node_key] = {"prompt": prompt, "params": params}
@@ -65,31 +67,89 @@ class OrchestratorService:
         async def on_start(node, node_key):
             nid = self._node_ids.get(node_key)
             if nid:
+                now_start = datetime.now(timezone.utc)
                 await self.storage.save_node(
-                    Node(id=nid, run_id=run_uuid, key=node_key, title=getattr(node, "title", node_key), status=NodeStatus.running, started_at=datetime.now(timezone.utc))
+                    Node(
+                        id=nid,
+                        run_id=run_uuid,
+                        key=node_key,
+                        title=getattr(node, "title", node_key),
+                        status=NodeStatus.running,
+                        started_at=now_start,
+                    )
                 )
+                # mémorise pour calculer la durée
+                self._node_started_at[node_key] = now_start
                 setattr(node, "db_id", str(nid))
 
         async def on_end(node, node_key, status):
             nid = self._node_ids.get(node_key)
             if nid:
+                now_end = datetime.now(timezone.utc)
                 await self.storage.save_node(
-                    Node(id=nid, run_id=run_uuid, key=node_key, title=getattr(node, "title", node_key), status=NodeStatus.completed if status=="completed" else NodeStatus.failed, updated_at=datetime.now(timezone.utc))
+                    Node(
+                        id=nid,
+                        run_id=run_uuid,
+                        key=node_key,
+                        title=getattr(node, "title", node_key),
+                        status=NodeStatus.completed if status == "completed" else NodeStatus.failed,
+                        updated_at=now_end,
+                    )
+                )
+                # événement NODE_COMPLETED / NODE_FAILED
+                started = self._node_started_at.get(node_key)
+                dur_ms = (
+                    int((now_end - started).total_seconds() * 1000) if started else None
+                )
+                meta: Dict[str, Any] = {"duration_ms": dur_ms, "result": status}
+                message = json.dumps(
+                    {
+                        "run_id": str(run_uuid),
+                        "node_id": str(nid),
+                        "node_key": node_key,
+                        "meta": meta,
+                    },
+                    ensure_ascii=False,
+                )
+                level = "NODE_COMPLETED" if status == "completed" else "NODE_FAILED"
+                await self.storage.save_event(
+                    run_id=run_uuid,
+                    node_id=nid,
+                    level=level,
+                    message=message,
+                )
+        async def _runner():
+            final_status = RunStatus.failed
+            try:
+                res = await run_graph(
+                    dag,
+                    self.storage,
+                    self.run_id,
+                    dry_run=dry_run,
+                    on_node_start=on_start,
+                    on_node_end=on_end,
+                    pause_event=self._pause_event,
+                    skip_nodes=self._skip,
+                    overrides=self._overrides,
+                )
+                if res.get("status") == "succeeded":
+                    final_status = RunStatus.completed
+            except Exception:
+                final_status = RunStatus.failed
+                raise
+            finally:
+                ended = datetime.now(timezone.utc)
+                await self.storage.save_run(
+                    Run(
+                        id=run_uuid,
+                        title=plan_spec.get("title") or plan_id,
+                        status=final_status,
+                        started_at=now,
+                        ended_at=ended,
+                    )
                 )
 
-        self._task = asyncio.create_task(
-            run_graph(
-                dag,
-                self.storage,
-                self.run_id,
-                dry_run=dry_run,
-                on_node_start=on_start,
-                on_node_end=on_end,
-                pause_event=self._pause_event,
-                skip_nodes=self._skip,
-                overrides=self._overrides,
-            )
-        )
+        self._task = asyncio.create_task(_runner())
         return self.run_id
 
     async def wait(self) -> None:


### PR DESCRIPTION
## Résumé
- Enrichissement de l'orchestrateur pour enregistrer les nœuds avec un événement `NODE_COMPLETED`/`NODE_FAILED` incluant la durée et le résultat.
- Finalisation automatique des runs avec statut et horodatage de fin.
- Publication des métadonnées de nœud dans l'API runner via le champ `meta`.

## Tests
- `pytest -q backend/tests/api/test_tasks_e2e.py::test_create_and_follow_task backend/tests/api/test_node_completed_meta.py::test_node_completed_has_meta`


------
https://chatgpt.com/codex/tasks/task_e_68ba0683b9a48327aa2001e66285419f