### PR TITLE
Enforce API auth and accelerate test runs

### DIFF
--- a/backend/api/fastapi_app/app.py
+++ b/backend/api/fastapi_app/app.py
@@ -126,23 +126,18 @@ app.add_middleware(
 
 # -------- Routes --------
 # Auth: toutes les routes sensibles exigent une clé API, /health reste public
+protected = [Depends(strict_api_key_auth)]
 app.include_router(health.router)
-app.include_router(runs.router, dependencies=[Depends(strict_api_key_auth)])
-app.include_router(nodes.router, dependencies=[Depends(strict_api_key_auth)])
-app.include_router(
-    artifacts.router_nodes, dependencies=[Depends(strict_api_key_auth)]
-)
-app.include_router(
-    artifacts.router_artifacts, dependencies=[Depends(strict_api_key_auth)]
-)
-app.include_router(events.router, dependencies=[Depends(strict_api_key_auth)])
-app.include_router(tasks.router, dependencies=[Depends(strict_api_key_auth)])
-app.include_router(
-    node_actions.router, dependencies=[Depends(strict_api_key_auth)]
-)
-app.include_router(plans.router, dependencies=[Depends(strict_api_key_auth)])
-app.include_router(agents.router, dependencies=[Depends(strict_api_key_auth)])
-app.include_router(feedbacks.router, dependencies=[Depends(strict_api_key_auth)])
+app.include_router(runs.router, dependencies=protected)
+app.include_router(nodes.router, dependencies=protected)
+app.include_router(artifacts.router_nodes, dependencies=protected)
+app.include_router(artifacts.router_artifacts, dependencies=protected)
+app.include_router(events.router, dependencies=protected)
+app.include_router(tasks.router, dependencies=protected)
+app.include_router(node_actions.router, dependencies=protected)
+app.include_router(plans.router, dependencies=protected)
+app.include_router(agents.router, dependencies=protected)
+app.include_router(feedbacks.router, dependencies=protected)
 app.include_router(qa_router)
 
 # Redirection vers Swagger

--- a/backend/api/fastapi_app/deps.py
+++ b/backend/api/fastapi_app/deps.py
@@ -207,16 +207,6 @@ def require_api_key(
     # Exempter /health
     if request.url.path == "/health":
         return True
-    # Bypass pour les tests utilisant dependency_overrides
-    try:
-        override_target = globals().get("api_key_auth", strict_api_key_auth)
-        if (
-            override_target in request.app.dependency_overrides
-            or strict_api_key_auth in request.app.dependency_overrides
-        ):
-            return True
-    except Exception:
-        pass
     return _check_api_key(x_api_key)
 
 

--- a/backend/orchestrator/api_runner.py
+++ b/backend/orchestrator/api_runner.py
@@ -186,7 +186,7 @@ async def run_task(
 
         if not meta:
             # micro‑retry: laisse le temps à l’exécuteur d’écrire le sidecar
-            await anyio.sleep(0.35)
+            await anyio.sleep(0 if os.getenv("FAST_TEST_RUN") == "1" else 0.35)
             meta = _read_llm_sidecar_fs(run_id, node_key) or {}
         duration_ms = int((ended - node_started_at.get(node_key, ended)).total_seconds() * 1000)
         meta_payload: Dict[str, Any] = {"duration_ms": duration_ms}
@@ -296,3 +296,6 @@ async def run_task(
                 get_runs_total().labels(status=status_metric).inc()
                 get_run_duration_seconds().labels(status=status_metric).observe(total)
             metrics_recorded = True
+        if os.getenv("FAST_TEST_RUN") == "1":
+            # Chemin rapide en tests : on force un yield pour éviter tout blocage
+            await anyio.sleep(0)


### PR DESCRIPTION
## Summary
- applique l’authentification clé API sur tous les routeurs, hors `/health`
- simplifie la vérification de clé API
- ajoute un chemin d’exécution rapide pour les tests via `FAST_TEST_RUN`

## Testing
- `FAST_TEST_RUN=1 make test` *(échec : assert 200 == 401, assert 202 == 401, RuntimeError: no running event loop)*
- `make test` *(échec : assert 200 == 401, assert 202 == 401, RuntimeError: no running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_68bb12e024588327b3962f2e4739193b