### PR TITLE
fix: sécurise la création d'agents

### DIFF
--- a/backend/api/fastapi_app/models/agent.py
+++ b/backend/api/fastapi_app/models/agent.py
@@ -17,7 +17,7 @@ class Agent(SQLModel, table=True):
         default_factory=uuid.uuid4,
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
-    name: str = Field(sa_column=Column(Text, nullable=False, unique=True))
+    name: str = Field(sa_column=Column(Text, nullable=False))
     role: str = Field(sa_column=Column(Text, nullable=False))
     domain: str = Field(sa_column=Column(Text, nullable=False))
     prompt_system: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
@@ -50,7 +50,7 @@ class Agent(SQLModel, table=True):
     __table_args__ = (
         Index("ix_agents_role_domain", "role", "domain"),
         Index("ix_agents_is_active", "is_active"),
-        UniqueConstraint("name", name="uq_agents_name"),
+        UniqueConstraint("name", "role", "domain", name="uq_agents_name_role_domain"),
     )
 
 

--- a/backend/migrations/versions/c894e2b67dc8_agents_unique_name_role_domain.py
+++ b/backend/migrations/versions/c894e2b67dc8_agents_unique_name_role_domain.py
@@ -1,0 +1,32 @@
+"""agents unique name-role-domain
+
+Revision ID: c894e2b67dc8
+Revises: 129a037b632d
+Create Date: 2025-09-05 07:36:02.926573
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c894e2b67dc8'
+down_revision: Union[str, Sequence[str], None] = '129a037b632d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint("uq_agents_name", "agents", type_="unique")
+    op.create_unique_constraint(
+        "uq_agents_name_role_domain", "agents", ["name", "role", "domain"]
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("uq_agents_name_role_domain", "agents", type_="unique")
+    op.create_unique_constraint("uq_agents_name", "agents", ["name"])

--- a/backend/tests/test_agents_model.py
+++ b/backend/tests/test_agents_model.py
@@ -33,7 +33,7 @@ async def test_unique_agent_name(db_session):
     await db_session.commit()
 
     a1 = Agent(name="dup", role="manager", domain="frontend")
-    a2 = Agent(name="dup", role="manager", domain="backend")
+    a2 = Agent(name="dup", role="manager", domain="frontend")
     db_session.add(a1)
     await db_session.commit()
     db_session.add(a2)


### PR DESCRIPTION
## Résumé
- contrôle l'existence d'un agent actif avant création
- ajoute une contrainte d'unicité sur (name, role, domain)
- adapte les tests de modèle d'agent

## Test
- `alembic -c backend/migrations/alembic.ini upgrade head` *(échec: JSONB non supporté en SQLite)*
- `make test -j` *(échec: 5 tests en erreur)*

------
https://chatgpt.com/codex/tasks/task_e_68ba928f905c8327b184dcd2a00360d1