### PR TITLE
refactor: rediriger les imports vers backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SUP_DESC            ?= "Décomposer la production d'un rapport de 80 pages."
 SUP_ACCEPTANCE      ?= --acceptance "structure claire" --acceptance "pas de cycles"
 
 # API
-API_MODULE          ?= api.fastapi_app.app:app
+API_MODULE          ?= backend.api.fastapi_app.app:app
 API_HOST            ?= 0.0.0.0
 API_PORT            ?= 8000
 

--- a/backend/api/database/models.py
+++ b/backend/api/database/models.py
@@ -3,11 +3,8 @@
 from sqlmodel import SQLModel
 
 from core.storage.db_models import Artifact, Event, Node, Run, Feedback
-from app.models.task import Task
-from app.models.plan import Plan
-from app.models.plan_review import PlanReview
-from app.models.assignment import Assignment
-from api.fastapi_app.models.agent import Agent, AgentTemplate, AgentModelsMatrix
+from backend.core.models import Task, Plan, PlanReview, Assignment
+from backend.api.fastapi_app.models.agent import Agent, AgentTemplate, AgentModelsMatrix
 
 # Les tests s’attendent à un objet ayant un attribut `metadata`.
 Base = SQLModel

--- a/backend/api/fastapi_app/main.py
+++ b/backend/api/fastapi_app/main.py
@@ -1,7 +1,7 @@
 """Entry point for FastAPI application.
 
 This module exposes the FastAPI ``app`` instance so tests and
-runners can import it using ``from api.fastapi_app.main import app``.
+runners can import it using ``from backend.api.fastapi_app.main import app``.
 """
 
 from .app import app

