### PR TITLE
fix(api,cors): standardize ALLOWED_ORIGINS and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,9 +137,9 @@ ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 # Auth API  (⚠️ comme il y a un # dans la valeur, on MET DES GUILLEMETS)
 API_KEY=DaSnC6jaDXoXnnd
 
-# CORS
+# CORS (défaut: Next 3000 & Vite 5173)
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
-API_URL=http://127.0.0.1:8000
+API_URL=http://localhost:8000
 STORAGE_ORDER=file,pg
 
 # Variables Dashboard (Vite)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Variables d'environnement minimales :
 API_KEY=test-key
 DATABASE_URL=sqlite+aiosqlite:///./app.db
 API_URL=http://localhost:8000
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 ```
 
 ### Étapes (local)

--- a/backend/api/fastapi_app/app.py
+++ b/backend/api/fastapi_app/app.py
@@ -113,17 +113,10 @@ if metrics_enabled():
         )
 
 # CORS
-# Origines autorisées via variable d'env ALLOWED_ORIGINS (CSV)
-ALLOWED_ORIGINS = [
-    origin.strip()
-    for origin in os.getenv(
-        "ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173"
-    ).split(",")
-    if origin.strip()
-]
+# Origines autorisées via la variable d'environnement ALLOWED_ORIGINS (CSV)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=ALLOWED_ORIGINS,
+    allow_origins=settings.allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/api/fastapi_app/deps.py
+++ b/backend/api/fastapi_app/deps.py
@@ -87,7 +87,10 @@ class Settings(BaseSettings):
         default="sqlite+aiosqlite:///./app.db", alias="DATABASE_URL"
     )
     api_key: str = Field(default="test-key", alias="API_KEY")
-    allowed_origins_raw: str = Field(default="", alias="ALLOWED_ORIGINS")
+    allowed_origins_raw: str = Field(
+        default="http://localhost:3000,http://localhost:5173",
+        alias="ALLOWED_ORIGINS",
+    )
     artifacts_dir: str = Field(default=".runs", alias="ARTIFACTS_DIR")  # ← ajouté
 
     @property

--- a/backend/tests/api/test_cors_preview.py
+++ b/backend/tests/api/test_cors_preview.py
@@ -13,6 +13,8 @@ async def test_cors_preview(monkeypatch):
     original = os.getenv("ALLOWED_ORIGINS")
     monkeypatch.setenv("ALLOWED_ORIGINS", f"{origin},{other_origin}")
 
+    import backend.api.fastapi_app.deps as deps_module
+    importlib.reload(deps_module)
     import backend.api.fastapi_app.app as app_module
     importlib.reload(app_module)
     app = app_module.app
@@ -42,4 +44,5 @@ async def test_cors_preview(monkeypatch):
         monkeypatch.setenv("ALLOWED_ORIGINS", original)
     else:
         monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    importlib.reload(deps_module)
     importlib.reload(app_module)


### PR DESCRIPTION
## Summary
- centraliser la configuration CORS sur `ALLOWED_ORIGINS`
- documenter `ALLOWED_ORIGINS` et `API_URL`
- ajuster le test CORS pour recharger les settings

## Testing
- `pytest -k cors`


------
https://chatgpt.com/codex/tasks/task_e_68babf1c36308327adab17317ad76001