### PR TITLE
test: switch tests to postgres

### DIFF
--- a/backend/tests/api/fastapi/conftest.py
+++ b/backend/tests/api/fastapi/conftest.py
@@ -1,2 +1,1 @@
 from ..conftest import *  # noqa: F401,F403
-from ..conftest import _dispose_engine  # noqa: F401

--- a/backend/tests/api/test_metrics.py
+++ b/backend/tests/api/test_metrics.py
@@ -8,7 +8,10 @@ from asgi_lifespan import LifespanManager
 async def _create_client_and_metrics(monkeypatch, enabled: str):
     monkeypatch.setenv("METRICS_ENABLED", enabled)
     monkeypatch.setenv("STORAGE_ORDER", "file")
-    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test_metrics.db")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres",
+    )
 
     import core.telemetry.metrics as metrics
     import backend.api.fastapi_app.deps as deps

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,13 +7,11 @@ import anyio
 
 try:
     from tests.api.conftest import *  # noqa: F401,F403
-    from tests.api.conftest import _dispose_engine  # noqa: F401
 except ImportError:  # pragma: no cover - fallback when package not on path
     ROOT = Path(__file__).resolve().parents[1]
     if str(ROOT) not in sys.path:
         sys.path.insert(0, str(ROOT))
     from tests.api.conftest import *  # noqa: F401,F403
-    from tests.api.conftest import _dispose_engine  # noqa: F401
 
 
 def reset_settings_env(monkeypatch, **env):


### PR DESCRIPTION
## Summary
- configure session-scoped PostgreSQL test database with Alembic migrations and connection cleanup
- point metrics tests to PostgreSQL

## Testing
- `pytest -q` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ac0787c8327a2b54b43fc39063d