--- a/backend/api/fastapi_app/routes/agents.py
+++ b/backend/api/fastapi_app/routes/agents.py
@@ -19,7 +19,7 @@ from ..schemas_base import (
 from ..schemas.prompting import RecruitRequest, RecruitResponse
 from ..services.recruit_service import RecruitService
 from ..models.agent import Agent, AgentModelsMatrix
-from app.utils.pagination import PaginationParams, pagination_params, set_pagination_headers
+from backend.api.utils.pagination import PaginationParams, pagination_params, set_pagination_headers
 from ..ordering import apply_order
 
 router = APIRouter(prefix="/agents", tags=["agents"], dependencies=[Depends(strict_api_key_auth)])

--- a/backend/api/fastapi_app/routes/artifacts.py
+++ b/backend/api/fastapi_app/routes/artifacts.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import get_session, settings, strict_api_key_auth
 from ..schemas_base import Page, ArtifactOut
-from app.utils.pagination import (
+from backend.api.utils.pagination import (
     PaginationParams,
     pagination_params,
     set_pagination_headers,

--- a/backend/api/fastapi_app/routes/events.py
+++ b/backend/api/fastapi_app/routes/events.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import get_session, strict_api_key_auth, cap_date_range
 from ..schemas_base import Page, EventOut
-from app.utils.pagination import (
+from backend.api.utils.pagination import (
     PaginationParams,
     pagination_params,
     set_pagination_headers,

--- a/backend/api/fastapi_app/routes/feedbacks.py
+++ b/backend/api/fastapi_app/routes/feedbacks.py
@@ -17,7 +17,7 @@ from ..deps import (
     to_tz,
 )
 from ..schemas_base import Page
-from app.utils.pagination import (
+from backend.api.utils.pagination import (
     PaginationParams,
     pagination_params,
     set_pagination_headers,

--- a/backend/api/fastapi_app/routes/node_actions.py
+++ b/backend/api/fastapi_app/routes/node_actions.py
@@ -6,9 +6,9 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request
 
-from api.fastapi_app.deps import strict_api_key_auth
-from app.schemas.node_actions import NodeActionRequest, NodeActionResponse
-from app.services import orchestrator_adapter
+from backend.api.fastapi_app.deps import strict_api_key_auth
+from backend.api.schemas.node_actions import NodeActionRequest, NodeActionResponse
+from backend.orchestrator import orchestrator_adapter
 
 router = APIRouter(prefix="/nodes", tags=["nodes"], dependencies=[Depends(strict_api_key_auth)])
 

--- a/backend/api/fastapi_app/routes/nodes.py
+++ b/backend/api/fastapi_app/routes/nodes.py
@@ -14,7 +14,7 @@ from ..deps import (
 )
 from ..schemas_base import Page, NodeOut
 from ..schemas.feedbacks import FeedbackOut
-from app.utils.pagination import (
+from backend.api.utils.pagination import (
     PaginationParams,
     pagination_params,
     set_pagination_headers,

--- a/backend/api/fastapi_app/routes/plans.py
+++ b/backend/api/fastapi_app/routes/plans.py
@@ -6,11 +6,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.plan import Plan, PlanStatus
-from app.models.plan_review import PlanReview
-from app.models.assignment import Assignment
-from app.schemas.assignment import AssignmentsPayload, AssignmentsResponse
-from api.fastapi_app.deps import get_db, strict_api_key_auth
+from backend.core.models import Plan, PlanStatus
+from backend.core.models import PlanReview
+from backend.core.models import Assignment
+from backend.api.schemas.assignment import AssignmentsPayload, AssignmentsResponse
+from backend.api.fastapi_app.deps import get_db, strict_api_key_auth
 
 router = APIRouter(
     prefix="/plans",

--- a/backend/api/fastapi_app/routes/qa_report.py
+++ b/backend/api/fastapi_app/routes/qa_report.py
@@ -7,10 +7,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.fastapi_app.deps import get_session
-from api.fastapi_app.models.run import Run
-from api.fastapi_app.models.node import Node
-from api.fastapi_app.models.feedback import Feedback
+from backend.api.fastapi_app.deps import get_session
+from backend.api.fastapi_app.models.run import Run
+from backend.api.fastapi_app.models.node import Node
+from backend.api.fastapi_app.models.feedback import Feedback
 
 router = APIRouter(prefix="/runs", tags=["qa"])
 

--- a/backend/api/fastapi_app/routes/runs.py
+++ b/backend/api/fastapi_app/routes/runs.py
@@ -24,7 +24,7 @@ from ..schemas_base import (
     DagOut,
 )
 from ..schemas.feedbacks import FeedbackOut
-from app.utils.pagination import (
+from backend.api.utils.pagination import (
     PaginationParams,
     pagination_params,
     set_pagination_headers,

--- a/backend/api/fastapi_app/routes/tasks.py
+++ b/backend/api/fastapi_app/routes/tasks.py
@@ -18,15 +18,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..deps import strict_api_key_auth, get_session
 from ..schemas_base import TaskRequest, TaskAcceptedResponse
 
-from app.models.task import Task, TaskStatus
-from app.schemas.task import TaskCreate, TaskOut
+from backend.core.models import Task, TaskStatus
+from backend.api.schemas.task import TaskCreate, TaskOut
 
-from app.models.plan import Plan, PlanStatus
-from app.schemas.plan import PlanCreateResponse
-from app.services.supervisor import generate_plan
-from app.services import orchestrator_adapter
+from backend.core.models import Plan, PlanStatus
+from backend.api.schemas.plan import PlanCreateResponse
+from backend.core.services.supervisor import generate_plan
+from backend.orchestrator import orchestrator_adapter
 
-from core.services.orchestrator_service import schedule_run
+from backend.core.services.orchestrator_service import schedule_run
 
 router = APIRouter(
     prefix="/tasks",

--- a/backend/api/schemas/__init__.py
+++ b/backend/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Schémas Pydantic exposés pour l'API."""

--- a/backend/api/schemas/assignment.py
+++ b/backend/api/schemas/assignment.py
@@ -1,0 +1,1 @@
+from backend.app.schemas.assignment import *  # noqa: F401,F403

--- a/backend/api/schemas/node_actions.py
+++ b/backend/api/schemas/node_actions.py
@@ -1,0 +1,1 @@
+from backend.app.schemas.node_actions import *  # noqa: F401,F403

--- a/backend/api/schemas/plan.py
+++ b/backend/api/schemas/plan.py
@@ -1,0 +1,1 @@
+from backend.app.schemas.plan import *  # noqa: F401,F403

--- a/backend/api/schemas/task.py
+++ b/backend/api/schemas/task.py
@@ -1,0 +1,1 @@
+from backend.app.schemas.task import *  # noqa: F401,F403

--- a/backend/api/utils/__init__.py
+++ b/backend/api/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilitaires pour l'API."""

--- a/backend/api/utils/pagination.py
+++ b/backend/api/utils/pagination.py
@@ -1,0 +1,1 @@
+from backend.app.utils.pagination import *  # noqa: F401,F403

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -2,8 +2,8 @@ from sqlmodel import SQLModel
 
 # Import des modèles pour qu'ils soient enregistrés auprès de SQLModel
 # Import minimal models so SQLModel.metadata is populated
-from app.models.plan import Plan  # noqa: F401
-from app.models.task import Task  # noqa: F401
-from api.fastapi_app.models.agent import Agent, AgentTemplate, AgentModelsMatrix  # noqa: F401
+from backend.core.models import Plan  # noqa: F401
+from backend.core.models import Task  # noqa: F401
+from backend.api.fastapi_app.models.agent import Agent, AgentTemplate, AgentModelsMatrix  # noqa: F401
 
 Base = SQLModel

--- a/backend/app/schemas/plan.py
+++ b/backend/app/schemas/plan.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from app.models.plan import PlanStatus
+from backend.core.models import PlanStatus
 
 
 class PlanNode(BaseModel):

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from app.models.task import TaskStatus
+from backend.core.models import TaskStatus
 
 
 class TaskCreate(BaseModel):

--- a/backend/app/services/supervisor.py
+++ b/backend/app/services/supervisor.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
-from app.models.task import Task
-from app.models.plan import PlanStatus
-from app.schemas.plan import (
+from backend.core.models import Task
+from backend.core.models import PlanStatus
+from backend.api.schemas.plan import (
     PlanNode,
     PlanGraph,
     PlanGenerationResult,

--- a/backend/core/models/__init__.py
+++ b/backend/core/models/__init__.py
@@ -1,0 +1,13 @@
+from backend.app.models.task import Task, TaskStatus
+from backend.app.models.plan import Plan, PlanStatus
+from backend.app.models.plan_review import PlanReview
+from backend.app.models.assignment import Assignment
+
+__all__ = [
+    "Task",
+    "TaskStatus",
+    "Plan",
+    "PlanStatus",
+    "PlanReview",
+    "Assignment",
+]

--- a/backend/core/services/__init__.py
+++ b/backend/core/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services de la couche métier."""

--- a/backend/core/services/supervisor.py
+++ b/backend/core/services/supervisor.py
@@ -1,0 +1,3 @@
+from backend.app.services.supervisor import generate_plan  # noqa: F401
+
+__all__ = ["generate_plan"]

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -10,7 +10,7 @@ from sqlmodel import SQLModel
 # Modèles existants
 from core.storage.db_models import Run, Node, Artifact, Event  # noqa: F401
 # Modèles de l'application
-from app.db.base import Base  # noqa: F401
+from backend.api.database.models import Base  # noqa: F401
 from dotenv import load_dotenv
 load_dotenv()  # charge le .env tôt
 

--- a/backend/orchestrator/hooks/qa_reviewer.py
+++ b/backend/orchestrator/hooks/qa_reviewer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from core.llm import call_json  # doit retourner un dict JSON
-from api.fastapi_app.clients.feedbacks import create_feedback  # POST /feedbacks
+from backend.api.fastapi_app.clients.feedbacks import create_feedback  # POST /feedbacks
 
 CHECKLISTS_ROOT = Path("quality/checklists")
 CHECKLISTS_ALIAS = CHECKLISTS_ROOT / "latest"

--- a/backend/orchestrator/orchestrator_adapter.py
+++ b/backend/orchestrator/orchestrator_adapter.py
@@ -1,0 +1,1 @@
+from backend.app.services.orchestrator_adapter import *  # noqa: F401,F403

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -13,11 +13,11 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import delete, insert
 
 # --- importe l'app et les deps ---
-from api.fastapi_app.app import app
-from api.fastapi_app import deps as api_deps  # <-- contient get_db et (probablement) les deps d'auth
+from backend.api.fastapi_app.app import app
+from backend.api.fastapi_app import deps as api_deps  # <-- contient get_db et (probablement) les deps d'auth
 
 # --- importe tes modèles & Base ---
-from api.database.models import Base, Run, Node, Artifact, Event
+from backend.api.database.models import Base, Run, Node, Artifact, Event
 
 
 # ---------- Engine & Session de test (SQLite fichier) ----------

--- a/backend/tests/api/fastapi/test_feedbacks_api.py
+++ b/backend/tests/api/fastapi/test_feedbacks_api.py
@@ -1,7 +1,7 @@
 import uuid
 import pytest
 
-from api.fastapi_app import deps
+from backend.api.fastapi_app import deps
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_agents_api_more.py
+++ b/backend/tests/api/test_agents_api_more.py
@@ -4,7 +4,7 @@ import datetime as dt
 import pytest
 from sqlalchemy import insert
 
-from api.fastapi_app.models.agent import Agent, AgentModelsMatrix
+from backend.api.fastapi_app.models.agent import Agent, AgentModelsMatrix
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_agents_recruit_api.py
+++ b/backend/tests/api/test_agents_recruit_api.py
@@ -1,6 +1,6 @@
 import pytest
-from api.fastapi_app import deps
-from api.fastapi_app.routes import agents as agents_routes
+from backend.api.fastapi_app import deps
+from backend.api.fastapi_app.routes import agents as agents_routes
 
 
 class DummyRecruit:

--- a/backend/tests/api/test_cors_preview.py
+++ b/backend/tests/api/test_cors_preview.py
@@ -13,7 +13,7 @@ async def test_cors_preview(monkeypatch):
     original = os.getenv("ALLOWED_ORIGINS")
     monkeypatch.setenv("ALLOWED_ORIGINS", f"{origin},{other_origin}")
 
-    import api.fastapi_app.app as app_module
+    import backend.api.fastapi_app.app as app_module
     importlib.reload(app_module)
     app = app_module.app
 

--- a/backend/tests/api/test_metrics.py
+++ b/backend/tests/api/test_metrics.py
@@ -11,9 +11,9 @@ async def _create_client_and_metrics(monkeypatch, enabled: str):
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test_metrics.db")
 
     import core.telemetry.metrics as metrics
-    import api.fastapi_app.deps as deps
-    import api.fastapi_app.middleware.metrics as mw_metrics
-    import api.fastapi_app.app as app_module
+    import backend.api.fastapi_app.deps as deps
+    import backend.api.fastapi_app.middleware.metrics as mw_metrics
+    import backend.api.fastapi_app.app as app_module
 
     importlib.reload(metrics)
     importlib.reload(deps)

--- a/backend/tests/api/test_node_actions.py
+++ b/backend/tests/api/test_node_actions.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 from fastapi import HTTPException
 
-from app.services import orchestrator_adapter
+from backend.orchestrator import orchestrator_adapter
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_task_start.py
+++ b/backend/tests/api/test_task_start.py
@@ -3,8 +3,8 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.task import Task, TaskStatus
-from app.models.plan import Plan, PlanStatus
+from backend.core.models import Task, TaskStatus
+from backend.core.models import Plan, PlanStatus
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_tasks_plan.py
+++ b/backend/tests/api/test_tasks_plan.py
@@ -3,11 +3,11 @@ import uuid
 import pytest
 from sqlalchemy import insert, select
 
-from app.models.task import Task, TaskStatus
-from app.models.plan import Plan, PlanStatus
-from app.models.plan_review import PlanReview
-from app.schemas.plan import PlanGraph, PlanNode, PlanGenerationResult
-import api.fastapi_app.routes.tasks as tasks_routes
+from backend.core.models import Task, TaskStatus
+from backend.core.models import Plan, PlanStatus
+from backend.core.models import PlanReview
+from backend.api.schemas.plan import PlanGraph, PlanNode, PlanGenerationResult
+import backend.api.fastapi_app.routes.tasks as tasks_routes
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_tasks_validation.py
+++ b/backend/tests/api/test_tasks_validation.py
@@ -15,7 +15,7 @@ async def test_rate_limit_returns_429(async_client, monkeypatch):
         return uuid.uuid4()
 
     monkeypatch.setattr(
-        "api.fastapi_app.routes.tasks.schedule_run", fake_schedule_run
+        "backend.api.fastapi_app.routes.tasks.schedule_run", fake_schedule_run
     )
 
     payload = {"title": "R", "task_spec": {"type": "demo"}}

--- a/backend/tests/security/test_rbac.py
+++ b/backend/tests/security/test_rbac.py
@@ -1,5 +1,5 @@
 import pytest
-from api.fastapi_app import deps
+from backend.api.fastapi_app import deps
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_agents_model.py
+++ b/backend/tests/test_agents_model.py
@@ -3,7 +3,7 @@ import pytest
 from sqlalchemy import select, delete
 from sqlalchemy.exc import IntegrityError
 
-from api.fastapi_app.models.agent import Agent
+from backend.api.fastapi_app.models.agent import Agent
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_feedbacks_route.py
+++ b/backend/tests/test_feedbacks_route.py
@@ -3,9 +3,9 @@ import datetime as dt
 import pytest
 from sqlalchemy import insert, delete
 
-from api.fastapi_app.models.run import Run
-from api.fastapi_app.models.node import Node
-from api.fastapi_app.models.feedback import Feedback
+from backend.api.fastapi_app.models.run import Run
+from backend.api.fastapi_app.models.node import Node
+from backend.api.fastapi_app.models.feedback import Feedback
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_qa_report.py
+++ b/backend/tests/test_qa_report.py
@@ -3,9 +3,9 @@ import uuid
 import pytest
 from sqlalchemy import insert, delete
 
-from api.fastapi_app.models.run import Run
-from api.fastapi_app.models.node import Node
-from api.fastapi_app.models.feedback import Feedback
+from backend.api.fastapi_app.models.run import Run
+from backend.api.fastapi_app.models.node import Node
+from backend.api.fastapi_app.models.feedback import Feedback
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -6,8 +6,8 @@ from httpx import AsyncClient, ASGITransport
 from asgi_lifespan import LifespanManager
 import sentry_sdk
 
-from api.fastapi_app.app import app
-from api.fastapi_app.observability import init_sentry, SentryContextMiddleware
+from backend.api.fastapi_app.app import app
+from backend.api.fastapi_app.observability import init_sentry, SentryContextMiddleware
 from orchestrator import executor
 from core.planning.task_graph import PlanNode, TaskGraph
 

--- a/scripts/seed_agents.py
+++ b/scripts/seed_agents.py
@@ -7,8 +7,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "backend"))
 
 from sqlalchemy import select
 
-from api.fastapi_app.models.agent import AgentTemplate, AgentModelsMatrix
-from api.fastapi_app.deps import get_sessionmaker
+from backend.api.fastapi_app.models.agent import AgentTemplate, AgentModelsMatrix
+from backend.api.fastapi_app.deps import get_sessionmaker
 
 
 async def seed_templates(path: str = "seeds/agent_templates.json") -> None:

--- a/scripts/validate_tasks_integration.sh
+++ b/scripts/validate_tasks_integration.sh
@@ -77,7 +77,7 @@ fi
 
 # ========= Étape 2 : Lancement API (uvicorn) =========
 log "Lancement de l’API (uvicorn) en arrière-plan…"
-UVICORN_CMD=(uvicorn api.fastapi_app.app:app --host "$API_HOST" --port "$API_PORT")
+UVICORN_CMD=(uvicorn backend.api.fastapi_app.app:app --host "$API_HOST" --port "$API_PORT")
 if [ -f ".env" ]; then
   UVICORN_CMD+=(--env-file .env)
 fi


### PR DESCRIPTION
## Résumé
- Remplacement des anciens chemins `app.*` et `api.fastapi_app.*` par `backend.*`
- Ajout de modules de compatibilité (`backend.core.models`, `backend.api.schemas`, etc.)
- Mise à jour des scripts et de la configuration pour la nouvelle arborescence

## Tests
- `pytest`
- `PYTHONPATH=backend python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68ba07b6d2648327a92fb06b62aaac2d