### PR TITLE
Replace SQLite with PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ __pycache__/
 
 # --- Bases de données locales ---
 *.db
-*.sqlite3
-app.db
 pgdata/
 dump.sql
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ used for testing.
 
 ```
 API_KEY=test-key
-DATABASE_URL=sqlite+aiosqlite:///./app.db
+DATABASE_URL=postgresql+asyncpg://crew:crew@localhost:5432/crew
+ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 API_URL=http://127.0.0.1:8000
 ```
@@ -109,7 +110,8 @@ Variables d'environnement minimales :
 
 ```
 API_KEY=test-key
-DATABASE_URL=sqlite+aiosqlite:///./app.db
+DATABASE_URL=postgresql+asyncpg://crew:crew@localhost:5432/crew
+ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 API_URL=http://127.0.0.1:8000
 ```
 

--- a/backend/api/fastapi_app/deps.py
+++ b/backend/api/fastapi_app/deps.py
@@ -10,6 +10,7 @@ from fastapi import Header, HTTPException, status, Request, Depends
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from sqlalchemy import event
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -80,11 +81,11 @@ class Settings(BaseSettings):
     )
 
     # Provide sensible defaults so the API can start without mandatory
-    # environment variables. Tests override the database connection so a
-    # lightweight SQLite URL is sufficient here and a fixed API key keeps
-    # the authentication logic enabled.
+    # environment variables. Tests override the database connection and
+    # a fixed API key keeps the authentication logic enabled.
     database_url: str = Field(
-        default="sqlite+aiosqlite:///./app.db", alias="DATABASE_URL"
+        default="postgresql+asyncpg://crew:crew@localhost:5432/crew",
+        alias="DATABASE_URL",
     )
     api_key: str = Field(default="test-key", alias="API_KEY")
     allowed_origins_raw: str = Field(
@@ -105,6 +106,11 @@ def get_settings() -> Settings:
 
 
 settings = get_settings()
+
+url = make_url(settings.database_url)
+if url.get_backend_name() != "postgresql":
+    logger.error("DATABASE_URL doit utiliser le dialecte postgresql: %s", settings.database_url)
+    raise RuntimeError("Unsupported database dialect")
 
 # SQLAlchemy async engine/session (lecture seule côté API)
 engine: AsyncEngine = create_async_engine(settings.database_url, pool_pre_ping=True)

--- a/backend/orchestrator/api_runner.py
+++ b/backend/orchestrator/api_runner.py
@@ -256,7 +256,7 @@ async def run_task(
                 meta={"request_id": request_id},
             )
         )
-        # Force la visibilité immédiate de l’update (SQLite/test)
+        # Force la visibilité immédiate de l’update lors des tests
         try:
             await storage.get_run(UUID(run_id))  # no-op logique, mais force le flush/commit
         except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pydantic-settings
 networkx
 sqlmodel
 SQLAlchemy
-aiosqlite
 asyncpg
 httpx
 asgi-lifespan

--- a/scripts/validate_tasks_integration.sh
+++ b/scripts/validate_tasks_integration.sh
@@ -26,7 +26,7 @@ ROOT_DIR="${SCRIPT_DIR%/scripts}"
 cd "$ROOT_DIR"
 export PYTHONPATH=backend
 
-# Charge .env si présent, sinon valeurs par défaut adaptées aux tests (SQLite)
+# Charge .env si présent, sinon valeurs par défaut adaptées aux tests (PostgreSQL)
 if [ -f ".env" ]; then
   API_KEY="$(grep -E '^API_KEY=' .env | cut -d= -f2- | tr -d '"')" || true
   DB_URL="$(grep -E '^ALEMBIC_DATABASE_URL=' .env | cut -d= -f2- | tr -d '"')" || true
@@ -34,8 +34,8 @@ if [ -f ".env" ]; then
 else
   warn ".env introuvable à la racine du projet — utilisation des valeurs par défaut."
   API_KEY="test-key"
-  DB_URL="sqlite:///./test_api.db"
-  ASYNC_DB_URL="sqlite+aiosqlite:///./test_api.db"
+  DB_URL="postgresql+psycopg://crew:crew@localhost:5432/crew"
+  ASYNC_DB_URL="postgresql+asyncpg://crew:crew@localhost:5432/crew"
 fi
 API_HOST="127.0.0.1"
 API_PORT="8000"
@@ -58,11 +58,11 @@ else
   warn "docker compose absent ou pas de docker-compose.yml — je suppose une DB Postgres déjà joignable."
 fi
 
-if command -v alembic >/dev/null 2>&1 && test -n "${DB_URL:-}" && [[ "$DB_URL" != sqlite* ]]; then
+if command -v alembic >/dev/null 2>&1 && test -n "${DB_URL:-}"; then
   log "Mise à niveau du schéma (alembic upgrade head)…"
   alembic upgrade head
 else
-  warn "Aucune migration Alembic exécutée (SQLite ou alembic absent) — création directe du schéma."
+  warn "Aucune migration Alembic exécutée (alembic absent) — création directe du schéma."
   python - <<'PY'
 import os, asyncio
 from core.storage.postgres_adapter import PostgresAdapter


### PR DESCRIPTION
## Summary
- replace SQLite URLs and dependencies with PostgreSQL equivalents
- check DATABASE_URL dialect on startup and fail fast if not PostgreSQL
- update integration scripts and docs for PostgreSQL only

## Testing
- `pre-commit run --files scripts/validate_tasks_integration.sh README.md requirements.txt backend/api/fastapi_app/deps.py backend/orchestrator/api_runner.py .gitignore`
- `pytest` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('127.0.0.1', 5432))*
- `git grep -n "sqlite" || true`


------
https://chatgpt.com/codex/tasks/task_e_68bb3602c2a08327add5edc64bc73d1a