### PR TITLE
Basculer la stack vers PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ __pycache__/
 # --- Bases de données locales ---
 *.db
 *.sqlite3
-app.db
 pgdata/
 dump.sql
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test-recovery: ensure-venv
 
 .PHONY: migrate-feedbacks
 migrate-feedbacks: ensure-venv
-	@$(ACTIVATE) && alembic upgrade head
+	@$(ACTIVATE) && alembic -c backend/migrations/alembic.ini upgrade head
 
 .PHONY: test-feedbacks
 test-feedbacks: ensure-venv
@@ -216,7 +216,7 @@ api-migrate: ensure-venv
 
 .PHONY: migrate-fil8
 migrate-fil8:
-	poetry run alembic upgrade head
+	poetry run alembic -c backend/migrations/alembic.ini upgrade head
 
 .PHONY: seed-agents
 seed-agents:
@@ -349,3 +349,11 @@ cockpit-build:
 # Tests côté cockpit (Vitest)
 cockpit-test:
 	@cd frontend/cockpit && npm test
+
+.PHONY: db-revision
+db-revision:
+	@alembic -c backend/migrations/alembic.ini revision -m "$(msg)" --autogenerate
+
+.PHONY: db-upgrade
+db-upgrade:
+	@alembic -c backend/migrations/alembic.ini upgrade head

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ used for testing.
 
 ```
 API_KEY=test-key
-DATABASE_URL=sqlite+aiosqlite:///./app.db
+DATABASE_URL=postgresql+asyncpg://crew:crew@localhost:5432/crew
+ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 API_URL=http://127.0.0.1:8000
 ```
@@ -109,7 +110,8 @@ Variables d'environnement minimales :
 
 ```
 API_KEY=test-key
-DATABASE_URL=sqlite+aiosqlite:///./app.db
+DATABASE_URL=postgresql+asyncpg://crew:crew@localhost:5432/crew
+ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew
 API_URL=http://127.0.0.1:8000
 ```
 
@@ -118,7 +120,8 @@ API_URL=http://127.0.0.1:8000
 1. Appliquer les migrations :
 
    ```bash
-   make api-migrate
+   ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew \
+     alembic -c backend/migrations/alembic.ini upgrade head
    ```
 
 2. Démarrer l'API (terminal séparé) :
