### PR TITLE
fix(api,cors): standardize ALLOWED_ORIGINS and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,8 +138,8 @@ ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 API_KEY=DaSnC6jaDXoXnnd
 
 # CORS
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
-API_URL=http://127.0.0.1:8000
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173  # Origines autorisées en dev
+API_URL=http://127.0.0.1:8000  # URL publique de l'API
 STORAGE_ORDER=file,pg
 
 # Variables Dashboard (Vite)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ used for testing.
 ```
 API_KEY=test-key
 DATABASE_URL=sqlite+aiosqlite:///./app.db
-ALLOWED_ORIGINS=
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+API_URL=http://127.0.0.1:8000
 ```
 
 2. Start the API with Uvicorn (loads variables from `.env`):
@@ -23,7 +24,7 @@ make api-run
 3. Query the API (replace the API key if you changed it):
 
 ```
-curl -H "X-API-Key: test-key" http://localhost:8000/runs
+curl -H "X-API-Key: test-key" http://127.0.0.1:8000/runs
 ```
 
 > **Note :** Après un `git pull`, lancez `make deps-update` pour installer les nouvelles dépendances.
@@ -31,7 +32,7 @@ curl -H "X-API-Key: test-key" http://localhost:8000/runs
 Pour lister les événements d'un run spécifique :
 
 ```
-curl -H "X-API-Key: test-key" "http://localhost:8000/events?run_id=<RUN_ID>"
+curl -H "X-API-Key: test-key" "http://127.0.0.1:8000/events?run_id=<RUN_ID>"
 ```
 
 ### Feedbacks
@@ -39,7 +40,7 @@ curl -H "X-API-Key: test-key" "http://localhost:8000/events?run_id=<RUN_ID>"
 Créer un feedback manuel :
 
 ```
-curl -X POST "http://localhost:8000/feedbacks" \
+curl -X POST "http://127.0.0.1:8000/feedbacks" \
  -H 'Content-Type: application/json' \
  -H 'X-API-Key: test-key' -H 'X-Request-ID: demo-1' -H 'X-Role: editor' \
  -d '{
@@ -109,7 +110,7 @@ Variables d'environnement minimales :
 ```
 API_KEY=test-key
 DATABASE_URL=sqlite+aiosqlite:///./app.db
-API_URL=http://localhost:8000
+API_URL=http://127.0.0.1:8000
 ```
 
 ### Étapes (local)
@@ -173,7 +174,8 @@ Les variables essentielles sont définies dans `.env` (voir [`.env.example`](.en
 
 - `API_KEY` — clé requise sur toutes les requêtes API.
 - `DATABASE_URL` — URL de connexion asynchrone à la base.
-- `ALLOWED_ORIGINS` — origines autorisées pour CORS.
+- `ALLOWED_ORIGINS` — origines autorisées pour CORS (par défaut `http://localhost:3000,http://localhost:5173`).
+- `API_URL` — URL de base publique de l'API.
 - `LLM_DEFAULT_PROVIDER` et `LLM_DEFAULT_MODEL` — fournisseur et modèle par défaut des agents.
 - `FEEDBACK_CRITICAL_THRESHOLD` — seuil (0-100) déclenchant un badge critique (défaut 60).
 - `FEEDBACK_REVIEW_TIMEOUT_MS` — délai d'attente de l'auto‑review en ms (défaut 3500).
@@ -209,7 +211,7 @@ Décommentez le bloc correspondant à votre contexte pour obtenir une configurat
   ```
   curl -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
        -d '{"title":"Demo","task_spec":{"type":"demo"}}' \
-       http://localhost:8000/tasks
+       http://127.0.0.1:8000/tasks
   ```
 
 - **CLI** : lancer l'orchestrateur en générant le plan :
@@ -258,7 +260,7 @@ make db-upgrade
 scrape_configs:
   - job_name: 'crew_ia_api'
     static_configs:
-      - targets: ['localhost:8000']
+      - targets: ['127.0.0.1:8000']
     metrics_path: /metrics
 ```
 

--- a/backend/api/fastapi_app/app.py
+++ b/backend/api/fastapi_app/app.py
@@ -114,13 +114,7 @@ if metrics_enabled():
 
 # CORS
 # Origines autorisées via variable d'env ALLOWED_ORIGINS (CSV)
-ALLOWED_ORIGINS = [
-    origin.strip()
-    for origin in os.getenv(
-        "ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173"
-    ).split(",")
-    if origin.strip()
-]
+ALLOWED_ORIGINS = settings.allowed_origins
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,

--- a/backend/api/fastapi_app/deps.py
+++ b/backend/api/fastapi_app/deps.py
@@ -87,7 +87,10 @@ class Settings(BaseSettings):
         default="sqlite+aiosqlite:///./app.db", alias="DATABASE_URL"
     )
     api_key: str = Field(default="test-key", alias="API_KEY")
-    allowed_origins_raw: str = Field(default="", alias="ALLOWED_ORIGINS")
+    allowed_origins_raw: str = Field(
+        default="http://localhost:3000,http://localhost:5173",
+        alias="ALLOWED_ORIGINS",
+    )
     artifacts_dir: str = Field(default=".runs", alias="ARTIFACTS_DIR")  # ← ajouté
 
     @property

--- a/backend/tests/api/test_cors_preview.py
+++ b/backend/tests/api/test_cors_preview.py
@@ -13,6 +13,9 @@ async def test_cors_preview(monkeypatch):
     original = os.getenv("ALLOWED_ORIGINS")
     monkeypatch.setenv("ALLOWED_ORIGINS", f"{origin},{other_origin}")
 
+    import backend.api.fastapi_app.deps as deps
+    deps.get_settings.cache_clear()
+    deps.settings = deps.get_settings()
     import backend.api.fastapi_app.app as app_module
     importlib.reload(app_module)
     app = app_module.app
@@ -42,4 +45,6 @@ async def test_cors_preview(monkeypatch):
         monkeypatch.setenv("ALLOWED_ORIGINS", original)
     else:
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    deps.get_settings.cache_clear()
+    deps.settings = deps.get_settings()
     importlib.reload(app_module)


### PR DESCRIPTION
## Summary
- centraliser la configuration CORS via `ALLOWED_ORIGINS`
- documenter `ALLOWED_ORIGINS` et `API_URL` dans l'exemple d'environnement et le README
- ajuster le test de prévisualisation CORS

## Testing
- `pytest -k cors`
- `pre-commit run --files .env.example README.md backend/api/fastapi_app/app.py backend/api/fastapi_app/deps.py backend/tests/api/test_cors_preview.py` *(failure: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68babf1c36308327adab17317ad76001