### PR TITLE
Expose LLM metadata at top level

### DIFF
--- a/backend/orchestrator/api_runner.py
+++ b/backend/orchestrator/api_runner.py
@@ -193,12 +193,15 @@ async def run_task(
         if meta:
             meta_payload.update(meta)
 
+        # Expose LLM metadata à la fois à la racine et dans "meta" pour la
+        # rétro‑compatibilité des consommateurs d'événements.
         payload = {
             "run_id": run_id,
             "node_id": str(node_id) if node_id else None,
             "node_key": node_key,
             "status": node_status.value.upper(),
             "checksum": getattr(node, "checksum", None),
+            **meta_payload,
             "meta": meta_payload,
         }
 


### PR DESCRIPTION
## Summary
- expose LLM metadata fields at root of NODE_COMPLETED events for easier access

## Testing
- `pytest backend/tests/test_llm_meta_fallback_fs.py::test_llm_meta_fallback_fs -q`
- `pytest backend/tests/api/fastapi/test_tasks_meta_e2e.py::test_events_include_llm_metadata -q` *(fails: missing NODE_COMPLETED)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a70ad30832798ecc64e6d1d805f