### PR TITLE
fix: stabilize e2e polling

### DIFF
--- a/backend/core/storage/db_models.py
+++ b/backend/core/storage/db_models.py
@@ -78,22 +78,23 @@ class Node(SQLModel, table=True):
         sa_column=Column(PGUUID(as_uuid=True), primary_key=True, nullable=False),
     )
     run_id: uuid.UUID = Field(
-        sa_column=Column(PGUUID(as_uuid=True), nullable=False, index=True)
+        sa_column=Column(PGUUID(as_uuid=True), nullable=False)
     )
-    key: str = Field(sa_column=Column(String, nullable=False, index=True))
+    key: str = Field(sa_column=Column(String, nullable=False))
     title: str = Field(sa_column=Column(String, nullable=False))
-status: NodeStatus = Field(
-    sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False)
-)
-role: Optional[str] = Field(
-    default=None, sa_column=Column(String, nullable=True, index=True)
-)
-deps: Optional[List[str]] = Field(
-    default=None, sa_column=Column(JSONB, nullable=True)
-)
-checksum: Optional[str] = Field(
-    default=None, sa_column=Column(String, nullable=True)
-)
+
+    status: NodeStatus = Field(
+        sa_column=Column(SAEnum(NodeStatus, name="nodestatus"), nullable=False)
+    )
+    role: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True, index=True)
+    )
+    deps: Optional[List[str]] = Field(
+        default=None, sa_column=Column(JSONB, nullable=True)
+    )
+    checksum: Optional[str] = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
 
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),

--- a/backend/orchestrator/api_runner.py
+++ b/backend/orchestrator/api_runner.py
@@ -148,6 +148,7 @@ async def run_task(
             },
             request_id=request_id,
         )
+        await anyio.sleep(0)
 
     async def on_node_end(node, node_key: str, status: str):
         ended = dt.datetime.now(dt.timezone.utc)
@@ -222,6 +223,7 @@ async def run_task(
                 meta_payload.get("latency_ms"),
             )
         await event_publisher.emit(event_type, payload, request_id=request_id)
