### PR TITLE
Consolider JSONB et contrainte node.key

### DIFF
--- a/backend/core/storage/db_models.py
+++ b/backend/core/storage/db_models.py
@@ -8,14 +8,13 @@ from sqlalchemy import (
     Column,
     DateTime,
     Enum as SAEnum,
-    JSON,
     String,
     Text,
     func,
     Integer,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.dialects.postgresql import UUID as PGUUID, JSONB
 from sqlmodel import Field, SQLModel
 
 
@@ -58,7 +57,7 @@ class Run(SQLModel, table=True):
     )
     meta: Optional[Dict] = Field(
         default=None,
-        sa_column=Column("metadata", JSON, nullable=True),
+        sa_column=Column("metadata", JSONB, nullable=True),
     )
 
     created_at: datetime = Field(
@@ -77,12 +76,14 @@ class Node(SQLModel, table=True):
         default_factory=uuid.uuid4,
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
-    run_id: uuid.UUID = Field(sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True))
-    key: Optional[str] = Field(default=None, sa_column=Column(String, index=True))
+    run_id: uuid.UUID = Field(
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True)
+    )
+    key: str = Field(sa_column=Column(String, nullable=False, index=True))
     title: str = Field(sa_column=Column(String, nullable=False))
     status: NodeStatus = Field(sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False))
     role: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True, index=True))
-    deps: Optional[List[str]] = Field(default=None, sa_column=Column(JSON, nullable=True))
+    deps: Optional[List[str]] = Field(default=None, sa_column=Column(JSONB, nullable=True))
     checksum: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
@@ -150,10 +151,10 @@ class Feedback(SQLModel, table=True):
     score: Optional[int] = Field(default=None, sa_column=Column(Integer, nullable=True))
     comment: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     meta: Optional[Dict] = Field(
-        default=None, sa_column=Column("metadata", JSON, nullable=True)
+        default=None, sa_column=Column("metadata", JSONB, nullable=True)
     )
     evaluation: Optional[Dict[str, Any]] = Field(
-        default=None, sa_column=Column(JSON, nullable=True)
+        default=None, sa_column=Column(JSONB, nullable=True)
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/backend/migrations/versions/20240905_nodes_run_key_unique.py
+++ b/backend/migrations/versions/20240905_nodes_run_key_unique.py
@@ -1,16 +1,29 @@
 from alembic import op
 
+
 revision = "20240905_nodes_run_key_unique"
 down_revision = "129a037b632d"
 branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    op.create_unique_constraint(
-        "uq_nodes_run_key", "nodes", ["run_id", "key"]
+def upgrade() -> None:
+    op.execute(
+        """
+        WITH d AS (
+            SELECT ctid, run_id, key,
+                   ROW_NUMBER() OVER (PARTITION BY run_id, key ORDER BY id) AS rn
+            FROM nodes
+            WHERE key IS NOT NULL
+        )
+        UPDATE nodes n
+        SET key = n.key || '__' || substr(n.id::text,1,8)
+        FROM d
+        WHERE n.ctid = d.ctid AND d.rn > 1;
+        """
     )
+    op.create_unique_constraint("uq_nodes_run_key", "nodes", ["run_id", "key"])
 
 
-def downgrade():
+def downgrade() -> None:
     op.drop_constraint("uq_nodes_run_key", "nodes", type_="unique")

--- a/backend/migrations/versions/20240907_node_key_not_null.py
+++ b/backend/migrations/versions/20240907_node_key_not_null.py
@@ -1,0 +1,16 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240907_node_key_not_null"
+down_revision = "20240905_nodes_run_key_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE nodes SET key = id::text WHERE key IS NULL")
+    op.alter_column("nodes", "key", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("nodes", "key", existing_type=sa.String(), nullable=True)

--- a/backend/migrations/versions/20240908_jsonb_meta_nodes.py
+++ b/backend/migrations/versions/20240908_jsonb_meta_nodes.py
@@ -1,0 +1,42 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20240908_jsonb_meta_nodes"
+down_revision = "3998bc48da90"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "runs",
+        "metadata",
+        existing_type=sa.JSON(),
+        type_=postgresql.JSONB(),
+        postgresql_using="metadata::jsonb",
+    )
+    op.alter_column(
+        "nodes",
+        "deps",
+        existing_type=sa.JSON(),
+        type_=postgresql.JSONB(),
+        postgresql_using="deps::jsonb",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "runs",
+        "metadata",
+        existing_type=postgresql.JSONB(),
+        type_=sa.JSON(),
+        postgresql_using="metadata::json",
+    )
+    op.alter_column(
+        "nodes",
+        "deps",
+        existing_type=postgresql.JSONB(),
+        type_=sa.JSON(),
+        postgresql_using="deps::json",
+    )

--- a/backend/migrations/versions/20240909_feedbacks_jsonb.py
+++ b/backend/migrations/versions/20240909_feedbacks_jsonb.py
@@ -1,0 +1,42 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20240909_feedbacks_jsonb"
+down_revision = "20240908_jsonb_meta_nodes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "feedbacks",
+        "metadata",
+        existing_type=sa.JSON(),
+        type_=postgresql.JSONB(),
+        postgresql_using="metadata::jsonb",
+    )
+    op.alter_column(
+        "feedbacks",
+        "evaluation",
+        existing_type=sa.JSON(),
+        type_=postgresql.JSONB(),
+        postgresql_using="evaluation::jsonb",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "feedbacks",
+        "metadata",
+        existing_type=postgresql.JSONB(),
+        type_=sa.JSON(),
+        postgresql_using="metadata::json",
+    )
+    op.alter_column(
+        "feedbacks",
+        "evaluation",
+        existing_type=postgresql.JSONB(),
+        type_=sa.JSON(),
+        postgresql_using="evaluation::json",
+    )

--- a/backend/migrations/versions/3998bc48da90_merge_heads.py
+++ b/backend/migrations/versions/3998bc48da90_merge_heads.py
@@ -1,7 +1,7 @@
 """merge heads
 
 Revision ID: 3998bc48da90
-Revises: c894e2b67dc8, 20240905_nodes_run_key_unique
+Revises: c894e2b67dc8, 20240907_node_key_not_null
 Create Date: 2025-09-05 20:06:37.022548
 
 """
@@ -13,7 +13,10 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '3998bc48da90'
-down_revision: Union[str, Sequence[str], None] = ('c894e2b67dc8', '20240905_nodes_run_key_unique')
+down_revision: Union[str, Sequence[str], None] = (
+    'c894e2b67dc8',
+    '20240907_node_key_not_null',
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Résumé
- rendre node.key obligatoire et normaliser les doublons avant contrainte unique
- migrations JSONB séparées pour runs/nodes et feedbacks

## Tests
- `ALEMBIC_DATABASE_URL=postgresql+psycopg:///crew alembic -c backend/migrations/alembic.ini upgrade head` *(échec : connexion refusée)*
- `ALEMBIC_DATABASE_URL=postgresql+psycopg:///crew DATABASE_URL=postgresql+asyncpg:///crew pytest -q` *(80 erreurs : connexion refusée)*

------
https://chatgpt.com/codex/tasks/task_e_68bb46742ee483279fcdcfc1613e2481