### PR TITLE
Fix migrations, request logging and run flow

### DIFF
--- a/backend/api/fastapi_app/app.py
+++ b/backend/api/fastapi_app/app.py
@@ -32,7 +32,8 @@ from .routes import (
     plans,
 )
 from .routes.qa_report import router as qa_router
-from .middleware import RequestIDMiddleware
+from .middleware.request_id import RequestIdMiddleware
+from .middleware.access import AccessLogMiddleware
 from .middleware.metrics import MetricsMiddleware
 from .observability import (
     metrics_enabled,
@@ -97,7 +98,8 @@ app = FastAPI(
 )
 
 # -------- Middlewares --------
-app.add_middleware(RequestIDMiddleware)                # X-Request-ID propagation
+app.add_middleware(RequestIdMiddleware)                # X-Request-ID propagation
+app.add_middleware(AccessLogMiddleware)                # access logs
 if init_sentry():
     app.add_middleware(SentryContextMiddleware)        # Sentry annotations
 app.add_middleware(MetricsMiddleware)                  # Prometheus metrics

--- a/backend/api/fastapi_app/clients/__init__.py
+++ b/backend/api/fastapi_app/clients/__init__.py
@@ -1,3 +1,1 @@
-from .request_id import RequestIDMiddleware
-
-__all__ = ["RequestIDMiddleware"]
+__all__: list[str] = []

--- a/backend/api/fastapi_app/middleware/__init__.py
+++ b/backend/api/fastapi_app/middleware/__init__.py
@@ -1,3 +1,4 @@
-from .request_id import RequestIDMiddleware
+from .request_id import RequestIdMiddleware
+from .access import AccessLogMiddleware
 
-__all__ = ["RequestIDMiddleware"]
+__all__ = ["RequestIdMiddleware", "AccessLogMiddleware"]

--- a/backend/api/fastapi_app/middleware/access.py
+++ b/backend/api/fastapi_app/middleware/access.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from typing import Any
+
+
+class AccessLogMiddleware(BaseHTTPMiddleware):
+    """Log chaque requête HTTP avec son statut."""
+
+    async def dispatch(self, request: Request, call_next: Any):  # type: ignore[override]
+        response = await call_next(request)
+        rid = getattr(request.state, "request_id", None) or response.headers.get("X-Request-ID")
+        logging.getLogger("api.access").info(
+            "%s %s %s",
+            request.method,
+            request.url.path,
+            response.status_code,
+            extra={"request_id": rid},
+        )
+        return response

--- a/backend/api/fastapi_app/middleware/request_id.py
+++ b/backend/api/fastapi_app/middleware/request_id.py
@@ -1,39 +1,23 @@
 from __future__ import annotations
 
-import logging
-import time
 import uuid
-from core.log import request_id_var
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
 from core.log import request_id_var
 
-class RequestIDMiddleware(BaseHTTPMiddleware):
-    """Attach a request ID and log access in JSON format."""
 
-    def __init__(self, app):
-        super().__init__(app)
-        # Dedicated logger so uvicorn's access formatter is untouched
-        self.logger = logging.getLogger("api.access")
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Propagate X-Request-ID and attach to request state."""
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         rid = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = rid
         token = request_id_var.set(rid)
-        start = time.perf_counter()
-        response = await call_next(request)
-        duration_ms = int((time.perf_counter() - start) * 1000)
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
         response.headers["X-Request-ID"] = rid
-        self.logger.info(
-            "access",
-            extra={
-                "method": request.method,
-                "path": request.url.path,
-                "status_code": response.status_code,
-                "duration_ms": duration_ms,
-            },
-        )
-        request_id_var.reset(token)
         return response

--- a/backend/api/fastapi_app/utils/__init__.py
+++ b/backend/api/fastapi_app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilitaires pour l'orchestration des runs."""

--- a/backend/api/fastapi_app/utils/run_flow.py
+++ b/backend/api/fastapi_app/utils/run_flow.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Awaitable
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.storage.db_models import Run, RunStatus, Node, NodeStatus, Event
+
+ARTIFACTS_DIR = Path(os.getenv("ARTIFACTS_DIR") or ".runs")
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def make_callbacks(
+    session: AsyncSession, run_id: uuid.UUID, request_id: str | None
+) -> tuple[
+    Callable[[Any, str], Awaitable[None]],
+    Callable[[Any, str, str], Awaitable[None]],
+]:
+    async def on_node_start(node: Any, node_key: str) -> None:
+        now = utcnow()
+        db_node = Node(
+            run_id=run_id,
+            key=node_key,
+            title=getattr(node, "title", ""),
+            status=NodeStatus.running,
+            role=getattr(node, "suggested_agent_role", None),
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(db_node)
+        await session.flush()
+        try:
+            setattr(node, "db_id", db_node.id)
+        except Exception:
+            pass
+        session.add(
+            Event(
+                run_id=run_id,
+                node_id=db_node.id,
+                level="NODE_STARTED",
+                message="{}",
+                request_id=request_id,
+            )
+        )
+        await session.commit()
+
+    async def on_node_end(node: Any, node_key: str, status: str) -> None:
+        now = utcnow()
+        node_id = getattr(node, "db_id", None)
+        if node_id is None:
+            res = await session.execute(
+                select(Node.id).where(Node.run_id == run_id, Node.key == node_key)
+            )
+            node_id = res.scalar_one_or_none()
+        node_obj = await session.get(Node, node_id) if node_id else None
+        try:
+            node_status = NodeStatus(status)
+        except Exception:
+            node_status = NodeStatus.failed
+        if node_obj:
+            node_obj.status = node_status
+            node_obj.updated_at = now
+        meta = {}
+        node_dir = ARTIFACTS_DIR / str(run_id) / "nodes" / node_key
+        if node_dir.is_dir():
+            for p in node_dir.glob("*.llm.json"):
+                try:
+                    data = json.loads(p.read_text(encoding="utf-8"))
+                except Exception:
+                    continue
+                usage = data.get("usage") or {}
+                usage.setdefault("completion_tokens", 0)
+                data["usage"] = usage
+                session.add(
+                    Event(
+                        run_id=run_id,
+                        node_id=node_id,
+                        level="LLM_METADATA",
+                        message="llm metadata",
+                        extra=data,
+                        request_id=request_id,
+                    )
+                )
+                if not meta:
+                    meta = data
+        payload = dict(meta)
+        if request_id and "request_id" not in payload:
+            payload["request_id"] = request_id
+        session.add(
+            Event(
+                run_id=run_id,
+                node_id=node_id,
+                level="NODE_COMPLETED" if node_status == NodeStatus.completed else "NODE_FAILED",
+                message=json.dumps(payload),
+                request_id=request_id,
+            )
+        )
+        await session.commit()
+
+    return on_node_start, on_node_end
+
+
+async def finalize_run(session: AsyncSession, run: Run, result: Any) -> None:
+    status_val = (result or {}).get("status")
+    if status_val in {"success", "completed", "ok", "done"}:
+        run.status = RunStatus.completed
+    else:
+        run.status = RunStatus.failed
+    run.ended_at = utcnow()
+    session.add(run)
+    await session.commit()

--- a/backend/core/storage/db_models.py
+++ b/backend/core/storage/db_models.py
@@ -155,6 +155,9 @@ class Event(SQLModel, table=True):
     request_id: Optional[str] = Field(
         default=None, sa_column=Column(String, nullable=True, index=True)
     )
+    extra: Optional[Dict] = Field(
+        default=None, sa_column=Column(JSONB, nullable=True)
+    )
 
 
 class Feedback(SQLModel, table=True):

--- a/backend/migrations/versions/83c6c56308fb_global_min_schema_patch.py
+++ b/backend/migrations/versions/83c6c56308fb_global_min_schema_patch.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "83c6c56308fb"
+down_revision = "15d1c1466f53"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, name: str) -> bool:
+    return conn.execute(text("SELECT to_regclass(:n)"), {"n": name}).scalar() is not None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # enlarge alembic_version.version_num to allow long revision identifiers
+    op.execute(
+        "ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(255)"
+    )
+
+    # align enums runstatus / nodestatus
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          -- runstatus
+          IF EXISTS (
+            SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'runstatus' AND e.enumlabel = 'success'
+          ) THEN
+            ALTER TYPE runstatus RENAME VALUE 'success' TO 'completed';
+          END IF;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'runstatus' AND e.enumlabel = 'completed'
+          ) THEN
+            ALTER TYPE runstatus ADD VALUE 'completed';
+          END IF;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'runstatus' AND e.enumlabel = 'failed'
+          ) THEN
+            ALTER TYPE runstatus ADD VALUE 'failed';
+          END IF;
+
+          -- nodestatus
+          IF EXISTS (
+            SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'nodestatus' AND e.enumlabel = 'success'
+          ) THEN
+            ALTER TYPE nodestatus RENAME VALUE 'success' TO 'completed';
+          END IF;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'nodestatus' AND e.enumlabel = 'completed'
+          ) THEN
+            ALTER TYPE nodestatus ADD VALUE 'completed';
+          END IF;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'nodestatus' AND e.enumlabel = 'failed'
+          ) THEN
+            ALTER TYPE nodestatus ADD VALUE 'failed';
+          END IF;
+        END
+        $$;
+        """
+    )
+
+    # nodes table
+    if _table_exists(conn, "nodes"):
+        op.execute("ALTER TABLE nodes ADD COLUMN IF NOT EXISTS role VARCHAR")
+        op.execute("ALTER TABLE nodes ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ")
+        op.execute("ALTER TABLE nodes ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ")
+        op.execute(
+            "UPDATE nodes SET created_at=COALESCE(created_at, now()), updated_at=COALESCE(updated_at, now())"
+        )
+
+    # events table
+    if _table_exists(conn, "events"):
+        op.execute("ALTER TABLE events ADD COLUMN IF NOT EXISTS request_id VARCHAR")
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_events_request_id ON events(request_id)"
+        )
+
+    # feedbacks table
+    if _table_exists(conn, "feedbacks"):
+        op.execute("ALTER TABLE feedbacks ADD COLUMN IF NOT EXISTS metadata JSONB")
+        op.execute("ALTER TABLE feedbacks ADD COLUMN IF NOT EXISTS evaluation JSONB")
+
+    # artifacts table
+    if _table_exists(conn, "artifacts"):
+        op.execute("ALTER TABLE artifacts ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ")
+        op.execute(
+            "UPDATE artifacts SET created_at=COALESCE(created_at, now())"
+        )
+
+    # optional project tables
+    optional = [
+        "plans",
+        "plan_tasks",
+        "plan_assignments",
+        "plan_reviews",
+        "agents",
+        "agent_models_matrix",
+    ]
+    for tbl in optional:
+        if _table_exists(conn, tbl):
+            op.execute(
+                f"ALTER TABLE {tbl} ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ"
+            )
+            op.execute(
+                f"ALTER TABLE {tbl} ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ"
+            )
+            op.execute(
+                f"UPDATE {tbl} SET created_at=COALESCE(created_at, now()), updated_at=COALESCE(updated_at, now())"
+            )
+
+
+def downgrade() -> None:
+    # aucun downgrade sûr
+    pass


### PR DESCRIPTION
## Summary
- rendre la migration de schéma minimale idempotente et tolérante
- ajouter middleware Request-ID et access log
- créer utilitaires d'exécution de run et ajuster les endpoints de tâches

## Testing
- `ALEMBIC_DATABASE_URL=postgresql+psycopg://crew:crew@localhost:5432/crew alembic -c backend/migrations/alembic.ini upgrade head` (fail: connection refused)
- `pytest -q backend/tests/api/fastapi/test_feedbacks_api.py::test_post_feedback_requires_request_id` (fail: cannot connect to database)


------
https://chatgpt.com/codex/tasks/task_e_68bc50e402fc83278ba7084171949292