+        await anyio.sleep(0)
 
     try:
         await event_publisher.emit(
@@ -229,6 +231,7 @@ async def run_task(
             {"run_id": run_id, "title": title},
             request_id=request_id,
         )
+        await anyio.sleep(0)
 
         res = await run_graph(
             dag,
@@ -242,9 +245,11 @@ async def run_task(
 
         ended = dt.datetime.now(dt.timezone.utc)
         # ...............................................................
+        status_val = (res or {}).get("status")
+        success_markers = {"succeeded", "success", "completed", "ok", True}
         final_status = (
             RunStatus.completed
-            if res.get("status") == "succeeded"
+            if status_val in success_markers
             else RunStatus.failed
         )
         status_metric = "completed" if final_status == RunStatus.completed else "failed"
@@ -258,6 +263,7 @@ async def run_task(
                 meta={"request_id": request_id},
             )
         )
+        await anyio.sleep(0)
         # Force la visibilité immédiate de l’update lors des tests
         try:
             await storage.get_run(
@@ -298,6 +304,7 @@ async def run_task(
                 meta={"request_id": request_id},
             )
         )
+        await anyio.sleep(0)
         # Même stratégie en cas d’échec
         try:
             await storage.get_run(UUID(run_id))

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -2,6 +2,7 @@
 import asyncio
 import datetime as dt
 import os
+import time
 import uuid
 from pathlib import Path
 
@@ -12,7 +13,8 @@ from asgi_lifespan import LifespanManager
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import delete, insert, text
+from sqlalchemy import delete, text
+from sqlalchemy.dialects.postgresql import insert
 
 # --- importe l'app et les deps ---
 from backend.api.fastapi_app.app import app
@@ -287,3 +289,28 @@ async def seed_sample(db_session: AsyncSession):
         await db_session.execute(delete(Node).where(Node.run_id == run_id))
         await db_session.execute(delete(Run).where(Run.id == run_id))
         await db_session.commit()
+
+
+# Helper de polling simple/robuste pour les runs
+
+
+async def wait_status(
+    client,
+    run_id: str,
+    target: str = "completed",
+    timeout: float = 5.0,
+    interval: float = 0.05,
+) -> bool:
+    """Attend qu'un run atteigne le statut cible dans le délai imparti."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        r = await client.get(f"/runs/{run_id}", headers={"X-API-Key": "test-key"})
+        st = (r.json() or {}).get("status")
+        if target == "completed":
+            if st in ("completed", "failed"):
+                return True
+        else:
+            if st == target:
+                return True
+        await asyncio.sleep(interval)
+    return False

--- a/backend/tests/api/test_tasks.py
+++ b/backend/tests/api/test_tasks.py
@@ -1,5 +1,5 @@
-import asyncio
 import pytest
+from ..conftest import wait_status
 
 
 @pytest.mark.asyncio
@@ -14,11 +14,8 @@ async def test_create_and_follow_task(client):
     assert body["status"] == "accepted"
     run_id = body["run_id"]
 
-    for _ in range(80):
-        r_status = await client.get(f"/runs/{run_id}", headers={"X-API-Key": "test-key"})
-        if r_status.json()["status"] in ("completed", "failed"):
-            break
-        await asyncio.sleep(0.05)
+    assert await wait_status(client, run_id, "completed", timeout=5.0)
+    r_status = await client.get(f"/runs/{run_id}", headers={"X-API-Key": "test-key"})
     assert r_status.status_code == 200
     assert r_status.json()["status"] == "completed"
 

--- a/backend/tests/api/test_tasks_e2e.py
+++ b/backend/tests/api/test_tasks_e2e.py
@@ -1,5 +1,5 @@
-import asyncio
 import pytest
+from ..conftest import wait_status
 
 @pytest.mark.asyncio
 async def test_create_and_follow_task(client):
@@ -16,12 +16,9 @@ async def test_create_and_follow_task(client):
     assert body["location"] == f"/runs/{run_id}"
 
     # Poll jusqu'à completion
-    for _ in range(60):
-        rr = await client.get(f"/runs/{run_id}", headers={"X-API-Key": "test-key"})
-        assert rr.status_code == 200
-        if rr.json()["status"] in ("completed", "failed"):
-            break
-        await asyncio.sleep(0.05)
+    assert await wait_status(client, run_id, "completed", timeout=5.0)
+    rr = await client.get(f"/runs/{run_id}", headers={"X-API-Key": "test-key"})
+    assert rr.status_code == 200
     assert rr.json()["status"] == "completed"
 
     # Noeuds + artifacts

--- a/backend/tests/api/test_tasks_happy_e2e.py
+++ b/backend/tests/api/test_tasks_happy_e2e.py
@@ -1,4 +1,5 @@
-import asyncio, json, pytest
+import json, pytest
+from ..conftest import wait_status
 
 import uuid
 from sqlalchemy import delete, select
@@ -22,11 +23,8 @@ async def test_post_tasks_and_follow(async_client, db_session):
     run_uuid = uuid.UUID(rid)
 
     # poll jusqu'à fin
-    for _ in range(80):
-        rs = await async_client.get(f"/runs/{rid}", headers={"X-API-Key":"test-key"})
-        if rs.json()["status"] in ("completed","failed"):
-            break
-        await asyncio.sleep(0.05)
+    assert await wait_status(async_client, rid, "completed", timeout=5.0)
+    rs = await async_client.get(f"/runs/{rid}", headers={"X-API-Key":"test-key"})
 
     # checks de base
     nodes = await async_client.get(f"/runs/{rid}/nodes", headers={"X-API-Key":"test-key"})

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-import anyio
 
 try:
     from tests.api.conftest import *  # noqa: F401,F403
@@ -43,15 +42,3 @@ def artifacts_tmpdir(tmp_path, monkeypatch):
     monkeypatch.setenv("ARTIFACTS_DIR", str(runs_dir))
     yield runs_dir
 
-
-async def wait_status(client, run_id: str, expect: str, timeout: float = 2.0):
-    """Attend qu'un run atteigne le statut souhaité ou expire."""
-    import time
-
-    end = time.monotonic() + timeout
-    while time.monotonic() < end:
-        resp = await client.get(f"/runs/{run_id}")
-        if resp.status_code == 200 and resp.json().get("status") == expect:
-            return True
-        await anyio.sleep(0.05)
-    return False


### PR DESCRIPTION
## Summary
- ensure event loop yields after save_run and event publication to prevent polling deadlocks
- use wait_status helper in e2e tests for consistent polling
- fix PostgreSQL insert import and relative helper path; restore Node model indentation
- normalize run status results and drop redundant node indexes

## Testing
- `pytest backend/tests/test_tasks_e2e.py backend/tests/api/test_request_id_event.py backend/tests/api/test_tasks.py backend/tests/api/test_tasks_e2e.py backend/tests/api/test_tasks_happy_e2e.py backend/tests/api/fastapi/test_tasks_meta_e2e.py -q` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*
- `pytest backend/tests/api/test_tasks.py::test_create_and_follow_task -q` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68bc0cb78c048327a97c7bd4088b7870