### PR TITLE
tests: utilise le dialecte PostgreSQL pour les insertions

### DIFF
--- a/backend/core/storage/db_models.py
+++ b/backend/core/storage/db_models.py
@@ -19,7 +19,6 @@ from sqlmodel import Field, SQLModel
 
 # ---------------- Enums ----------------
 
-
 class RunStatus(str, Enum):
     pending = "pending"
     running = "running"
@@ -82,18 +81,18 @@ class Node(SQLModel, table=True):
     )
     key: str = Field(sa_column=Column(String, nullable=False, index=True))
     title: str = Field(sa_column=Column(String, nullable=False))
-status: NodeStatus = Field(
-    sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False)
-)
-role: Optional[str] = Field(
-    default=None, sa_column=Column(String, nullable=True, index=True)
-)
-deps: Optional[List[str]] = Field(
-    default=None, sa_column=Column(JSONB, nullable=True)
-)
-checksum: Optional[str] = Field(
-    default=None, sa_column=Column(String, nullable=True)
-)
+    status: NodeStatus = Field(
+        sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False)
+    )
+    role: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True, index=True)
+    )
+    deps: Optional[List[str]] = Field(
+        default=None, sa_column=Column(JSONB, nullable=True)
+    )
+    checksum: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
 
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -12,7 +12,8 @@ from asgi_lifespan import LifespanManager
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import delete, insert, text
+from sqlalchemy import delete, text
+from sqlalchemy.dialects.postgresql import insert
 
 # --- importe l'app et les deps ---
 from backend.api.fastapi_app.app import app

--- a/backend/tests/api/test_agents_api_more.py
+++ b/backend/tests/api/test_agents_api_more.py
@@ -2,7 +2,7 @@ import uuid
 import datetime as dt
 
 import pytest
-from sqlalchemy import insert
+from sqlalchemy.dialects.postgresql import insert
 
 from backend.api.fastapi_app.models.agent import Agent, AgentModelsMatrix
 

--- a/backend/tests/api/test_artifacts.py
+++ b/backend/tests/api/test_artifacts.py
@@ -2,7 +2,8 @@ import uuid
 import datetime as dt
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import insert, delete
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert
 from api.database.models import Artifact
 
 pytestmark = pytest.mark.asyncio

--- a/backend/tests/api/test_pagination_links.py
+++ b/backend/tests/api/test_pagination_links.py
@@ -1,7 +1,8 @@
 import pytest
 import uuid
 import datetime as dt
-from sqlalchemy import insert, delete
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert
 
 from api.database.models import Run, Artifact, Event
 

--- a/backend/tests/api/test_plan_assignments.py
+++ b/backend/tests/api/test_plan_assignments.py
@@ -1,6 +1,7 @@
 import uuid
 import pytest
-from sqlalchemy import insert, select
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 
 from api.database.models import Plan, Task, Assignment
 

--- a/backend/tests/api/test_runs.py
+++ b/backend/tests/api/test_runs.py
@@ -1,7 +1,8 @@
 import pytest
 import datetime as dt
 import uuid
-from sqlalchemy import insert, delete
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert
 from api.database.models import Run
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_tasks_plan.py
+++ b/backend/tests/api/test_tasks_plan.py
@@ -1,7 +1,8 @@
 import uuid
 
 import pytest
-from sqlalchemy import insert, select
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 
 from backend.core.models import Task, TaskStatus
 from backend.core.models import Plan, PlanStatus

--- a/backend/tests/test_feedbacks_route.py
+++ b/backend/tests/test_feedbacks_route.py
@@ -1,7 +1,8 @@
 import uuid
 import datetime as dt
 import pytest
-from sqlalchemy import insert, delete
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert
 
 from backend.api.fastapi_app.models.run import Run
 from backend.api.fastapi_app.models.node import Node

--- a/backend/tests/test_qa_report.py
+++ b/backend/tests/test_qa_report.py
@@ -1,7 +1,8 @@
 import datetime as dt
 import uuid
 import pytest
-from sqlalchemy import insert, delete
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert
 
 from backend.api.fastapi_app.models.run import Run
 from backend.api.fastapi_app.models.node import Node


### PR DESCRIPTION
## Résumé
- remplace les imports `insert` génériques par le dialecte PostgreSQL dans les tests
- corrige l'indentation de `Node` dans `db_models.py` pour garder les champs au sein de la classe

## Test
- `pre-commit run --files backend/core/storage/db_models.py`
- `pytest backend/tests/test_feedbacks_route.py backend/tests/test_qa_report.py backend/tests/api/test_agents_api_more.py backend/tests/api/test_tasks_plan.py backend/tests/api/test_pagination_links.py backend/tests/api/test_artifacts.py backend/tests/api/test_runs.py backend/tests/api/test_plan_assignments.py -q` *(échoue : connexion refusée à Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0caca8ac8327b71d6718e44a4ff7