### PR TITLE
Assurer l'idempotence de la contrainte unique sur nodes

### DIFF
--- a/backend/migrations/versions/20240905_nodes_run_key_unique.py
+++ b/backend/migrations/versions/20240905_nodes_run_key_unique.py
@@ -1,6 +1,7 @@
 """unicité run_id, key pour nodes"""
 
 from alembic import op
+from sqlalchemy import inspect
 
 # Identifiants Alembic
 revision = "20240905_nodes_run_key_unique"
@@ -27,8 +28,14 @@ def upgrade() -> None:
     )
 
     # Contrainte d’unicité (run_id, key)
-    op.create_unique_constraint("uq_nodes_run_key", "nodes", ["run_id", "key"])
+    bind = op.get_bind()
+    existing = [c["name"] for c in inspect(bind).get_unique_constraints("nodes")]
+    if "uq_nodes_run_key" not in existing:
+        op.create_unique_constraint("uq_nodes_run_key", "nodes", ["run_id", "key"])
 
 
 def downgrade() -> None:
-    op.drop_constraint("uq_nodes_run_key", "nodes", type_="unique")
+    bind = op.get_bind()
+    existing = [c["name"] for c in inspect(bind).get_unique_constraints("nodes")]
+    if "uq_nodes_run_key" in existing:
+        op.drop_constraint("uq_nodes_run_key", "nodes", type_="unique")


### PR DESCRIPTION
## Résumé
- rend la contrainte unique `(run_id, key)` idempotente dans la migration

## Tests
- `pre-commit run --files backend/migrations/versions/20240905_nodes_run_key_unique.py`
- `pytest backend/tests` *(échoue : [Errno 111] Connect call failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7f02006c83278f3ab8789ad28845