@@ -174,6 +177,7 @@ Les variables essentielles sont définies dans `.env` (voir [`.env.example`](.en
 
 - `API_KEY` — clé requise sur toutes les requêtes API.
 - `DATABASE_URL` — URL de connexion asynchrone à la base.
+- `ALEMBIC_DATABASE_URL` — URL de connexion synchrone utilisée par Alembic.
 - `API_URL` — URL de base de l'API.
 - `ALLOWED_ORIGINS` — origines autorisées pour CORS (défaut `http://localhost:3000,http://localhost:5173`).
 
@@ -235,11 +239,12 @@ list).
 
 ## Database migrations
 
-Alembic is used for schema migrations. Set `ALEMBIC_DATABASE_URL` and run:
+Alembic est utilisé pour les migrations de schéma. Pour appliquer les
+migrations localement :
 
-```
-make db-revision msg="add table"
-make db-upgrade
+```bash
+ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew \
+  alembic -c backend/migrations/alembic.ini upgrade head
 ```
 
 ## Make targets

--- a/backend/core/storage/db_models.py
+++ b/backend/core/storage/db_models.py
@@ -4,8 +4,17 @@ from datetime import datetime, UTC
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import Column, DateTime, Enum as SAEnum, JSON, String, Text, func, Integer
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    String,
+    Text,
+    func,
+    Integer,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
 from sqlmodel import Field, SQLModel
 
 
@@ -37,7 +46,9 @@ class Run(SQLModel, table=True):
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
     title: str = Field(sa_column=Column(String, nullable=False))
-    status: RunStatus = Field(sa_column=Column(SAEnum(RunStatus, name="runstatus"), nullable=False))
+    status: RunStatus = Field(
+        sa_column=Column(SAEnum(RunStatus, name="runstatus"), nullable=False)
+    )
     started_at: Optional[datetime] = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
@@ -48,32 +59,47 @@ class Run(SQLModel, table=True):
     )
     meta: Optional[Dict] = Field(
         default=None,
-        sa_column=Column("metadata", JSON, nullable=True),
+        sa_column=Column("metadata", JSONB, nullable=True),
     )
 
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
     )
 
 
 class Node(SQLModel, table=True):
     __tablename__ = "nodes"
+    __table_args__ = (UniqueConstraint("run_id", "key", name="uq_nodes_run_key"),)
 
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
-    run_id: uuid.UUID = Field(sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True))
-    key: Optional[str] = Field(default=None, sa_column=Column(String, index=True))
+    run_id: uuid.UUID = Field(
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True)
+    )
+    key: str = Field(sa_column=Column(String, nullable=False, index=True))
     title: str = Field(sa_column=Column(String, nullable=False))
-    status: NodeStatus = Field(sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False))
-    role: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True, index=True))
-    deps: Optional[List[str]] = Field(default=None, sa_column=Column(JSON, nullable=True))
-    checksum: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
+    status: NodeStatus = Field(
+        sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False)
+    )
+    role: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True, index=True)
+    )
+    deps: Optional[List[str]] = Field(
+        default=None, sa_column=Column(JSONB, nullable=True)
+    )
+    checksum: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
     )
     updated_at: Optional[datetime] = Field(
         default=None,
@@ -88,14 +114,20 @@ class Artifact(SQLModel, table=True):
         default_factory=uuid.uuid4,
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
-    node_id: uuid.UUID = Field(sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True))
+    node_id: uuid.UUID = Field(
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True)
+    )
     type: str = Field(sa_column=Column(String, nullable=False))
     path: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
     content: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
-    summary: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
+    summary: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
     )
 
 
@@ -114,7 +146,9 @@ class Event(SQLModel, table=True):
     )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
     )
     level: str = Field(sa_column=Column(String, nullable=False))
     message: str = Field(sa_column=Column(Text, nullable=False))
@@ -130,20 +164,25 @@ class Feedback(SQLModel, table=True):
         default_factory=uuid.uuid4,
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
-    run_id: uuid.UUID = Field(sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True))
-    node_id: uuid.UUID = Field(sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True))
+    run_id: uuid.UUID = Field(
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True)
+    )
+    node_id: uuid.UUID = Field(
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True)
+    )
     source: str = Field(sa_column=Column(String, nullable=False))
     reviewer: str = Field(sa_column=Column(String, nullable=False))
     score: Optional[int] = Field(default=None, sa_column=Column(Integer, nullable=True))
     comment: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     meta: Optional[Dict] = Field(
-        default=None, sa_column=Column("metadata", JSON, nullable=True)
+        default=None, sa_column=Column("metadata", JSONB, nullable=True)
     )
     evaluation: Optional[Dict[str, Any]] = Field(
-        default=None, sa_column=Column(JSON, nullable=True)
+        default=None, sa_column=Column(JSONB, nullable=True)
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
     )
-

--- a/backend/core/storage/db_tracking.py
+++ b/backend/core/storage/db_tracking.py
@@ -40,7 +40,7 @@ class DbTracker:
             Run(
                 id=self.run_db.id,
                 title=self.run_db.title,
-                status=RunStatus.succeeded if success else RunStatus.failed,
+                status=RunStatus.completed if success else RunStatus.failed,
                 started_at=self.run_db.started_at,
                 ended_at=datetime.now(timezone.utc),
                 meta=self.run_db.meta,
@@ -55,10 +55,10 @@ class DbTracker:
         node_db = await self.pg.save_node(
             Node(
                 run_id=self.run_db.id,
-                key=node.id,                 # clé logique du plan
+                key=node.id,  # clé logique du plan
                 title=getattr(node, "title", node.id),
                 status=NodeStatus.running,
-                started_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
                 deps=getattr(node, "deps", []) or [],
                 checksum=getattr(node, "checksum", None),
             )
@@ -77,8 +77,8 @@ class DbTracker:
                 run_id=self.run_db.id,
                 key=node.id,
                 title=getattr(node, "title", node.id),
-                status=NodeStatus.succeeded if success else NodeStatus.failed,
-                ended_at=datetime.now(timezone.utc),
+                status=NodeStatus.completed if success else NodeStatus.failed,
+                updated_at=datetime.now(timezone.utc),
             )
         )
 

--- a/backend/core/storage/hooks.py
+++ b/backend/core/storage/hooks.py
@@ -1,36 +1,42 @@
 # core/storage/hooks.py
+import json
 from datetime import datetime, timezone
 from core.storage.db_models import Run, Node, Artifact, Event, RunStatus, NodeStatus
+
 
 async def on_run_start(storage, title: str, meta: dict | None = None) -> Run:
     run = Run(
         title=title,
         status=RunStatus.running,
         started_at=datetime.now(timezone.utc),
-        meta=meta
+        meta=meta,
     )
     return await storage.save_run(run)
+
 
 async def on_run_end(storage, run: Run, status: RunStatus):
     run.status = status
     run.ended_at = datetime.now(timezone.utc)
     return await storage.save_run(run)
 
-async def on_node_start(storage, run_id, title, deps=None, checksum=None) -> Node:
+
+async def on_node_start(storage, run_id, key, title, deps=None, checksum=None) -> Node:
     node = Node(
         run_id=run_id,
+        key=key,
         title=title,
         status=NodeStatus.running,
-        started_at=datetime.now(timezone.utc),
         deps=list(deps or []),
         checksum=checksum,
     )
     return await storage.save_node(node)
 
+
 async def on_node_end(storage, node: Node, status: NodeStatus):
     node.status = status
-    node.ended_at = datetime.now(timezone.utc)
+    node.updated_at = datetime.now(timezone.utc)
     return await storage.save_node(node)
+
 
 async def on_artifact(storage, node_id, type_, path, summary=None, content=None):
     art = Artifact(
@@ -42,6 +48,12 @@ async def on_artifact(storage, node_id, type_, path, summary=None, content=None)
     )
     return await storage.save_artifact(art)
 
+
 async def log(storage, level: str, message: str, run_id=None, node_id=None, extra=None):
-    evt = Event(run_id=run_id, node_id=node_id, level=level, message=message, extra=extra)
+    if extra is not None:
+        try:
+            message = json.dumps({"message": message, "extra": extra}, ensure_ascii=False)
+        except Exception:
+            message = f"{message} | extra={extra}"
+    evt = Event(run_id=run_id, node_id=node_id, level=level, message=message)
     return await storage.save_event(evt)

--- a/backend/core/storage/postgres_adapter.py
+++ b/backend/core/storage/postgres_adapter.py
@@ -7,16 +7,27 @@ from typing import List, Optional, Any, Dict
 from contextlib import asynccontextmanager
 
 from sqlalchemy import text, select, update
-from sqlalchemy.dialects.postgresql import insert, JSONB
 import sqlalchemy as sa
+from sqlalchemy.engine import make_url
+from sqlalchemy.dialects.postgresql import insert, JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.pool import NullPool
 from sqlmodel import SQLModel
 
-from core.storage.db_models import Run, Node, Artifact, Event, Feedback, RunStatus, NodeStatus
+from core.storage.db_models import (
+    Run,
+    Node,
+    Artifact,
+    Event,
+    Feedback,
+    RunStatus,
+    NodeStatus,
+)
 
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://crew:crew@localhost:5432/crew")
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgresql+asyncpg://crew:crew@localhost:5432/crew"
+)
 
 
 class PostgresAdapter:
@@ -24,6 +35,7 @@ class PostgresAdapter:
     Adaptateur PostgreSQL asynchrone (SQLModel / SQLAlchemy 2.0).
     Fournit des méthodes souples (prennent soit un objet, soit des kwargs).
     """
+
     expects_uuid_ids: bool = True  # IDs UUID pour run_id / node_id
 
     def __init__(self, database_url: Optional[str] = None, echo: bool = False):
@@ -31,11 +43,17 @@ class PostgresAdapter:
         if not self.database_url:
             raise ValueError("DATABASE_URL must be provided")
 
+        url = make_url(self.database_url)
+        if url.get_backend_name() != "postgresql":
+            raise RuntimeError(
+                f"Unsupported database dialect: {url.get_backend_name()}"
+            )
+
         self._engine = create_async_engine(
             self.database_url,
             future=True,
             echo=echo,
-            poolclass=NullPool,       # 1 connexion par session (tests/outils)
+            poolclass=NullPool,  # 1 connexion par session (tests/outils)
             pool_pre_ping=True,
         )
         # IMPORTANT: expire_on_commit=False pour matérialiser avant fermeture
@@ -43,6 +61,7 @@ class PostgresAdapter:
             bind=self._engine, expire_on_commit=False, class_=AsyncSession
         )
         self._runs = Run.__table__
+        self._nodes = Node.__table__
 
     # ---------- Infra utilitaires ----------
 
@@ -73,33 +92,42 @@ class PostgresAdapter:
         payload = {
             "id": obj.id,
             "title": obj.title,
-            "status": obj.status.value if isinstance(obj.status, RunStatus) else obj.status,
+            "status": (
+                obj.status.value if isinstance(obj.status, RunStatus) else obj.status
+            ),
             "started_at": obj.started_at,
             "ended_at": obj.ended_at,
-            "meta": obj.meta or {},
+            "metadata": obj.meta or {},
         }
 
         insert_stmt = insert(self._runs).values(**payload)
         excluded = insert_stmt.excluded
-        empty_json = sa.cast(sa.text("'{}'"), JSONB)
-        existing_meta = sa.func.coalesce(sa.cast(self._runs.c.meta, JSONB), empty_json)
-        incoming_meta = sa.func.coalesce(sa.cast(excluded.meta, JSONB), empty_json)
-        stmt = (
-            insert_stmt.on_conflict_do_update(
-                index_elements=[self._runs.c.id],
-                set_={
-                    "title": sa.func.coalesce(excluded.title, self._runs.c.title),
-                    "status": excluded.status,
-                    "started_at": sa.func.coalesce(excluded.started_at, self._runs.c.started_at),
-                    "ended_at": excluded.ended_at,
-                    "meta": existing_meta.op("||")(incoming_meta),
-                },
-            ).returning(*self._runs.c)
-        )
+        stmt = insert_stmt.on_conflict_do_update(
+            index_elements=[self._runs.c.id],
+            set_={
+                "title": sa.func.coalesce(excluded.title, self._runs.c.title),
+                "status": excluded.status,
+                "started_at": sa.func.coalesce(
+                    excluded.started_at, self._runs.c.started_at
+                ),
+                "ended_at": excluded.ended_at,
+                "metadata": sa.func.coalesce(
+                    sa.cast(self._runs.c.metadata, JSONB), sa.text("'{}'::jsonb")
+                ).op("||")(
+                    sa.func.coalesce(
+                        sa.cast(excluded.metadata, JSONB), sa.text("'{}'::jsonb")
+                    )
+                ),
+            },
+        ).returning(*self._runs.c)
         async with self._engine.begin() as conn:
             result = await conn.execute(stmt)
             row = result.fetchone()
-        return Run(**row._mapping) if row else obj
+        if row:
+            data = dict(row._mapping)
+            data["meta"] = data.pop("metadata", None)
+            return Run(**data)
+        return obj
 
     async def get_run(self, run_id: uuid.UUID) -> Optional[Run]:
         async with self.session() as s:
@@ -119,23 +147,46 @@ class PostgresAdapter:
 
     async def save_node(self, node: Optional[Node] = None, **kwargs) -> Node:
         obj = self._coalesce_obj(Node, node, kwargs)
-        async with self.session() as s:
-            try:
-                existing = await s.get(Node, obj.id) if obj.id else None
-                if existing:
-                    data = obj.model_dump() if hasattr(obj, "model_dump") else obj.dict()
-                    for k, v in data.items():
-                        setattr(existing, k, v)
-                    await s.flush()
-                    await s.commit()
-                    return existing
-                s.add(obj)
-                await s.flush()
-                await s.commit()
-                return obj
-            except Exception:
-                await s.rollback()
-                raise
+        # Assure un ID et le reflète sur l'objet
+        new_id = obj.id or uuid.uuid4()
+        obj.id = new_id
+        payload = {
+            "id": new_id,
+            "run_id": obj.run_id,
+            "key": obj.key,
+            "title": obj.title,
+            "status": (
+                obj.status.value if isinstance(obj.status, NodeStatus) else obj.status
+            ),
+            "role": obj.role,
+            "deps": obj.deps,
+            "checksum": obj.checksum,
+        }
+        # Laisse created_at au défaut DB si non fourni
+        if getattr(obj, "created_at", None) is not None:
+            payload["created_at"] = obj.created_at
+        if getattr(obj, "updated_at", None) is not None:
+            payload["updated_at"] = obj.updated_at
+
+        insert_stmt = insert(self._nodes).values(**payload)
+        excluded = insert_stmt.excluded
+        stmt = insert_stmt.on_conflict_do_update(
+            index_elements=[self._nodes.c.run_id, self._nodes.c.key],
+            set_={
+                "run_id": excluded.run_id,
+                "key": excluded.key,
+                "title": excluded.title,
+                "status": excluded.status,
+                "role": excluded.role,
+                "deps": excluded.deps,
+                "checksum": excluded.checksum,
+                "updated_at": sa.func.now(),
+            },
+        ).returning(*self._nodes.c)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(stmt)
+            row = result.fetchone()
+        return Node(**row._mapping) if row else obj
 
     async def ensure_node(
         self,
@@ -156,9 +207,14 @@ class PostgresAdapter:
                     await s.execute(
                         update(Node)
                         .where(Node.id == existing.id)
-                        .values(status=status, title=title, updated_at=datetime.now(timezone.utc))
+                        .values(
+                            status=status,
+                            title=title,
+                            updated_at=datetime.now(timezone.utc),
+                        )
                     )
                     await s.flush()
+                    await s.refresh(existing)
                     await s.commit()
                     return existing
 
@@ -181,7 +237,9 @@ class PostgresAdapter:
 
     # ---------- Artifacts ----------
 
-    async def save_artifact(self, artifact: Optional[Artifact] = None, **kwargs) -> Artifact:
+    async def save_artifact(
+        self, artifact: Optional[Artifact] = None, **kwargs
+    ) -> Artifact:
         obj = self._coalesce_obj(Artifact, artifact, kwargs)
         if obj.type is None:
             obj.type = "artifact"
@@ -218,7 +276,7 @@ class PostgresAdapter:
         run_id: Optional[uuid.UUID] = None,
         node_id: Optional[uuid.UUID] = None,
         level: Optional[str] = None,
-        limit: int = 200
+        limit: int = 200,
     ) -> List[Event]:
         stmt = select(Event).order_by(Event.timestamp.desc()).limit(limit)
         if run_id:
@@ -234,7 +292,9 @@ class PostgresAdapter:
 
     # ---------- Feedbacks ----------
 
-    async def save_feedback(self, feedback: Optional[Feedback] = None, **kwargs) -> Feedback:
+    async def save_feedback(
+        self, feedback: Optional[Feedback] = None, **kwargs
+    ) -> Feedback:
         obj = self._coalesce_obj(Feedback, feedback, kwargs)
         if obj.created_at is None:
             obj.created_at = datetime.now(timezone.utc)
@@ -254,7 +314,7 @@ class PostgresAdapter:
         # suppose une colonne JSONB 'meta' :: {"key": "..."}
         async with self.session() as s:
             res = await s.execute(
-                text("SELECT id FROM runs WHERE meta ->> 'key' = :k LIMIT 1"),
+                text("SELECT id FROM runs WHERE metadata ->> 'key' = :k LIMIT 1"),
                 {"k": run_key},
             )
             row = res.first()
@@ -274,18 +334,22 @@ class PostgresAdapter:
         )
         return await self.save_run(r)
 
-    async def resolve_node_uuid(self, run_key: str, node_key: str) -> Optional[uuid.UUID]:
+    async def resolve_node_uuid(
+        self, run_key: str, node_key: str
+    ) -> Optional[uuid.UUID]:
         # suppose 'runs.meta' + 'nodes.key'
         async with self.session() as s:
             res = await s.execute(
-                text("""
+                text(
+                    """
                     SELECT n.id
                     FROM nodes n
                     JOIN runs r ON r.id = n.run_id
-                    WHERE (r.meta ->> 'key') = :rk
+                    WHERE (r.metadata ->> 'key') = :rk
                       AND n.key = :nk
                     LIMIT 1
-                """),
+                    """
+                ),
                 {"rk": run_key, "nk": node_key},
             )
             row = res.first()
@@ -293,25 +357,31 @@ class PostgresAdapter:
 
     # ---------- Télémétrie LLM (pour enrichir NODE_COMPLETED) ----------
 
-    async def get_node_id_by_logical(self, run_id: str | uuid.UUID, logical_id: str) -> Optional[str]:
+    async def get_node_id_by_logical(
+        self, run_id: str | uuid.UUID, logical_id: str
+    ) -> Optional[str]:
         """
         Retourne l'UUID DB d'un node à partir de la clé logique (plan.id).
         On cast explicitement run_id en UUID pour éviter tout souci de comparaison.
         """
         # cast run_id en UUID côté Python (évite d'avoir à faire ::uuid côté SQL)
         try:
-            run_uuid = run_id if isinstance(run_id, uuid.UUID) else uuid.UUID(str(run_id))
+            run_uuid = (
+                run_id if isinstance(run_id, uuid.UUID) else uuid.UUID(str(run_id))
+            )
         except Exception:
             return None
 
-        q = text("""
+        q = text(
+            """
             SELECT id::text
             FROM nodes
             WHERE run_id = :run_uuid
-              AND (key = :logical_id OR logical_id = :logical_id)
+              AND key = :logical_id
             ORDER BY created_at DESC NULLS LAST
             LIMIT 1
-        """)
+        """
+        )
         async with self.session() as s:
             r = await s.execute(q, {"run_uuid": run_uuid, "logical_id": logical_id})
             row = r.first()
@@ -322,21 +392,25 @@ class PostgresAdapter:
         Liste brute des artifacts pour un node.
         Colonnes: artifacts(id UUID, node_id UUID, type TEXT, content TEXT, path TEXT, created_at TIMESTAMPTZ)
         """
-        q = text("""
+        q = text(
+            """
             SELECT id::text, type, content, path, created_at
             FROM artifacts
             WHERE node_id = :node_id
             ORDER BY created_at DESC NULLS LAST
-        """)
+        """
+        )
         async with self.session() as s:
             r = await s.execute(q, {"node_id": node_id})
             items = []
             for aid, typ, content, path, created_at in r.fetchall():
-                items.append({
-                    "id": aid,
-                    "type": typ,
-                    "content": content,
-                    "path": path,
-                    "created_at": created_at.isoformat() if created_at else None,
-                })
+                items.append(
+                    {
+                        "id": aid,
+                        "type": typ,
+                        "content": content,
+                        "path": path,
+                        "created_at": created_at.isoformat() if created_at else None,
+                    }
+                )
             return items

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -8,9 +8,8 @@ from sqlmodel import SQLModel
 
 # --- Importe tes modèles pour que SQLModel.metadata soit peuplé ---
 # Modèles existants
-from core.storage.db_models import Run, Node, Artifact, Event  # noqa: F401
+from core.storage.db_models import Run, Node, Artifact, Event, Feedback  # noqa: F401
 # Modèles de l'application
-from backend.api.database.models import Base  # noqa: F401
 from dotenv import load_dotenv
 load_dotenv()  # charge le .env tôt
 

--- a/backend/migrations/versions/20240905_nodes_run_key_unique.py
+++ b/backend/migrations/versions/20240905_nodes_run_key_unique.py
@@ -1,0 +1,30 @@
+"""unicité run_id, key pour nodes"""
+
+from alembic import op
+
+revision = "20240905_nodes_run_key_unique"
+down_revision = "c894e2b67dc8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        WITH d AS (
+            SELECT ctid, run_id, key,
+                   ROW_NUMBER() OVER (PARTITION BY run_id, key ORDER BY id) AS rn
+            FROM nodes
+            WHERE key IS NOT NULL
+        )
+        UPDATE nodes n
+        SET key = n.key || '__' || substr(n.id::text,1,8)
+        FROM d
+        WHERE n.ctid = d.ctid AND d.rn > 1;
+        """
+    )
+    op.create_unique_constraint("uq_nodes_run_key", "nodes", ["run_id", "key"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_nodes_run_key", "nodes", type_="unique")

--- a/backend/migrations/versions/20240907_node_key_not_null.py
+++ b/backend/migrations/versions/20240907_node_key_not_null.py
@@ -1,0 +1,18 @@
+"""make nodes.key non-nullable"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240907_node_key_not_null"
+down_revision = "20240905_nodes_run_key_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE nodes SET key = id::text WHERE key IS NULL")
+    op.alter_column("nodes", "key", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("nodes", "key", existing_type=sa.String(), nullable=True)

--- a/backend/migrations/versions/20240908_jsonb_meta_nodes.py
+++ b/backend/migrations/versions/20240908_jsonb_meta_nodes.py
@@ -1,0 +1,18 @@
+"""convert metadata and deps to jsonb"""
+
+from alembic import op
+
+revision = "20240908_jsonb_meta_nodes"
+down_revision = "20240907_node_key_not_null"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE runs  ALTER COLUMN metadata TYPE jsonb USING metadata::jsonb;")
+    op.execute("ALTER TABLE nodes ALTER COLUMN deps      TYPE jsonb USING deps::jsonb;")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE runs  ALTER COLUMN metadata TYPE json  USING metadata::json;")
+    op.execute("ALTER TABLE nodes ALTER COLUMN deps      TYPE json  USING deps::json;")

--- a/backend/migrations/versions/20240909_feedbacks_jsonb.py
+++ b/backend/migrations/versions/20240909_feedbacks_jsonb.py
@@ -1,0 +1,27 @@
+"""convert feedbacks metadata/evaluation to jsonb"""
+
+from alembic import op
+
+revision = "20240909_feedbacks_jsonb"
+down_revision = "20240908_jsonb_meta_nodes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE feedbacks ALTER COLUMN metadata  TYPE jsonb USING metadata::jsonb;"
+    )
+    op.execute(
+        "ALTER TABLE feedbacks ALTER COLUMN evaluation TYPE jsonb USING evaluation::jsonb;"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE feedbacks ALTER COLUMN metadata  TYPE json  USING metadata::json;"
+    )
+    op.execute(
+        "ALTER TABLE feedbacks ALTER COLUMN evaluation TYPE json  USING evaluation::json;"
+    )
+

--- a/backend/orchestrator/api_runner.py
+++ b/backend/orchestrator/api_runner.py
@@ -67,6 +67,7 @@ def _extract_llm_meta_from_artifacts(artifacts: list[dict]) -> dict:
             return out
     return {}
 
+
 def _read_llm_sidecar_fs(run_id: str, node_key: str, runs_root: str = None) -> dict:
     base = runs_root or os.getenv("ARTIFACTS_DIR") or os.getenv("RUNS_ROOT") or ".runs"
     node_dir = Path(base) / run_id / "nodes" / node_key
@@ -126,7 +127,7 @@ async def run_task(
                 title=getattr(node, "title", "")
                 or (node.get("title") if isinstance(node, dict) else ""),
                 status=NodeStatus.running,
-                started_at=now,
+                updated_at=now,
                 checksum=getattr(node, "checksum", None)
                 or (node.get("checksum") if isinstance(node, dict) else None),
             )
@@ -165,7 +166,6 @@ async def run_task(
                 title=getattr(node, "title", "")
                 or (node.get("title") if isinstance(node, dict) else ""),
                 status=node_status,
-                started_at=node_started_at.get(node_key),
                 updated_at=ended,
                 checksum=getattr(node, "checksum", None)
                 or (node.get("checksum") if isinstance(node, dict) else None),
@@ -188,7 +188,9 @@ async def run_task(
             # micro‑retry: laisse le temps à l’exécuteur d’écrire le sidecar
             await anyio.sleep(0 if os.getenv("FAST_TEST_RUN") == "1" else 0.35)
             meta = _read_llm_sidecar_fs(run_id, node_key) or {}
-        duration_ms = int((ended - node_started_at.get(node_key, ended)).total_seconds() * 1000)
+        duration_ms = int(
+            (ended - node_started_at.get(node_key, ended)).total_seconds() * 1000
+        )
         meta_payload: Dict[str, Any] = {"duration_ms": duration_ms}
         if meta:
             meta_payload.update(meta)
@@ -241,11 +243,11 @@ async def run_task(
         ended = dt.datetime.now(dt.timezone.utc)
         # ...............................................................
         final_status = (
-            RunStatus.completed if res.get("status") == "succeeded" else RunStatus.failed
+            RunStatus.completed
+            if res.get("status") == "succeeded"
+            else RunStatus.failed
         )
-        status_metric = (
-            "completed" if final_status == RunStatus.completed else "failed"
-        )
+        status_metric = "completed" if final_status == RunStatus.completed else "failed"
         await storage.save_run(
             run=Run(
                 id=UUID(run_id),
@@ -258,7 +260,9 @@ async def run_task(
         )
         # Force la visibilité immédiate de l’update (SQLite/test)
         try:
-            await storage.get_run(UUID(run_id))  # no-op logique, mais force le flush/commit
+            await storage.get_run(
+                UUID(run_id)
+            )  # no-op logique, mais force le flush/commit
         except Exception:
             pass
 
@@ -277,6 +281,7 @@ async def run_task(
         log.exception("Background run failed for run_id=%s", run_id)
         if os.getenv("SENTRY_DSN"):
             import sentry_sdk
+
             with sentry_sdk.push_scope() as scope:
                 if run_id:
                     scope.set_tag("run_id", run_id)

--- a/backend/tests/api/test_metrics.py
+++ b/backend/tests/api/test_metrics.py
@@ -8,10 +8,6 @@ from asgi_lifespan import LifespanManager
 async def _create_client_and_metrics(monkeypatch, enabled: str):
     monkeypatch.setenv("METRICS_ENABLED", enabled)
     monkeypatch.setenv("STORAGE_ORDER", "file")
-    monkeypatch.setenv(
-        "DATABASE_URL",
-        "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres",
-    )
 
     import core.telemetry.metrics as metrics
     import backend.api.fastapi_app.deps as deps
@@ -28,7 +24,7 @@ async def _create_client_and_metrics(monkeypatch, enabled: str):
 
 
 @pytest.mark.asyncio
-async def test_metrics_endpoint_enabled(monkeypatch):
+async def test_metrics_endpoint_enabled(pg_test_db, monkeypatch):
     app, metrics = await _create_client_and_metrics(monkeypatch, "1")
 
     metrics.get_db_pool_in_use().labels(db="primary").inc()
@@ -59,7 +55,7 @@ async def test_metrics_endpoint_enabled(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_metrics_endpoint_disabled(monkeypatch):
+async def test_metrics_endpoint_disabled(pg_test_db, monkeypatch):
     app, _ = await _create_client_and_metrics(monkeypatch, "0")
 
     async with LifespanManager(app):

--- a/backend/tests/unit/test_postgres_adapter_runs.py
+++ b/backend/tests/unit/test_postgres_adapter_runs.py
@@ -1,0 +1,15 @@
+import uuid
+import pytest
+
+from core.storage.postgres_adapter import PostgresAdapter
+from core.storage.db_models import Run, RunStatus
+from backend.tests.api.conftest import pg_test_db
+
+
+@pytest.mark.asyncio
+async def test_save_run_returns_model_with_meta(pg_test_db):
+    adapter = PostgresAdapter(pg_test_db)
+    run = Run(id=uuid.uuid4(), title="T", status=RunStatus.running, meta={"k": "v"})
+    saved = await adapter.save_run(run)
+    assert isinstance(saved, Run)
+    assert saved.meta == {"k": "v"}

--- a/docs/quality/USAGE.md
+++ b/docs/quality/USAGE.md
@@ -43,5 +43,6 @@ Retourne les statistiques globales, par type de nœud et la liste des feedbacks.
 ## Migration de base de données
 Appliquer les migrations (dont l'ajout du champ `evaluation`) :
 ```bash
-DATABASE_URL=<url_postgres> alembic upgrade head
+ALEMBIC_DATABASE_URL=<url_postgres_sync_psycopg> \
+  alembic -c backend/migrations/alembic.ini upgrade head
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,9 @@ pydantic-settings
 networkx
 sqlmodel
 SQLAlchemy
-aiosqlite
 asyncpg
+psycopg[binary]
+alembic
 httpx
 asgi-lifespan
 pytest


### PR DESCRIPTION
## Résumé
- Basculer l'ensemble de la persistance vers PostgreSQL avec des colonnes JSONB et vérifications de dialecte
- Garantir l'unicité `(run_id, key)` des nœuds et retourner des objets rafraîchis lors des mises à jour
- Documentation, scripts et tests alignés sur l'utilisation d'une base PostgreSQL éphémère

## Tests
- `pytest -q` *(échoue : Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68bb3768d2a48327a9f782dc023bcbb8