### PR TITLE
Sécuriser la migration des ENUMs runstatus/nodestatus

### DIFF
--- a/backend/migrations/versions/d6d12e0cac2a_align_enums_runstatus_nodestatus.py
+++ b/backend/migrations/versions/d6d12e0cac2a_align_enums_runstatus_nodestatus.py
@@ -8,63 +8,71 @@ depends_on = None
 
 def upgrade():
     # RUNSTATUS
-    op.execute("""
+    op.execute(
+        """
     DO $do$
     BEGIN
-      -- rename legacy 'success' -> 'completed' if present
-      IF EXISTS (
-        SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
-        WHERE t.typname = 'runstatus' AND e.enumlabel = 'success'
-      ) THEN
-        ALTER TYPE runstatus RENAME VALUE 'success' TO 'completed';
-      END IF;
+      IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'runstatus') THEN
+        -- rename legacy 'success' -> 'completed' if present
+        IF EXISTS (
+          SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+          WHERE t.typname = 'runstatus' AND e.enumlabel = 'success'
+        ) THEN
+          ALTER TYPE runstatus RENAME VALUE 'success' TO 'completed';
+        END IF;
 
-      -- ensure 'completed'
-      IF NOT EXISTS (
-        SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
-        WHERE t.typname = 'runstatus' AND e.enumlabel = 'completed'
-      ) THEN
-        ALTER TYPE runstatus ADD VALUE 'completed';
-      END IF;
+        -- ensure 'completed'
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+          WHERE t.typname = 'runstatus' AND e.enumlabel = 'completed'
+        ) THEN
+          ALTER TYPE runstatus ADD VALUE 'completed';
+        END IF;
 
-      -- ensure 'failed'
-      IF NOT EXISTS (
-        SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
-        WHERE t.typname = 'runstatus' AND e.enumlabel = 'failed'
-      ) THEN
-        ALTER TYPE runstatus ADD VALUE 'failed';
+        -- ensure 'failed'
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+          WHERE t.typname = 'runstatus' AND e.enumlabel = 'failed'
+        ) THEN
+          ALTER TYPE runstatus ADD VALUE 'failed';
+        END IF;
       END IF;
     END
     $do$;
-    """)
+    """
+    )
 
     # NODESTATUS
-    op.execute("""
+    op.execute(
+        """
     DO $do$
     BEGIN
-      IF EXISTS (
-        SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
-        WHERE t.typname = 'nodestatus' AND e.enumlabel = 'success'
-      ) THEN
-        ALTER TYPE nodestatus RENAME VALUE 'success' TO 'completed';
-      END IF;
+      IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'nodestatus') THEN
+        IF EXISTS (
+          SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+          WHERE t.typname = 'nodestatus' AND e.enumlabel = 'success'
+        ) THEN
+          ALTER TYPE nodestatus RENAME VALUE 'success' TO 'completed';
+        END IF;
 
-      IF NOT EXISTS (
-        SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
-        WHERE t.typname = 'nodestatus' AND e.enumlabel = 'completed'
-      ) THEN
-        ALTER TYPE nodestatus ADD VALUE 'completed';
-      END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+          WHERE t.typname = 'nodestatus' AND e.enumlabel = 'completed'
+        ) THEN
+          ALTER TYPE nodestatus ADD VALUE 'completed';
+        END IF;
 
-      IF NOT EXISTS (
-        SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
-        WHERE t.typname = 'nodestatus' AND e.enumlabel = 'failed'
-      ) THEN
-        ALTER TYPE nodestatus ADD VALUE 'failed';
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
+          WHERE t.typname = 'nodestatus' AND e.enumlabel = 'failed'
+        ) THEN
+          ALTER TYPE nodestatus ADD VALUE 'failed';
+        END IF;
       END IF;
     END
     $do$;
-    """)
+    """
+    )
 
 def downgrade():
     # Pas de downgrade sûr pour les ENUM -> no-op


### PR DESCRIPTION
## Résumé
- Vérifie la présence des types `runstatus` et `nodestatus` avant de renommer ou d'ajouter des valeurs dans la migration.

## Tests
- `make lint`
- `make test` *(échoue : Connection refused vers des services externes)*
- `make api-migrate` *(échoue : Connection refused vers PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_68bc84585c748327addc1b2d2671357b