### PR TITLE
fix: configuration CORS via ALLOWED_ORIGINS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,7 +138,8 @@ ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 API_KEY=DaSnC6jaDXoXnnd
 
 # CORS
-ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://192.168.1.50:3000
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
 
 STORAGE_ORDER=file,pg
 

--- a/backend/api/fastapi_app/app.py
+++ b/backend/api/fastapi_app/app.py
@@ -116,17 +116,18 @@ if metrics_enabled():
 # Origines autorisées via variable d'env ALLOWED_ORIGINS (CSV)
 ALLOWED_ORIGINS = [
     origin.strip()
-    for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173").split(",")
+    for origin in os.getenv(
+        "ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173"
+    ).split(",")
     if origin.strip()
 ]
-CORS_ALLOW_METHODS = ["GET", "POST", "PATCH", "OPTIONS"]
-CORS_ALLOW_HEADERS = ["Content-Type", "Authorization", "X-API-Key", "X-Request-ID", "X-Role"]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=CORS_ALLOW_METHODS,
-    allow_headers=CORS_ALLOW_HEADERS,
+    allow_methods=["*"],
+    allow_headers=["*"],
+    expose_headers=["Link", "X-Total-Count"],
 )
 
 # -------- Routes --------


### PR DESCRIPTION
## Summary
- configure FastAPI CORS middleware using `ALLOWED_ORIGINS`
- document default origins and API URL in example env

## Testing
- `pytest -q backend/tests/api/test_cors.py::test_cors_options_localhost`


------
https://chatgpt.com/codex/tasks/task_e_68ba06e5b9a083279f3b691c4f81ef36