### PR TITLE
Purge de agent_models_matrix avant chaque test

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
 
+import pytest
+import sqlalchemy as sa
+
 try:
     from tests.api.conftest import *  # noqa: F401,F403
     from tests.api.conftest import _dispose_engine  # noqa: F401
@@ -10,3 +13,10 @@ except ImportError:  # pragma: no cover - fallback when package not on path
         sys.path.insert(0, str(ROOT))
     from tests.api.conftest import *  # noqa: F401,F403
     from tests.api.conftest import _dispose_engine  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+async def _empty_matrix(db_session):
+    await db_session.execute(sa.text("DELETE FROM agent_models_matrix"))
+    await db_session.commit()
+    yield


### PR DESCRIPTION
## Résumé
- Vide automatiquement la table `agent_models_matrix` avant chaque test pour éviter les violations d'unicité

## Tests
- `pytest backend/tests/test_agents_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba929add748327b8048e0ec50b195d