### PR TITLE
Renforce l'authentification et traçabilité des runs

### DIFF
--- a/backend/api/fastapi_app/deps.py
+++ b/backend/api/fastapi_app/deps.py
@@ -188,28 +188,22 @@ async def require_request_id(x_request_id: str | None = Header(default=None, ali
     return x_request_id
 
 
-# Auth API key ---------------------------------------------------------------
+# --- Auth API key ---------------------------------------------------------------
 def require_api_key(
-    request: Request, x_api_key: str | None = Header(default=None, alias="X-API-Key")
+    request: Request,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
 ) -> bool:
-    """Vérifie la clé API.
-
-    - Les requêtes ``OPTIONS`` (preflight CORS) sont toujours autorisées.
-    - L'endpoint ``/health`` est accessible sans authentification.
-    - Si un override est défini (tests), la vérification est ignorée.
     """
-
-    # Autoriser les preflight CORS
+    Vérifie la clé API.
+    - Les requêtes OPTIONS (preflight CORS) sont toujours autorisées.
+    - L'endpoint /health est accessible sans authentification.
+    """
+    # Autoriser preflight CORS
     if request.method == "OPTIONS":
         return True
-
     # Exempter /health
     if request.url.path == "/health":
         return True
-
-    if api_key_auth in request.app.dependency_overrides:
-        return True
-
     return _check_api_key(x_api_key)
 
 

--- a/backend/orchestrator/api_runner.py
+++ b/backend/orchestrator/api_runner.py
@@ -252,6 +252,7 @@ async def run_task(
                 status=final_status,
                 started_at=started,
                 ended_at=ended,
+                meta={"request_id": request_id},
             )
         )
         await event_publisher.emit(


### PR DESCRIPTION
## Résumé
- impose systématiquement la vérification de la clé API hors OPTIONS et `/health`
- conserve le `request_id` lors de la finalisation d'un run pour une meilleure traçabilité

## Tests
- `make test` *(échec : 3 tests échoués, 153 réussis)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9eb5f4a08327bd9af1b5b1b8d378