### PR TITLE
Assure l'usage exclusif de PostgreSQL

### DIFF
--- a/backend/core/storage/db_models.py
+++ b/backend/core/storage/db_models.py
@@ -4,7 +4,17 @@ from datetime import datetime, UTC
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import Column, DateTime, Enum as SAEnum, JSON, String, Text, func, Integer
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    JSON,
+    String,
+    Text,
+    func,
+    Integer,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlmodel import Field, SQLModel
 
@@ -59,6 +69,9 @@ class Run(SQLModel, table=True):
 
 class Node(SQLModel, table=True):
     __tablename__ = "nodes"
+    __table_args__ = (
+        UniqueConstraint("run_id", "key", name="uq_nodes_run_key"),
+    )
 
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
@@ -146,4 +159,3 @@ class Feedback(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
     )
-

--- a/backend/migrations/versions/20240905_nodes_run_key_unique.py
+++ b/backend/migrations/versions/20240905_nodes_run_key_unique.py
@@ -1,0 +1,16 @@
+from alembic import op
+
+revision = "20240905_nodes_run_key_unique"
+down_revision = "129a037b632d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(
+        "uq_nodes_run_key", "nodes", ["run_id", "key"]
+    )
+
+
+def downgrade():
+    op.drop_constraint("uq_nodes_run_key", "nodes", type_="unique")


### PR DESCRIPTION
## Résumé
- Empêche les doublons de nœuds en rendant (run_id, key) unique et en upsertant sur cette paire
- Reflète l'identifiant réel du nœud après upsert
- Migration Alembic pour ajouter la contrainte d'unicité

## Tests
- `pre-commit run --files backend/core/storage/db_models.py backend/core/storage/postgres_adapter.py backend/migrations/versions/20240905_nodes_run_key_unique.py`
- `pytest` *(échoue : OSError multiples exceptions de connexion refusée)*

------
https://chatgpt.com/codex/tasks/task_e_68bb364776548327b14dd218d9dc81ef